### PR TITLE
industrial-edge-insights-time-series: Fixed the docs for path and port

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/get-started.md
@@ -185,7 +185,7 @@ To trigger the UDF inference on GPU in Time Series Analytics Microservice, run t
 
 ```sh
  curl -k -X 'POST' \
- 'https://<HOST_IP>:30001/ts-api/config' \
+ 'https://<HOST_IP>:3000/ts-api/config' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '<Add contents of edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/apps/wind-turbine-anomaly-detection/time-series-analytics-config/config.json with device

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/how-to-deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/how-to-deploy-with-helm.md
@@ -98,10 +98,10 @@ Use the following command to verify if all the application resources got install
 
 To copy your own or existing model into Time Series Analytics Microservice in order to run this sample application in Kubernetes environment:
 
-1. The following udf package is placed in the repository under `time_series_analytics_microservice`. 
+1. The following udf package is placed in the repository under `edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/apps/wind-turbine-anomaly-detection/time-series-analytics-config`. 
 
     ```
-    - time_series_analytics_microservice/
+    - time-series-analytics-config/
         - models/
             - windturbine_anomaly_detector.pkl
         - tick_scripts/


### PR DESCRIPTION


### Description

Changes:
 docs- Fixed the path to time-series-analytics-config folder and port number

Fixes # (issue)

### Any Newly Introduced Dependencies

No
### How Has This Been Tested?

Yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

