### PR TITLE
[Smart parking] added webrtc timeout

### DIFF
--- a/metro-ai-suite/smart-parking/docker-compose.yml
+++ b/metro-ai-suite/smart-parking/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - MTX_WEBRTCICESERVERS2_0_URL=turn:${HOST_IP}:3478
       - MTX_WEBRTCICESERVERS2_0_USERNAME=myusername
       - MTX_WEBRTCICESERVERS2_0_PASSWORD=mypassword
+      - MTX_WEBRTCTRACKGATHERTIMEOUT=10s
     ports:
       - "8889:8889"
       - "8189:8189"

--- a/metro-ai-suite/smart-parking/docs/user-guide/get-started.md
+++ b/metro-ai-suite/smart-parking/docs/user-guide/get-started.md
@@ -152,6 +152,10 @@ By following this guide, you will learn how to:
       systemctl restart docker
       ```
 
+5. **Not all streams are visible on Grafana**
+
+    - MediaMTX may fail to stream if the pipeline initialization (of any of the webrtc streaming pipeline) takes longer than 10 seconds. This would be evident from the "deadline exceeded" log in "mediamtx-server" docker container. To resolve this, you can increase the MTX_WEBRTCTRACKGATHERTIMEOUT value in the "environment" section of the docker-compose.yml file.
+
 ## Supporting Resources
 - [Docker Compose Documentation](https://docs.docker.com/compose/)
 - [DL Streamer Pipeline Server](https://docs.edgeplatform.intel.com/dlstreamer-pipeline-server/3.0.0/user-guide/Overview.html)


### PR DESCRIPTION
### Description

[Smart parking] added webrtc timeout

### How Has This Been Tested?
Steps in deploying the application: https://github.com/open-edge-platform/edge-ai-suites/blob/main/metro-ai-suite/smart-parking/docs/user-guide/get-started.md

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

