### PR TITLE
[Metro AI Suite] IBVS: Fix ibvs reboot issue

### DIFF
--- a/metro-ai-suite/image-based-video-search/compose.yml
+++ b/metro-ai-suite/image-based-video-search/compose.yml
@@ -77,7 +77,7 @@ services:
         condition: service_started
     volumes:
       - image-data:/user/src/app/static
-    restart: on-failure:5
+    restart: always
   streaming-pipeline:
     image: ${DOCKER_REGISTRY}intel/streaming-pipeline:v1.0.1
     build:
@@ -96,7 +96,7 @@ services:
       "
     depends_on:
       - rtsp-server
-    restart: on-failure:5
+    restart: always
   rtsp-server:
     image: docker.io/bluenviron/mediamtx:1.10.0
     container_name: ibvs-mediamtx
@@ -124,7 +124,7 @@ services:
       - ./src/broker:/mosquitto/config
     ports:
       - "1883:1883"
-    restart: on-failure:5
+    restart: always
   dlstreamer-pipeline-server:
     image: ${DOCKER_REGISTRY}intel/dlstreamer-pipeline-server:3.1.0-ubuntu22
     hostname: dlstreamer-pipeline-server


### PR DESCRIPTION
### Description

After bringing up the ibvs docker and doing a system reboot, some of the containers were not coming up. This was because the containers were not able to resolve the proxy-chain name. The containers failed after retrying for 5 times. The solution was to keep trying till the name gets resolved. So the 'restart' is set to 'always' in case of failure. 

Fixes # https://jira.devtools.intel.com/browse/ITEP-73765 

### Any Newly Introduced Dependencies

No new dependency has been introduced

### How Has This Been Tested?

Tested that after reboot - 
- all contianers are up
- milvus db entries remain same before and after reboot
- the search object works fine after reboot

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

