### PR TITLE
[DOCS] unifying CODEOWNERS for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
-README.md @xwu2intel
+README.md @xwu2intel @open-edge-platform/open-edge-platform-docs-write
 LICENSE @xwu2intel
-CONTRIBUTING.md @xwu2intel
+CONTRIBUTING.md @xwu2intel @open-edge-platform/open-edge-platform-docs-write
 CODE_OF_CONDUCT.md @xwu2intel
 SECURITY.md @xwu2intel
 /metro-ai-suite/image-based-video-search/ @dnoliver @rajpatel9498 @basakcap
@@ -13,3 +13,13 @@ SECURITY.md @xwu2intel
 /manufacturing-ai-suite/wind-turbine-anomaly-detection/ @vkb1 @sathyendranv @pooja-intel
 /manufacturing-ai-suite/industrial-edge-insights-vision/ @ajagadi1 @sugnanprabhu @rrajore @sajeevrajput
 /robotics-ai-suite/ @jouillet @jb-balaji @pirouf @mohitmeh12
+
+# documentation content
+/metro-ai-suite/README.md/*.md @open-edge-platform/open-edge-platform-docs-write
+/metro-ai-suite/**/docs @open-edge-platform/open-edge-platform-docs-write
+/metro-ai-suite/**/README.md @open-edge-platform/open-edge-platform-docs-write
+/manufacturing-ai-suite/README.md @open-edge-platform/open-edge-platform-docs-write
+/manufacturing-ai-suite/**/docs @open-edge-platform/open-edge-platform-docs-write
+/manufacturing-ai-suite/**/README.md @open-edge-platform/open-edge-platform-docs-write
+/retail-ai-suite/README.md @open-edge-platform/open-edge-platform-docs-write
+/media-and-entertainment-ai-suite/README.md @open-edge-platform/open-edge-platform-docs-write


### PR DESCRIPTION
### Description

Adjusting CODEOWNERS for easier documentation adjustments and group management (one documentation group across the organization).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

