### PR TITLE
[Image based video search] Remove learn more section from Overview

### DIFF
--- a/metro-ai-suite/image-based-video-search/docs/user-guide/Overview.md
+++ b/metro-ai-suite/image-based-video-search/docs/user-guide/Overview.md
@@ -62,10 +62,3 @@ continuously and appears in the UI as soon as the application starts.
 
 ![Screenshot of the Image-Based Video Search sample application interface displaying search input and matched results](_images/imagesearch2.png)
 
-### Learn More
-
-- [System Requirements](system-requirements.md)
-- [Get Started](get-started.md)
-- [Architecture Overview](overview-architecture.md)
-- [How to Deploy with Helm](how-to-deploy-helm.md)
-- [Release Notes](release-notes.md)


### PR DESCRIPTION
### Description

[Image based video search] Remove learn more section from Overview because it doesn't render in ESC

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

