### PR TITLE
Improve Port Forwarding documentation for Smart Intersection UI on Minikube

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/how-to-deploy-helm.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/how-to-deploy-helm.md
@@ -123,7 +123,7 @@ kubectl get service smart-intersection-grafana -n smart-intersection -o jsonpath
 
 ```bash
 WEB_POD=$(kubectl get pods -n smart-intersection -l app=smart-intersection-web -o jsonpath="{.items[0].metadata.name}")
-sudo -E kubectl -n smart-intersection port-forward $WEB_POD 443:443
+sudo -E kubectl -n smart-intersection port-forward $WEB_POD 443:443 --address <HOST_IP>
 ```
 
 - Go to https://<HOST_IP>


### PR DESCRIPTION
When using minikube as a chosen kubernetes flavour, user has to specify their host ip as an argument for port forwarding, otherwise they won't be able to access the application UI.

Other solution is to manually add a Auto Forwarded address, and to do so they have to follow below instructions:
1. Get a Node Port for desired app kubectl get service smart-intersection-web -n smart-intersection -o jsonpath='{.spec.ports[0].nodePort}
2. Open minikube tunnel
3. Add a forwarding, use Node Port from step 1 and minikube address from step 2

I chose the first solution, as it's easier and quicker to perform.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

