### PR TITLE
[Metro-vision-ai-suite] Updated tutorial-1 document for AI-tolling tutorial-1

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/tutorial-1.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/tutorial-1.md
@@ -271,15 +271,7 @@ Expected output should show containers for:
 - `grafana`
 - `mosquitto` (MQTT broker)
 
-### 2. **Access the Application Interface**
-
-Open your web browser and navigate to:
-- **Main Dashboard**: `https://<HOST_IP>/grafana` (Grafana)
-    - Username: admin
-    - Password: admin
-- **Node-RED Flow Editor**: `https://<HOST_IP>/nodered/`
-
-### 3. **Test Video Processing**
+### 2. **Test Video Processing**
 
 Start the AI pipeline and process the sample video:
 
@@ -308,7 +300,7 @@ curl -k -s https://localhost/api/pipelines/user_defined_pipelines/car_plate_reco
 }'
 ```
 
-### 4. **View Live Video Stream**
+### 3. **View Live Video Stream**
 
 Access the processed video stream with AI annotations through WebRTC:
 


### PR DESCRIPTION
### Description

Removed the step to access the application interface in tutorial-1 in AI-tolling before it is set up in tutorial-2 and tutorial-3

Fixes # (issue)

Document update

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tutorial with changes were followed 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

