### PR TITLE
remove unnecessary host-ip replacement

### DIFF
--- a/metro-ai-suite/loitering-detection/sample_start.sh
+++ b/metro-ai-suite/loitering-detection/sample_start.sh
@@ -8,7 +8,7 @@ curl http://localhost:8080/pipelines/user_defined_pipelines/object_tracking_1 -X
     "destination": {
         "metadata": {
             "type": "mqtt",
-            "host": "0.0.0.0:1883",
+            "host": "mqtt:1883",
             "topic": "object_tracking_1",
             "timeout": 1000
         },
@@ -31,7 +31,7 @@ curl http://localhost:8080/pipelines/user_defined_pipelines/object_tracking_2 -X
     "destination": {
         "metadata": {
             "type": "mqtt",
-            "host": "0.0.0.0:1883",
+            "host": "mqtt:1883",
             "topic": "object_tracking_2",
             "timeout": 1000
         },
@@ -54,7 +54,7 @@ curl http://localhost:8080/pipelines/user_defined_pipelines/object_tracking_3 -X
     "destination": {
         "metadata": {
             "type": "mqtt",
-            "host": "0.0.0.0:1883",
+            "host": "mqtt:1883",
             "topic": "object_tracking_3",
             "timeout": 1000
         },
@@ -77,7 +77,7 @@ curl http://localhost:8080/pipelines/user_defined_pipelines/object_tracking_4 -X
     "destination": {
         "metadata": {
             "type": "mqtt",
-            "host": "0.0.0.0:1883",
+            "host": "mqtt:1883",
             "topic": "object_tracking_4",
             "timeout": 1000
         },

--- a/metro-ai-suite/loitering-detection/update_dashboard.sh
+++ b/metro-ai-suite/loitering-detection/update_dashboard.sh
@@ -79,19 +79,3 @@ if [ -n "$NR_FILE" ]; then
   sed -i "s|\"broker\": *\"[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\{3\}\",|\"broker\": \"$HOST_IP\",|" "$NR_FILE"
 fi
 
-#############################################
-# Update sample_start.sh for video paths and  #
-# MQTT host IP                              #
-#############################################
-
-# Check if the sample_start.sh exists in the folder for the current case
-if [ -f "./sample_start.sh" ]; then
-  # Update the video source path to point to the folder
-  sed -i "s|file:///home/pipeline-server/videos/|file:///home/pipeline-server/videos/|g" ./sample_start.sh
-  
-  # Update the MQTT host IP in the file
-  sed -i "s|\"host\": *\"[0-9]\{1,3\}\(\.[0-9]\{1,3\}\)\{3\}:|\"host\": \"$HOST_IP:|g" ./sample_start.sh
-  
-else
-  echo "Warning: sample_start.sh not found in folder"
-fi


### PR DESCRIPTION
### Description

Microservices via docker-compose can resolve container names automatically. No need to replace 0.0.0.0 with HOST_IP. 
This improves robustness.

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Unit tested.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

