### PR TITLE
industrial-edge-insights-time-series: nmap port issue fix

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/grafana.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/grafana.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ $.Values.config.grafana.name }}
   namespace: {{ $.Values.namespace }}
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: ia-grafana
   ports:

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/time-series-analytics-microservice.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/time-series-analytics-microservice.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ .Values.config.time_series_analytics_microservice.name }}
   namespace: {{ .Values.namespace }}
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - port: {{ .Values.config.time_series_analytics_microservice.kapacitor_port }}
     name: kapacitor-port


### PR DESCRIPTION
### Description

Changes:
 helm - Changed the Service type from NodePort to ClusterIP for grafana
and time series microservice.

Fixes # (issue)

### Any Newly Introduced Dependencies

No
### How Has This Been Tested?

Yes
### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

