### PR TITLE
[Robotics][RVC] Run with container name

### DIFF
--- a/robotics-ai-suite/robot-vision-control/docker_run_rvc_img.sh
+++ b/robotics-ai-suite/robot-vision-control/docker_run_rvc_img.sh
@@ -25,7 +25,7 @@ set -e
 
 # Parse arguments
 ROS_DISTRO=${1:-humble}
-CONTAINER_NAME="rvc-container"
+CONTAINER_NAME="rvc-container-${ROS_DISTRO}"
 
 echo "Checking for existing container: ${CONTAINER_NAME}..."
 


### PR DESCRIPTION
### Description

The purpose of this PR is to allow the reuse of the rvc container once it has been already started. At the moment we're always creating a new container when we run `./docker_run_rvc_img.sh`.
This PR is based off:
* https://github.com/open-edge-platform/edge-ai-suites/pull/1117

and adding the generalization of the container via ROS_DISTRO.


### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Locally, by running multiple runs of  `./docker_run_rvc_img.sh ` and  `./docker_run_rvc_img.sh jazzy` and checking:
- the container is created if it doesn't exist
- on the second run of the same command we attached the correct container if it already exists


 
### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

