### PR TITLE
[Industrial edge insights vision] Offload nginx certificate creation from external script to init container in k8s deployment

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
@@ -87,11 +87,3 @@ download_artifacts() {
 }
 
 download_artifacts "pallet-defect-detection"
-
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
-if [ ! -f server.key ] || [ ! -f server.crt ]; then
-    echo "Generate self-signed certificate..."
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"
-    chown -R "$(id -u):$(id -g)" server.key server.crt 2>/dev/null || true
-fi

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
@@ -92,11 +92,3 @@ download_artifacts() {
 }
 
 download_artifacts "pcb-anomaly-detection"
-
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
-if [ ! -f server.key ] || [ ! -f server.crt ]; then
-    echo "Generate self-signed certificate..."
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"
-    chown -R "$(id -u):$(id -g)" server.key server.crt 2>/dev/null || true
-fi

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/weld-porosity/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/weld-porosity/setup.sh
@@ -87,11 +87,3 @@ download_artifacts() {
 }
 
 download_artifacts "weld-porosity"
-
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
-if [ ! -f server.key ] || [ ! -f server.crt ]; then
-    echo "Generate self-signed certificate..."
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"
-    chown -R "$(id -u):$(id -g)" server.key server.crt 2>/dev/null || true
-fi

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/worker-safety-gear-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/worker-safety-gear-detection/setup.sh
@@ -92,11 +92,3 @@ download_artifacts() {
 }
 
 download_artifacts "worker-safety-gear-detection"
-
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
-if [ ! -f server.key ] || [ ! -f server.crt ]; then
-    echo "Generate self-signed certificate..."
-    openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"
-    chown -R "$(id -u):$(id -g)" server.key server.crt 2>/dev/null || true
-fi

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/templates/nginx-reverse-proxy.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/templates/nginx-reverse-proxy.yaml
@@ -7,18 +7,23 @@ metadata:
 data:
   nginx.conf: |-
 {{ (.Files.Get (printf "apps/%s/configs/nginx/nginx.conf" .Values.env.SAMPLE_APP)) | indent 4 }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: nginx-ssl-certs
-  namespace: {{ .Values.namespace }}
-type: Opaque
-data:
-{{- $sslPath := printf "apps/%s/configs/nginx/ssl/*" .Values.env.SAMPLE_APP }}
-{{- range $path, $file := .Files.Glob $sslPath }}
-  {{ base $path }}: {{ $file | toString | b64enc }}
-{{- end }}
+  generate_certs.sh: |
+    #!/bin/sh
+    set -e
+    SSL_DIR="/etc/nginx/ssl"
+    mkdir -p "$SSL_DIR"
+    if ! command -v openssl >/dev/null 2>&1; then
+        echo "Installing openssl..."
+        apk add --no-cache openssl
+    fi
+    if [ ! -f "$SSL_DIR/server.crt" ] || [ ! -f "$SSL_DIR/server.key" ]; then
+      echo "🔐 Generating self-signed SSL certificate..."
+      openssl req -x509 -nodes -days 365 \
+        -newkey rsa:2048 \
+        -keyout "$SSL_DIR/server.key" \
+        -out "$SSL_DIR/server.crt" \
+        -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"
+    fi
 ---
 apiVersion: v1
 kind: Service
@@ -56,6 +61,17 @@ spec:
       labels:
         app: nginx-reverse-proxy
     spec:
+      initContainers:
+      - name: generate-certs
+        image: alpine/openssl:3.5.4
+        command: 
+        - /bin/sh
+        - /scripts/generate_certs.sh
+        volumeMounts:
+        - name: nginx-ssl
+          mountPath: /etc/nginx/ssl
+        - name: nginx-scripts
+          mountPath: /scripts
       containers:
       - name: nginx-reverse-proxy
         image: {{ $.Values.images.nginx }}
@@ -82,6 +98,15 @@ spec:
       - name: nginx-conf
         configMap:
           name: nginx-conf
+          items:
+          - key: nginx.conf
+            path: nginx.conf
+      - name: nginx-scripts
+        configMap:
+          name: nginx-conf
+          items:
+          - key: generate_certs.sh
+            path: generate_certs.sh
+            mode: 0755
       - name: nginx-ssl
-        secret:
-          secretName: nginx-ssl-certs
+        emptyDir: {}


### PR DESCRIPTION
### Description

Industrial edge insights vision: Offload nginx certificate creation from external script to init container in k8s deployment

EMF deployment of the helm charts is blocked because EMF cannot run ":./setup.sh helm" before deploying the helm chart. This PR fixes the problem and also is the ideal way of certificate generation without dependency on external script.

Fixes # (issue)
https://jira.devtools.intel.com/browse/ITEP-82646

### How Has This Been Tested?
Manual testing

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

