### PR TITLE
time-series, multimodal: Updated the tag to have -2026.0-weekly as suffix

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/.env
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/.env
@@ -36,7 +36,7 @@ FUSION_MODULE_IMAGE=intel/ia-multimodal-fusion-analytics:1.0.0
 DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 
 # Please provide the suffix for the image version you want to use like rc1, rc2, git hash id etc.
-IMAGE_SUFFIX=weekly
+IMAGE_SUFFIX=2026.0-weekly
 
 ## --------- Sample app secrets config ---------------
 # The INFLUXDB_USERNAME must contain only alphabets and be at least 5 characters minimum

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/.env
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/.env
@@ -36,7 +36,7 @@ OPC_UA_SERVER_IMAGE=intel/ia-opcua-server:1.1.0
 MQTT_PUBLISHER_IMAGE=intel/ia-mqtt-publisher:1.1.0
 
 # Please provide the suffix for the image version you want to use like rc1, rc2, git hash id etc.
-IMAGE_SUFFIX=weekly
+IMAGE_SUFFIX=2026.0-weekly
 
 ## --------- Sample app secrets config ---------------
 # The INFLUXDB_USERNAME must contain only alphabets and be at least 5 characters minimum

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/Makefile
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/Makefile
@@ -33,7 +33,7 @@ endif
 
 # Assign default value to version and appVersion if not provided for helm deployment
 ifeq ($(origin version), undefined)
-version := "1.1.0-weekly"
+version := "1.1.0-2026.0-weekly"
 endif
 
 export SAMPLE_APP

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/Chart.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0-weekly
+version: 1.1.0-2026.0-weekly
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0-weekly"
+appVersion: "1.1.0-2026.0-weekly"

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/README.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/README.md
@@ -1,1 +1,1 @@
-Please refer [link](https://docs.openedgeplatform.intel.com/2025.2/edge-ai-suites/ai-suite-manufacturing/industrial-edge-insights-time-series/how-to-guides/how-to-deploy-with-helm.html) for the helm deployment
+Please refer [link](https://docs.openedgeplatform.intel.com/dev/edge-ai-suites/ai-suite-manufacturing/industrial-edge-insights-time-series/how-to-guides/how-to-deploy-with-helm.html) for the helm deployment


### PR DESCRIPTION
### Description

Updated the docker image and helm charts version to have -2026.0-weekly as the suffix tag for weekly builds

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

To be updated

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

