### PR TITLE
[DOCS] hide toctrees in markdown files for 1.2.0

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/docs/user-guide/release_notes/Overview.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/docs/user-guide/release_notes/Overview.md
@@ -5,6 +5,7 @@
 - [March 2025](./march-2025.md)
 - [February 2025](./february-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -13,3 +14,4 @@ march-2025.md
 april-2025.md
 august-2025.md
 ```
+hide_directive-->

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/docs/user-guide/release_notes/Overview.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/docs/user-guide/release_notes/Overview.md
@@ -2,8 +2,10 @@
 
 - [August 2025](./august-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 august-2025.md
 ```
+hide_directive-->

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/weld-porosity/docs/user-guide/release_notes/Overview.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/weld-porosity/docs/user-guide/release_notes/Overview.md
@@ -4,6 +4,7 @@
 - [April 2025](./april-2025.md)
 - [August 2025](./august-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
@@ -11,3 +12,4 @@ march-2025.md
 april-2025.md
 august-2025.md
 ```
+hide_directive-->

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/worker-safety-gear-detection/docs/user-guide/release_notes/Overview.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/worker-safety-gear-detection/docs/user-guide/release_notes/Overview.md
@@ -2,8 +2,10 @@
 
 - [August 2025](./august-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 august-2025.md
 ```
+hide_directive-->

--- a/manufacturing-ai-suite/wind-turbine-anomaly-detection/docs/user-guide/release_notes/Overview.md
+++ b/manufacturing-ai-suite/wind-turbine-anomaly-detection/docs/user-guide/release_notes/Overview.md
@@ -2,8 +2,10 @@
 
 - [August 2025](./aug-2025.md)
 
+<!--hide_directive
 ```{toctree}
 :maxdepth: 5
 :hidden:
 aug-2025.md
 ```
+hide_directive-->


### PR DESCRIPTION
### Description

Toctree RST directives hidden, no longer appear on Github docs preview - port for release-1.2.0

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

