### PR TITLE
timeseries: nginx: Bumped internal port from 443 to 15443

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
@@ -347,7 +347,7 @@ services:
       no_proxy: "ia-grafana,ia-time-series-analytics-microservice,ia-mqtt-broker,${no_proxy}"
       NO_PROXY: "ia-grafana,ia-time-series-analytics-microservice,ia-mqtt-broker,${no_proxy}"
     ports:
-      - "${GRAFANA_PORT}:443"   # HTTPS for Grafana and TS MS Rest API 
+      - "${GRAFANA_PORT}:15443"   # HTTPS for Grafana and TS MS Rest API 
       - "1883:1883" # MQTT TCP Proxy
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/values.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/values.yaml
@@ -118,7 +118,7 @@ config:
   nginx:
     name: nginx
     int:
-      https_port: "443"
+      https_port: "15443"
       mqtt_port: "1883"
     ext:
       https_port: "30001"

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx.conf
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/nginx/nginx.conf
@@ -22,7 +22,7 @@ http {
     # TimeSeries Microservice REST API available at /ts-api/
     # Host mapping is defined in the Docker Compose file
     server {
-        listen 443 ssl;
+        listen 15443 ssl;
         # Nginx SSL cert paths
         ssl_certificate /opt/nginx/certs/cert.pem;
         ssl_certificate_key /opt/nginx/certs/key.pem;


### PR DESCRIPTION
### Description

Due to security policy in k8s, 443 port might be restricted

Fixes # (issue) 

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Verified

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

