### PR TITLE
Updated gh action to support metro_sdk_manager

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -23,6 +23,7 @@ jobs:
       image-based-video-search_changed: ${{ steps.filter.outputs.image-based-video-search }}
       industrial-edge-insights-time-series_changed: ${{ steps.filter.outputs.industrial-edge-insights-time-series }}
       loitering-detection_changed: ${{ steps.filter.outputs.loitering-detection }}
+      metro-sdk-manager_changed: ${{ steps.filter.outputs.metro-sdk-manager }}
       pallet-defect-detection_changed: ${{ steps.filter.outputs.pallet-defect-detection }}
       pcb-anomaly-detection_changed: ${{ steps.filter.outputs.pcb-anomaly-detection }}
       robotics-ai-suite_changed: ${{ steps.filter.outputs.robotics-ai-suite }}
@@ -48,6 +49,8 @@ jobs:
               - 'manufacturing-ai-suite/industrial-edge-insights-time-series/docs/**'
             loitering-detection:
               - 'metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/docs/**'
+            metro-sdk-manager:
+              - 'metro-ai-suite/metro-sdk-manager/docs/**'
             pallet-defect-detection:
               - 'manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/docs/**'
             pcb-anomaly-detection:
@@ -118,6 +121,19 @@ jobs:
       DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
     with:
       docs_directory: metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection
+
+  build_metro-sdk-manager:
+    permissions:
+      contents: read          # needed for actions/checkout
+    needs: filter
+    if: ${{ needs.filter.outputs.metro-sdk-manager_changed == 'true' }}
+    uses: open-edge-platform/orch-ci/.github/workflows/build-documentation.yml@b14b0105bf312a2c98457dd021622de4c14f6bff
+    secrets:
+      SYS_ORCH_GITHUB: ${{ secrets.SYS_ORCH_GITHUB }}
+      DOC_AWS_ACCESS_KEY_ID: ${{ secrets.DOC_AWS_ACCESS_KEY_ID }}
+      DOC_AWS_SECRET_ACCESS_KEY: ${{ secrets.DOC_AWS_SECRET_ACCESS_KEY }}
+    with:
+      docs_directory: metro-ai-suite/metro-sdk-manager
 
   build_pallet-defect-detection:
     permissions:


### PR DESCRIPTION
### Description

This pull request updates the `.github/workflows/pre-merge.yml` workflow to add support for building documentation for the `metro-sdk-manager` project. The changes ensure that when documentation in `metro-sdk-manager` is modified, the relevant build job is triggered automatically.

**Workflow enhancements for metro-sdk-manager:**

* Added a filter to detect changes in `metro-sdk-manager` documentation so that related jobs can be conditionally triggered.
* Updated the path filters to include `metro-ai-suite/metro-sdk-manager/docs/**`, allowing the workflow to monitor documentation changes for `metro-sdk-manager`.
* Introduced a new job, `build_metro-sdk-manager`, which runs the documentation build workflow specifically for the `metro-sdk-manager` directory when relevant changes are detected.
Fixes # (issue)

### Any Newly Introduced Dependencies
N/A

### How Has This Been Tested?
N/A

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

