### PR TITLE
[Edge AI Suites] Update ubuntu22 tag to ubuntu24 for dls and dlsps for all apps

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env
@@ -4,7 +4,7 @@ HOST_IP=
 REST_SERVER_PORT=8080
 
 # DL Streamer Pipeline Server
-DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 RTSP_CAMERA_IP=
 
 # Model Registry

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env_pallet_defect_detection
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env_pallet_defect_detection
@@ -4,7 +4,7 @@ HOST_IP=
 REST_SERVER_PORT=8080
 
 # DL Streamer Pipeline Server
-DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 RTSP_CAMERA_IP=
 
 # Model Registry

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env_pcb_anomaly_detection
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env_pcb_anomaly_detection
@@ -4,7 +4,7 @@ HOST_IP=
 REST_SERVER_PORT=8080
 
 # DL Streamer Pipeline Server
-DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 RTSP_CAMERA_IP=
 
 # Model Registry

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env_weld_porosity_classification
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env_weld_porosity_classification
@@ -4,7 +4,7 @@ HOST_IP=
 REST_SERVER_PORT=8080
 
 # DL Streamer Pipeline Server
-DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 RTSP_CAMERA_IP=
 
 # Model Registry

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/.env_worker_safety_gear_detection
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/.env_worker_safety_gear_detection
@@ -4,7 +4,7 @@ HOST_IP=
 REST_SERVER_PORT=8080
 
 # DL Streamer Pipeline Server
-DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+DLSTREAMER_PIPELINE_SERVER_IMAGE=intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
 RTSP_CAMERA_IP=
 
 # Model Registry

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values.yaml
@@ -52,7 +52,7 @@ webrtcturnserver:
 images:
   minio: minio/minio:RELEASE.2020-12-12T08-39-07Z
   model_registry: intel/model-registry:1.0.3
-  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
   nginx: nginx:1.27-alpine
   mqtt_broker: eclipse-mosquitto:latest
 config:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_pallet_defect_detection.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_pallet_defect_detection.yaml
@@ -52,7 +52,7 @@ webrtcturnserver:
 images:
   minio: minio/minio:RELEASE.2020-12-12T08-39-07Z
   model_registry: intel/model-registry:1.0.3
-  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
   nginx: nginx:1.27-alpine
   mqtt_broker: eclipse-mosquitto:latest
 config:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_pcb_anomaly_detection.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_pcb_anomaly_detection.yaml
@@ -52,7 +52,7 @@ webrtcturnserver:
 images:
   minio: minio/minio:RELEASE.2020-12-12T08-39-07Z
   model_registry: intel/model-registry:1.0.3
-  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
   nginx: nginx:1.27-alpine
   mqtt_broker: eclipse-mosquitto:latest
 config:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_weld_porosity_classification.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_weld_porosity_classification.yaml
@@ -52,7 +52,7 @@ webrtcturnserver:
 images:
   minio: minio/minio:RELEASE.2020-12-12T08-39-07Z
   model_registry: intel/model-registry:1.0.3
-  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
   nginx: nginx:1.27-alpine
   mqtt_broker: eclipse-mosquitto:latest
 config:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_worker_safety_gear_detection.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/values_worker_safety_gear_detection.yaml
@@ -52,7 +52,7 @@ webrtcturnserver:
 images:
   minio: minio/minio:RELEASE.2020-12-12T08-39-07Z
   model_registry: intel/model-registry:1.0.3
-  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu22
+  dlstreamer_pipeline_server: intel/dlstreamer-pipeline-server:2025.2.0-ubuntu24
   nginx: nginx:1.27-alpine
   mqtt_broker: eclipse-mosquitto:latest
 config:

--- a/metro-ai-suite/image-based-video-search/chart/values.yaml
+++ b/metro-ai-suite/image-based-video-search/chart/values.yaml
@@ -89,7 +89,7 @@ dlstreamerpipelineserver:
     # key: dlstreamerpipelineserver.repository.image
     image: docker.io/intel/dlstreamer-pipeline-server
     # key: dlstreamerpipelineserver.repository.tag
-    tag: 2025.2.0-ubuntu22
+    tag: 2025.2.0-ubuntu24
   # key: dlstreamerpipelineserver.replicas
   replicas: 1
   # key: dlstreamerpipelineserver.nodeSelector

--- a/metro-ai-suite/image-based-video-search/src/feature-matching/requirements.txt
+++ b/metro-ai-suite/image-based-video-search/src/feature-matching/requirements.txt
@@ -1,11 +1,11 @@
-marshmallow==3.23.1
+marshmallow==3.26.2
 pymilvus==2.5.0
 Pillow==11.0.0
 httpx==0.28.1
 paho-mqtt==2.1.0
 fastapi==0.121.0
 uvicorn==0.32.1
-numpy==2.2.1 
+numpy==2.2.1
 python-multipart==0.0.19
 certifi==2024.8.30
 requests==2.32.4


### PR DESCRIPTION
### Description

-  Update ubuntu22 tag to ubuntu24 for dls and dlsps for all apps
-  Upgrade marshmallow library in IBVS 

Fixes # https://jira.devtools.intel.com/browse/ITEP-84767 

### Any Newly Introduced Dependencies

No new dependency introduced

### How Has This Been Tested?

Verified basic flow of all the affected sample apps

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

