### PR TITLE
[Manufacturing AI Suite: Industrial Edge Insights for Vision] Update the condition to check if the LOCAL_MODEL_DIR directory is either missing or empty before triggering the model redownload

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/weld-porosity/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/weld-porosity/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/worker-safety-gear-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/worker-safety-gear-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/weld-porosity/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/weld-porosity/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/worker-safety-gear-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/worker-safety-gear-detection/setup.sh
@@ -38,7 +38,7 @@ download_artifacts() {
     fi
     # Download model artifacts if not already present
     LOCAL_MODEL_DIR="$SCRIPT_DIR/../../../resources/$app_name/models/$app_name"
-    if [ ! -d $LOCAL_MODEL_DIR ]; then
+    if [ ! -d $LOCAL_MODEL_DIR ] || [ -z "$(ls -A "$LOCAL_MODEL_DIR")" ]; then
         # create the models directory if it does not exist
 
         if ! mkdir -p $LOCAL_MODEL_DIR; then


### PR DESCRIPTION
### Description

[Manufacturing AI Suite: Industrial Edge Insights for Vision] Update the condition to check if the LOCAL_MODEL_DIR directory is either missing or empty before triggering the model redownload

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

When LOCAL_MODEL_DIR does not exist (model redownload triggered).

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

