### PR TITLE
[Metro AI Suite]: Update basler and balluff docs to use latest dlsps image

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-integrate-balluff-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-integrate-balluff-sdk.md
@@ -29,7 +29,7 @@ cd edge-ai-libraries/microservices/dlstreamer-pipeline-server
 Create a Docker file named `BalluffDockerfile` inside your `dlstreamer-pipeline-server` directory with the following content.
 
 ```dockerfile
-FROM intel/dlstreamer-pipeline-server:3.1.0-ubuntu24
+FROM intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 
 USER root
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-integrate-pylon-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-integrate-pylon-sdk.md
@@ -27,7 +27,7 @@ cd edge-ai-libraries/microservices/dlstreamer-pipeline-server
 Create a Docker file named `BaslerDockerfile` inside your `dlstreamer-pipeline-server` directory with the following content.
 
 ```dockerfile
-FROM intel/dlstreamer-pipeline-server:3.1.0-ubuntu24
+FROM intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 
 USER root
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-integrate-balluff-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-integrate-balluff-sdk.md
@@ -29,7 +29,7 @@ cd edge-ai-libraries/microservices/dlstreamer-pipeline-server
 Create a Docker file named `BalluffDockerfile` inside your `dlstreamer-pipeline-server` directory with the following content.
 
 ```dockerfile
-FROM intel/dlstreamer-pipeline-server:3.1.0-ubuntu24
+FROM intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 
 USER root
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-integrate-pylon-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-integrate-pylon-sdk.md
@@ -27,7 +27,7 @@ cd edge-ai-libraries/microservices/dlstreamer-pipeline-server
 Create a Docker file named `BaslerDockerfile` inside your `dlstreamer-pipeline-server` directory with the following content.
 
 ```dockerfile
-FROM intel/dlstreamer-pipeline-server:3.1.0-ubuntu24
+FROM intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 
 USER root
 


### PR DESCRIPTION
### Description

Updates the dlstreamer-pipeline-server image version to the latest release for Balluff and Basler documentation.

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Manually built and streamed the camera.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

