### PR TITLE
Fix restart of pods by waiting for database readiness using initContainer and web endpoint

### DIFF
--- a/metro-ai-suite/smart-intersection/chart/templates/scene/deployment.yaml
+++ b/metro-ai-suite/smart-intersection/chart/templates/scene/deployment.yaml
@@ -15,6 +15,19 @@ spec:
       labels:
         app: {{ .Release.Name }}-scene
     spec:
+      initContainers:
+      - name: wait-for-db-ready
+        image: curlimages/curl
+        command:
+          - sh
+          - -c
+          - |
+            echo "Waiting for DB via smart-intersection-web...";
+            until curl --insecure -s https://smart-intersection-web:443/api/v1/database-ready | grep 'true'; do
+              echo "Database not ready yet...";
+              sleep 5;
+            done;
+            echo "Database is ready!"
       # initContainers:
       # - name: init-scene-secrets
       #   image: busybox

--- a/metro-ai-suite/smart-intersection/chart/templates/web/deployment.yaml
+++ b/metro-ai-suite/smart-intersection/chart/templates/web/deployment.yaml
@@ -76,6 +76,7 @@ spec:
           cp /tmp/secrets/scenescape-web.key /run/secrets/certs/scenescape-web.key &&
           cp /tmp/secrets/secrets.py /home/scenescape/SceneScape/sscape/secrets.py &&
           sed -i "s/'HOST': 'localhost'/'HOST':'smart-intersection-pgserver'/g" /home/scenescape/SceneScape/sscape/settings.py &&
+          chown -R scenescape:scenescape /workspace &&
           /usr/local/bin/scenescape-init webserver --dbhost smart-intersection-pgserver --broker broker.scenescape.intel.com --brokerauth /run/secrets/browser.auth --brokerrootcert /run/secrets/certs/scenescape-ca.pem
       volumes:
       - name: pgserver-media


### PR DESCRIPTION
### Description

"web" pod restart multiple times short after being created. After Helm deployment, "web" pod restarts multiple times before it stabilize. Expected behavior: "web" pod is not restarted multiple times after being created (before it becomes stable).

Fixes # (issue)

https://jira.devtools.intel.com/browse/ITEP-66930

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

No new deps. Introduced initContainer for scene pod.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested locally in Intel Core Ultra 7 155H

kubectl get pods -n smart-intersection
NAME                                                             READY   STATUS    RESTARTS   AGE
smart-intersection-broker-65fd5d6db5-lm7pn                       1/1     Running   0          3m49s
smart-intersection-dlstreamer-pipeline-server-69d5d67c5d-z9lkb   1/1     Running   0          3m49s
smart-intersection-grafana-64b97d8cb-l2vsb                       1/1     Running   0          3m49s
smart-intersection-influxdb-76794d8cb-rn8ck                      1/1     Running   0          3m49s
smart-intersection-nodered-645445579-gj4bl                       1/1     Running   0          3m49s
smart-intersection-ntpserver-5f4864678f-cf6dd                    1/1     Running   0          3m49s
smart-intersection-pgserver-64987d95bc-4n92t                     1/1     Running   0          3m49s
smart-intersection-scene-6f55cd7774-tfml6                        1/1     Running   0          3m48s
smart-intersection-web-7966d67c65-sk5cq                          1/1     Running   0          3m48s

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

