### PR TITLE
Fixes the following error

### DIFF
--- a/robotics-ai-suite/components/object-detection/yolov8/docs/README.md
+++ b/robotics-ai-suite/components/object-detection/yolov8/docs/README.md
@@ -71,7 +71,7 @@ be generated in the command output when executing the
 > priority = 1 # 0=Low, 1=Normal, 2=High
 > precision = 1 #  0 = FP32, 1 = FP16 , this is passed as hint to openvino
 > num_requests = 1 # Number of inference requests (hint for openvino) recommended 1 per input stream
-> map_frame = "map" # setting is ignored if single topic is used, otherwise it will be used to synchronize camera location
+> map_frame = "" # setting is ignored if single topic is used, otherwise it will be used to synchronize camera location
 > queue_size = 10
 > workers = 2 # Aim for 2 workers per input stream
 > max_fps = -1 # -1 for unlimited


### PR DESCRIPTION
### Description

Update the documentation to address the segmentation error when launching the ros node,
 "Could not transform map to camera_color_optical_frame: "map" passed to lookupTransform argument target_frame does not exit" "[ros2run]: Segmentation fault"

Fixes # (issue)
Test case SL6-C57


Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

