### PR TITLE
nginx: Moved to bitnami to nginx:1.29.1-bookworm-perl

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
@@ -339,8 +339,9 @@ services:
 
 
   nginx:
-    image: bitnami/nginx:1.29-debian-12
+    image: nginx:1.29.1-bookworm-perl
     container_name: nginx_proxy
+    read_only: true
     environment:
       no_proxy: "ia-grafana,ia-time-series-analytics-microservice,ia-mqtt-broker,${no_proxy}"
       NO_PROXY: "ia-grafana,ia-time-series-analytics-microservice,ia-mqtt-broker,${no_proxy}"
@@ -348,8 +349,19 @@ services:
       - "${GRAFANA_PORT}:443"   # HTTPS for Grafana and TS MS Rest API 
       - "1883:1883" # MQTT TCP Proxy
     volumes:
-      - ./nginx/nginx.conf:/opt/bitnami/nginx/conf/nginx.conf:ro
-      - ./nginx/nginx-cert-gen.sh:/docker-entrypoint-initdb.d/nginx-cert-gen.sh:ro
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/nginx-cert-gen.sh:/usr/local/bin/nginx-cert-gen.sh:ro
+      - vol_nginx_tmpfs:/opt/intel/certs:rw
+      - vol_nginx_tmpfs:/var/cache/nginx:rw
+      - vol_nginx_tmpfs:/run:rw
+    command: >
+      /bin/bash -c "/usr/local/bin/nginx-cert-gen.sh && exec nginx -g 'daemon off;'"
+    restart: unless-stopped
+    security_opt:
+    - no-new-privileges
+    healthcheck:
+      test: ["CMD-SHELL", "exit", "0"]
+      interval: 5m
     networks:
       - timeseries_network
     depends_on:
@@ -389,6 +401,11 @@ volumes:
       type: tmpfs
       device: tmpfs
   mr_postgres_data:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+  vol_nginx_tmpfs:
     driver: local
     driver_opts:
       type: tmpfs

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx-cert-gen.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx-cert-gen.sh
@@ -6,7 +6,7 @@
 #
 
 # Set working directory for SSL certificates
-SSL_DIR="/opt/bitnami/nginx/conf/bitnami/certs"
+SSL_DIR="/opt/intel/certs"
 mkdir -p "$SSL_DIR"
 
 # Set default values for SSL parameters if not provided
@@ -15,7 +15,7 @@ DAYS=365
 SHA_ALGO="sha384"
 
 echo "Generating SSL certificates for Nginx..."
-if [ -d $SSL_DIR ]; then rm -rf $SSL_DIR; fi
+if [ -d $SSL_DIR ]; then rm -rf $SSL_DIR/*; fi
 	mkdir -p $SSL_DIR
 	openssl req -x509 -nodes -days ${DAYS} -${SHA_ALGO} -newkey rsa:${KEY_LENGTH} -keyout $SSL_DIR/key.pem -out $SSL_DIR/cert.pem -subj "/CN=localhost"
 	chmod 640 $SSL_DIR/key.pem $SSL_DIR/cert.pem

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx.conf
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx.conf
@@ -10,8 +10,8 @@ stream {
 
     server {
         listen 1883 ssl;
-        ssl_certificate /opt/bitnami/nginx/conf/bitnami/certs/cert.pem;
-        ssl_certificate_key /opt/bitnami/nginx/conf/bitnami/certs/key.pem;
+        ssl_certificate /opt/intel/certs/cert.pem;
+        ssl_certificate_key /opt/intel/certs/key.pem;
 
         proxy_pass ia-mqtt-broker;
     }
@@ -23,9 +23,9 @@ http {
     # Host mapping is defined in the Docker Compose file
     server {
         listen 443 ssl;
-        # Bitnami SSL cert paths
-        ssl_certificate /opt/bitnami/nginx/conf/bitnami/certs/cert.pem;
-        ssl_certificate_key /opt/bitnami/nginx/conf/bitnami/certs/key.pem;
+        # Nginx SSL cert paths
+        ssl_certificate /opt/intel/certs/cert.pem;
+        ssl_certificate_key /opt/intel/certs/key.pem;
 
         location /ts-api {
             proxy_pass http://ia-time-series-analytics-microservice:5000/;


### PR DESCRIPTION
### Description

Bitnami has moved most of its Catalog behind a subscription paywall. Hence we are moving to nginx:1.29.1-bookworm-perl

Fixes # (issue)

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

