### PR TITLE
Remove gvaclassify parameter called threshold

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/configs/pipeline-server-config.json
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/configs/pipeline-server-config.json
@@ -104,7 +104,7 @@
                 "name": "pcb_anomaly_detection_gpu",
                 "source": "gstreamer",
                 "queue_maxsize": 50,
-                "pipeline": "{auto_source} name=source ! parsebin ! vah264dec ! vapostproc ! video/x-raw(memory:VAMemory) ! gvaclassify inference-region=full-frame device=GPU pre-process-backend=va-surface-sharing model-instance-id=instgpu0 inference-interval=1 batch-size=8 nireq=2 ie-config=\"NUM_STREAMS=2\" threshold=0.7 name=classification ! queue ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination ! queue ! gvafpscounter ! appsink name=appsink",
+                "pipeline": "{auto_source} name=source ! parsebin ! vah264dec ! vapostproc ! video/x-raw(memory:VAMemory) ! gvaclassify inference-region=full-frame device=GPU pre-process-backend=va-surface-sharing model-instance-id=instgpu0 inference-interval=1 batch-size=8 nireq=2 ie-config=\"NUM_STREAMS=2\" name=classification ! queue ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination ! queue ! gvafpscounter ! appsink name=appsink",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -122,7 +122,7 @@
                 "name": "pcb_anomaly_detection_npu",
                 "source": "gstreamer",
                 "queue_maxsize": 50,
-                "pipeline": "{auto_source} name=source ! parsebin ! vah264dec ! vapostproc ! video/x-raw(memory:VAMemory) ! gvaclassify inference-region=full-frame device=NPU pre-process-backend=va model-instance-id=instnpu0 inference-interval=1 batch-size=1 nireq=4 threshold=0.7 name=classification ! queue ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination ! queue ! gvafpscounter ! appsink name=appsink",
+                "pipeline": "{auto_source} name=source ! parsebin ! vah264dec ! vapostproc ! video/x-raw(memory:VAMemory) ! gvaclassify inference-region=full-frame device=NPU pre-process-backend=va model-instance-id=instnpu0 inference-interval=1 batch-size=1 nireq=4 name=classification ! queue ! gvametaconvert add-empty-results=true name=metaconvert ! gvametapublish name=destination ! queue ! gvafpscounter ! appsink name=appsink",
                 "parameters": {
                     "type": "object",
                     "properties": {

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-benchmark.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-benchmark.md
@@ -7,7 +7,7 @@ This guide demonstrates how to benchmark the pallet defect detection pipeline to
 > Ensure the application is set up and running. Refer to the [Setup Guide](../setup-guide.md) for complete installation and configuration steps.
 
 - DL Streamer Pipeline Server (DLSPS) running and accessible
-- `curl`, `jq`, and `bc` utilities installed
+- `curl`, `jq`, `gawk` and `bc` utilities installed
 
 ### Benchmark Script Usage
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/how-to-benchmark.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/how-to-benchmark.md
@@ -7,7 +7,7 @@ This guide demonstrates how to benchmark the PCB anomaly detection pipeline to d
 > Ensure the application is set up and running. Refer to the [Setup Guide](../setup-guide.md) for complete installation and configuration steps.
 
 - DL Streamer Pipeline Server (DLSPS) running and accessible
-- `curl`, `jq`, and `bc` utilities installed
+- `curl`, `jq`, `gawk` and `bc` utilities installed
 
 ### Benchmark Script Usage
 
@@ -41,7 +41,7 @@ Available pipelines for PCB anomaly detection:
 These are the recommended parameters by Edge Benchmarking and Workloads team for workload with similar characteristics. These are configurable parameters that can be adjusted based on your specific requirements:
 
 ```
-inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config="NUM_STREAMS=2" threshold=0.7
+inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config="NUM_STREAMS=2"
 ```
 
 **Parameter Descriptions:**
@@ -50,7 +50,6 @@ inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config=
 - `batch-size=8`: Process 8 frames in a single batch for better GPU utilization
 - `nireq=2`: Number of inference requests to run in parallel
 - `ie-config="NUM_STREAMS=2"`: Intel OpenVINO engine streams configuration
-- `threshold=0.7`: Detection confidence threshold (70%)
 
 ### Steps to run benchmarks
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/how-to-benchmark.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/how-to-benchmark.md
@@ -7,7 +7,7 @@ This guide demonstrates how to benchmark the weld porosity classification pipeli
 > Ensure the application is set up and running. Refer to the [Setup Guide](../setup-guide.md) for complete installation and configuration steps.
 
 - DL Streamer Pipeline Server (DLSPS) running and accessible
-- `curl`, `jq`, and `bc` utilities installed
+- `curl`, `jq`, `gawk` and `bc` utilities installed
 
 ### Benchmark Script Usage
 
@@ -41,7 +41,7 @@ Available pipelines for weld porosity classification:
 These are the recommended parameters by Edge Benchmarking and Workloads team for workload with similar characteristics. These are configurable parameters that can be adjusted based on your specific requirements:
 
 ```
-inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config="NUM_STREAMS=2" threshold=0.7
+inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config="NUM_STREAMS=2"
 ```
 
 **Parameter Descriptions:**
@@ -50,7 +50,6 @@ inference-region=full-frame inference-interval=1 batch-size=8 nireq=2 ie-config=
 - `batch-size=8`: Process 8 frames in a single batch for better GPU utilization
 - `nireq=2`: Number of inference requests to run in parallel
 - `ie-config="NUM_STREAMS=2"`: Intel OpenVINO engine streams configuration
-- `threshold=0.7`: Detection confidence threshold (70%)
 
 ### Steps to run benchmarks
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-benchmark.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-benchmark.md
@@ -7,7 +7,7 @@ This guide demonstrates how to benchmark the worker safety gear detection pipeli
 > Ensure the application is set up and running. Refer to the [Setup Guide](../setup-guide.md) for complete installation and configuration steps.
 
 - DL Streamer Pipeline Server (DLSPS) running and accessible
-- `curl`, `jq`, and `bc` utilities installed
+- `curl`, `jq`, `gawk` and `bc` utilities installed
 
 ### Benchmark Script Usage
 


### PR DESCRIPTION
### Description

Remove gvaclassify parameter called threshold


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

