### PR TITLE
[PDD and Weld for Edge AI Suites v1.0.0 hotfix] Refactor references from 'emf-doc-weld' to 'emf-manufacturing-apps' in all files for consistency

### DIFF
--- a/manufacturing-ai-suite/pallet-defect-detection/README.md
+++ b/manufacturing-ai-suite/pallet-defect-detection/README.md
@@ -49,7 +49,7 @@ It also consists of the below Third-party microservices:
 * Clone the **edge-ai-suites** repository and change into Pallet Defect Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/pallet-defect-detection
     ```
 

--- a/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/get-started.md
+++ b/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/get-started.md
@@ -12,7 +12,7 @@
 1. Clone the **edge-ai-suites** repository and change into Pallet Defect Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/pallet-defect-detection
     ```
 

--- a/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/how-to-deploy-with-edge-orchestrator.md
+++ b/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/how-to-deploy-with-edge-orchestrator.md
@@ -27,7 +27,7 @@ To deploy the **Pallet Defect Detection** Sample Application with the Edge Orche
 1. Clone the **edge-ai-suites** repository and change into Pallet Defect Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/pallet-defect-detection
     ```
 

--- a/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/how-to-deploy-with-helm.md
+++ b/manufacturing-ai-suite/pallet-defect-detection/docs/user-guide/how-to-deploy-with-helm.md
@@ -40,7 +40,7 @@ Follow this procedure on the target system to install the package.
 1. Clone the **edge-ai-suites** repository and change into Pallet Defect Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/pallet-defect-detection
     ```
 

--- a/manufacturing-ai-suite/pallet-defect-detection/helm/README.md
+++ b/manufacturing-ai-suite/pallet-defect-detection/helm/README.md
@@ -60,7 +60,7 @@ It also consists of the below Third-party microservices:
 - Clone the **edge-ai-suites** repository and change into Pallet Defect Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/pallet-defect-detection
     ```
 

--- a/manufacturing-ai-suite/weld-porosity/README.md
+++ b/manufacturing-ai-suite/weld-porosity/README.md
@@ -49,7 +49,7 @@ It also consists of the below Third-party microservices:
 * Clone the **edge-ai-suites** repository and change into Weld Porosity Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/weld-porosity
     ```
     

--- a/manufacturing-ai-suite/weld-porosity/docs/user-guide/get-started.md
+++ b/manufacturing-ai-suite/weld-porosity/docs/user-guide/get-started.md
@@ -12,7 +12,7 @@
 1. Clone the **edge-ai-suites** repository and change into Weld Porosity Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/weld-porosity
     ```
 

--- a/manufacturing-ai-suite/weld-porosity/docs/user-guide/how-to-deploy-with-edge-orchestrator.md
+++ b/manufacturing-ai-suite/weld-porosity/docs/user-guide/how-to-deploy-with-edge-orchestrator.md
@@ -27,7 +27,7 @@ To deploy the **Weld Porosity Detection** Sample Application with the Edge Orche
 1. Clone the **edge-ai-suites** repository change into Weld Porosity Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/weld-porosity
     ```
 

--- a/manufacturing-ai-suite/weld-porosity/docs/user-guide/how-to-deploy-with-helm.md
+++ b/manufacturing-ai-suite/weld-porosity/docs/user-guide/how-to-deploy-with-helm.md
@@ -40,7 +40,7 @@ Follow this procedure on the target system to install the package.
 1. Clone the **edge-ai-suites** repository and change into Weld Porosity Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/weld-porosity
     ```
 

--- a/manufacturing-ai-suite/weld-porosity/helm/README.md
+++ b/manufacturing-ai-suite/weld-porosity/helm/README.md
@@ -59,7 +59,7 @@ It also consists of the below Third-party microservices:
 - Clone the **edge-ai-suites** repository and change into Weld Porosity Detection directory:
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-doc-weld
+    git clone https://github.com/open-edge-platform/edge-ai-suites -b hotfix/release-1.0.0/emf-manufacturing-apps
     cd edge-ai-suites/manufacturing-ai-suite/weld-porosity
     ```
 


### PR DESCRIPTION
### Description

Replaced all instances of 'emf-doc-weld' with 'emf-manufacturing-apps' across the documentation.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Verified by ensuring the project clones successfully.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

