### PR TITLE
Trigger documentation build workflow after pre-merge completes.

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -1,0 +1,96 @@
+---
+# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Build Documentation
+
+on:  # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows: ["Pre-Merge CI Pipeline"]
+    types:
+      - completed
+
+permissions:
+  contents: read          # needed for actions/checkout
+
+jobs:
+  filter:
+    runs-on: ubuntu-latest
+    outputs:
+      loitering-detection_changed: ${{ steps.filter.outputs.loitering-detection }}
+      image-based-video-search_changed: ${{ steps.filter.outputs.image-based-video-search }}
+      smart-parking_changed: ${{ steps.filter.outputs.smart-parking }}
+      pallet-defect-detection_changed: ${{ steps.filter.outputs.pallet-defect-detection }}
+      weld-porosity_changed: ${{ steps.filter.outputs.weld-porosity }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set paths filter
+        id: filter
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
+        with:
+          filters: |
+            loitering-detection:
+              - 'metro-ai-suite/loitering-detection/docs/**'
+            image-based-video-search:
+              - 'metro-ai-suite/image-based-video-search/docs/**'
+            smart-parking:
+              - 'metro-ai-suite/smart-parking/docs/**'
+            pallet-defect-detection:
+              - 'manufacturing-ai-suite/pallet-defect-detection/docs/**'
+            weld-porosity:
+              - 'manufacturing-ai-suite/weld-porosity/docs/**'
+
+  build_image-based-video-search:
+    needs: filter
+    if: ${{ needs.filter.outputs.image-based-video-search_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: metro-ai-suite/image-based-video-search
+
+  build_smart-parking:
+    needs: filter
+    if: ${{ needs.filter.outputs.smart-parking_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: metro-ai-suite/smart-parking
+
+  build_loitering-detection:
+    needs: filter
+    if: ${{ needs.filter.outputs.loitering-detection_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: metro-ai-suite/loitering-detection
+
+  build_pallet-defect-detection:
+    needs: filter
+    if: ${{ needs.filter.outputs.pallet-defect-detection_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: manufacturing-ai-suite/pallet-defect-detection
+
+  build_weld-porosity:
+    needs: filter
+    if: ${{ needs.filter.outputs.weld-porosity_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: manufacturing-ai-suite/weld-porosity

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -31,67 +31,47 @@ jobs:
         with:
           filters: |
             loitering-detection:
-              - 'metro-ai-suite/loitering-detection/docs/**'
+              - 'metro-ai-suite/loitering-detection/**'
             image-based-video-search:
-              - 'metro-ai-suite/image-based-video-search/docs/**'
+              - 'metro-ai-suite/image-based-video-search/**'
             smart-parking:
-              - 'metro-ai-suite/smart-parking/docs/**'
+              - 'metro-ai-suite/smart-parking/**'
             pallet-defect-detection:
-              - 'manufacturing-ai-suite/pallet-defect-detection/docs/**'
+              - 'manufacturing-ai-suite/pallet-defect-detection/**'
             weld-porosity:
-              - 'manufacturing-ai-suite/weld-porosity/docs/**'
+              - 'manufacturing-ai-suite/weld-porosity/**'
 
   build_image-based-video-search:
     needs: filter
     if: ${{ needs.filter.outputs.image-based-video-search_changed == 'true' }}
-    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
-    secrets:
-      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
-      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
-      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
-    with:
-      docs_directory: metro-ai-suite/image-based-video-search
+    shell: bash
+    run: |
+      echo "Running pipeline for: image-based-video-search"
 
   build_smart-parking:
     needs: filter
     if: ${{ needs.filter.outputs.smart-parking_changed == 'true' }}
-    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
-    secrets:
-      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
-      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
-      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
-    with:
-      docs_directory: metro-ai-suite/smart-parking
+    shell: bash
+    run: |
+      echo "Running pipeline for: smart-parking"
 
   build_loitering-detection:
     needs: filter
     if: ${{ needs.filter.outputs.loitering-detection_changed == 'true' }}
-    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
-    secrets:
-      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
-      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
-      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
-    with:
-      docs_directory: metro-ai-suite/loitering-detection
+    shell: bash
+    run: |
+      echo "Running pipeline for: loitering-detection"
 
   build_pallet-defect-detection:
     needs: filter
     if: ${{ needs.filter.outputs.pallet-defect-detection_changed == 'true' }}
-    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
-    secrets:
-      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
-      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
-      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
-    with:
-      docs_directory: manufacturing-ai-suite/pallet-defect-detection
+    shell: bash
+    run: |
+      echo "Running pipeline for: pallet-defect-detection"
 
   build_weld-porosity:
     needs: filter
     if: ${{ needs.filter.outputs.weld-porosity_changed == 'true' }}
-    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@734970a73e3d6e8d7cd160e2cad6366770f52403
-    secrets:
-      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
-      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
-      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
-    with:
-      docs_directory: manufacturing-ai-suite/weld-porosity
+    shell: bash
+    run: |
+      echo "Running pipeline for: weld-porosity"


### PR DESCRIPTION
### Description

Trigger documentation build workflow after pre-merge completes.

Forked repos do not have access to the repository secrets when the workflow triggered from a pull-request. Per the [GitHub documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow): "With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository."

A good solution is to create a workflow which is triggered on the completion of another workflow, per the GitHub Security Lab blog: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/

This PR splits the `build-documentation` steps out of the the `pre-merge` workflow, such that it is triggered after the `pre-merge` workflow completes.  In doing so, forked repos can execute the `build-documentation` workflow with access to repository secrets.

Fixes # (issue)

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

CI pipeline functions as expected.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

