### PR TITLE
remove proxy settings from .env

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env
@@ -2,9 +2,6 @@
 DOCKER_REGISTRY=
 HOST_IP=localhost
 REST_SERVER_PORT=8080
-no_proxy=127.0.0.1,localhost
-http_proxy=
-https_proxy=
 
 # DL Streamer Pipeline Server
 RTSP_CAMERA_IP=


### PR DESCRIPTION
### Description

The proxy settings in .env is not required. In fact, it is harmful to be in .env. If left unmodified, the empty value effectively disables any proxy settings from the shell environment.

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Unit tested

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

