### PR TITLE
refactor: Remove open-source Dobby motion controller references

### DIFF
--- a/robotics-ai-suite/robot-vision-control/docs/source/components/rvc_control/motion_controller_plugin.rst
+++ b/robotics-ai-suite/robot-vision-control/docs/source/components/rvc_control/motion_controller_plugin.rst
@@ -35,22 +35,6 @@ The configuration of this plugin is explained in :ref:`Moveit2 Servo pose tracki
 The reason is that the plugin isn't running its own ROS 2 node, but it runs in the main use case node, so the
 configuration of the motion controller and the grasp plugin is provided to the main node.
 
-Dobby Motion Controller
--------------------------------
-
-RVC is providing a real-time motion planning framework for robot manipulators called Dobby.
-
-Dobby is a real-time motion planning framework with a high success rate in complex environments:
-
-- An efficient map representation that allows for a fast collision checking.
-
-- A geometric path planner based on Rapidly-Exploring Random Trees with minimum distance as the cost function.
-
-- An efficient trajectory generation method that allows selecting the optimization criteria, e.g., minimum acceleration, minimum jerk, etc.
-
-- A novel cartesian trajectory generation algorithm that allows tracking time-dependent trajectories in cartesian space while avoiding self-collisions and avoiding obstacles mapped, providing dynamically feasible trajectories.
-
-
 Direct Universal Robot Pendant Controller
 -----------------------------------------
 

--- a/robotics-ai-suite/robot-vision-control/docs/source/components/rvc_control/parameters.rst
+++ b/robotics-ai-suite/robot-vision-control/docs/source/components/rvc_control/parameters.rst
@@ -19,10 +19,4 @@ Plugins
            motion_controller: "RVCMotionController::Moveit2ServoMotionController"
            grasp_plugin: "RVCControl::NonOrientedGrasp"
 
-To use Dobby planner plugin:
 
-.. code-block:: yaml
-
-   /**:
-       ros__parameters:
-           motion_controller: "RVCMotionController::DobbyMotionController"

--- a/robotics-ai-suite/robot-vision-control/docs/source/releasenotes.rst
+++ b/robotics-ai-suite/robot-vision-control/docs/source/releasenotes.rst
@@ -11,14 +11,13 @@ Click each tab to learn about the new and updated features in each release of In
 
    .. group-tab:: RVC v2.1
 
-      RVC v2.1 release includes bug and security updates as well as adds two new components: Intel Lab's Dobby Path Planner, an adaptive path planner that improves robot arm performance in complex environments; and Intel Lab’s Histodepth Pointcloud Segmentation algorithm in a Virtual Fence application.
+      RVC v2.1 release includes bug and security updates as well as Intel Lab's Histodepth Pointcloud Segmentation algorithm in a Virtual Fence application.
 
-      - **Intel Lab's Dobby Path Planner**: This new planner, available as an option in RVC's dynamic motion use case, enables fast collision checking, a new geometric path planner based on rapidly exploring random trees, new trajectory generation methods for user-specific optimization criteria, and a novel cartesian trajectory generation algorithm that allows tracking time-dependent trajectories in cartesian space enabling self and obstacle collision avoided while producing dynamically feasible trajectories.
       - **Intel Lab's Histodepth Pointcloud Segmentation Virtual Fence**: Now part of the RVC package, this virtual fence application running on ROS uses depth information from an Intel RealSense camera to create dynamic and static scene segmentation maps to enable live robotic virtual fencing and safety bounding. The use of this segmentation algorithm enables a drop-in approach to virtual fencing, requiring no training or learning before deployment.
 
       **Features**
 
-      - New dynamic path planning algorithm available.
+      - New dynamic path planning algorithm available (Dobby path planner available under NDA - contact eci.maintainer@intel.com for details).
       - New dynamic virtual fencing algorithm available.
 
       **Known Limitations and Issues**

--- a/robotics-ai-suite/robot-vision-control/docs/source/use_cases/dynamic_use_case.rst
+++ b/robotics-ai-suite/robot-vision-control/docs/source/use_cases/dynamic_use_case.rst
@@ -43,20 +43,6 @@ designated destination.
 
     Then press play on the Universal Robots UR5e teach pendant
 
-    If Dobby planner plugin is intended to be used, after running the above, in three different terminals, run the followings:
+    .. note::
 
-    .. code-block:: bash
-
-        ros2 launch hrc_perception_ros dobby_launch.py
-
-    To put ground floor run:
-
-    .. code-block:: bash
-
-        python3 src/dobby_planner/applications.robotics.manipulation.perception-ros/scripts/dobby_service_test_floor.py
-
-    Once all the nodes are running and the robot is ready, run the following service to enable the dobby planner:
-
-    .. code-block:: bash
-
-        ros2 service call /ipc/hrc_perception_ros/start_follow_service_service std_srvs/srv/Empty {}
+        The Dobby planner plugin is Intel IP available under NDA only. For customers interested in accessing this motion planning framework, please contact eci.maintainer@intel.com.

--- a/robotics-ai-suite/robot-vision-control/src/rvc_dynamic_motion_controller_use_case/config/parameters.yaml
+++ b/robotics-ai-suite/robot-vision-control/src/rvc_dynamic_motion_controller_use_case/config/parameters.yaml
@@ -10,7 +10,8 @@
                 base_link: "base_link"
                 ee_link: "ee_link"
                 motion_controller: "RVCMotionController::Moveit2ServoMotionController"
-                #motion_controller: "RVCMotionController::DobbyMotionController"
+                # Note: Dobby motion controller is Intel IP available under NDA only.
+                # For customers interested in the Dobby motion planner, please contact eci.maintainer@intel.com
                 grasp_plugin: "RVCControl::NonOrientedGrasp"
                 #collision_boxes: []
                 #collision_boxes: ["SideConveyorBeltBox", "FrontConveyorBeltBox", "CameraBox"]


### PR DESCRIPTION
### Description

Remove all references to Dobby motion controller from the open-source Robot Vision & Control (RVC) framework. Dobby is Intel Lab's proprietary motion planning framework and is available only under NDA with Intel.

Fixes # (issue)
This PR cleans up documentation and configuration to clearly indicate that the Dobby motion controller is Intel IP available by NDA and not available in the public open-source release.


### Files Modified
- `src/rvc_dynamic_motion_controller_use_case/config/parameters.yaml` - Updated configuration comments to note NDA requirement
- `docs/source/components/rvc_control/motion_controller_plugin.rst` - Removed Dobby Motion Controller section
- `docs/source/components/rvc_control/parameters.rst` - Removed Dobby planner plugin configuration example
- `docs/source/use_cases/dynamic_use_case.rst` - Replaced Dobby usage instructions with NDA notice
- `docs/source/releasenotes.rst` - Updated release notes to indicate NDA status and contact information

### Key Updates
- All Dobby references now include contact information: `eci.maintainer@intel.com`
- Release notes updated to maintain awareness of the dynamic path planning capability while clarifying NDA restrictions
- Users interested in Dobby are directed to contact Intel for licensing inquiries


### How Has This Been Tested?

Documentation builds successfully without broken references.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

