### PR TITLE
GPU enabled for ai-ecg

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docker-compose.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docker-compose.yaml
@@ -138,12 +138,13 @@ services:
       context: ./services/ai-ecg/backend
       dockerfile: Dockerfile
       args:
-          HTTP_PROXY: ${HTTP_PROXY}
-          HTTPS_PROXY: ${HTTPS_PROXY}
-          NO_PROXY: ${NO_PROXY}
-          http_proxy: ${HTTP_PROXY}
-          https_proxy: ${HTTPS_PROXY}
-          no_proxy: ${NO_PROXY}
+        INSTALL_DRIVER_VERSION: "25.31.34666"
+        HTTP_PROXY: ${HTTP_PROXY}
+        HTTPS_PROXY: ${HTTPS_PROXY}
+        NO_PROXY: ${NO_PROXY}
+        http_proxy: ${HTTP_PROXY}
+        https_proxy: ${HTTPS_PROXY}
+        no_proxy: ${NO_PROXY}
     image: intel/hl-ai-ecg:1.0.0
     container_name: ai-ecg
     network_mode: "host"
@@ -151,10 +152,17 @@ services:
       patient-monitoring-assets:
         condition: service_completed_successfully
       patient-monitoring-aggregator:
-          condition: service_started  
+        condition: service_started
+    environment:
+      - ECG_DEVICE=GPU
     volumes:
       - ./models:/models
       - ./videos:/videos
+    devices:
+      - "/dev/dri:/dev/dri"
+    group_add:
+      - video
+
 
   3dpose-estimation:
       build:

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/Dockerfile
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM python:3.10-slim
+FROM python:3.12-slim
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -9,26 +9,66 @@ ARG https_proxy
 ARG no_proxy
 
 ENV http_proxy=${http_proxy:-$HTTP_PROXY} \
-	https_proxy=${https_proxy:-$HTTPS_PROXY} \
-	no_proxy=${no_proxy:-$NO_PROXY} \
-	HTTP_PROXY=${HTTP_PROXY:-$http_proxy} \
-	HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy} \
-	NO_PROXY=${NO_PROXY:-$no_proxy}
-
+    https_proxy=${https_proxy:-$HTTPS_PROXY} \
+    no_proxy=${no_proxy:-$NO_PROXY} \
+    HTTP_PROXY=${HTTP_PROXY:-$http_proxy} \
+    HTTPS_PROXY=${HTTPS_PROXY:-$https_proxy} \
+    NO_PROXY=${NO_PROXY:-$no_proxy}
 
 WORKDIR /app
 
+# ----------------------------------------------------------------------------
+# System dependencies (OpenVINO + OpenCV GPU requirements)
+# ----------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender1 \
+    libgomp1 \
+    libgl1 \
+    libnuma1 \
+    ocl-icd-libopencl1 \
+    curl \
     ca-certificates \
- && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
+# ----------------------------------------------------------------------------
+# Install Python dependencies
+# ----------------------------------------------------------------------------
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# ----------------------------------------------------------------------------
+# GPU Driver Installation (Same as rppg)
+# ----------------------------------------------------------------------------
+ARG INSTALL_DRIVER_VERSION="25.31.34666"
 
+COPY scripts/install_ubuntu_gpu_drivers.sh /tmp/install_gpu_drivers.sh
+RUN chmod +x /tmp/install_gpu_drivers.sh
+RUN /tmp/install_gpu_drivers.sh
+
+RUN apt-get clean && \
+    rm -rf /tmp/install_gpu_drivers.sh && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/*
+
+# ----------------------------------------------------------------------------
+# Copy application code
+# ----------------------------------------------------------------------------
 COPY . .
 
+ENV PYTHONPATH=/app
 
 EXPOSE 8000
 
+# ----------------------------------------------------------------------------
+# Healthcheck
+# ----------------------------------------------------------------------------
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+# ----------------------------------------------------------------------------
+# Run app
+# ----------------------------------------------------------------------------
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/app.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/app.py
@@ -54,6 +54,7 @@ def predict_ecg(filename: str):
     try:
         pred = engine.predict(filename)
         return {
+            "file": filename, 
             "signal": pred["signal"],
             "result": pred["result"],
             "inference_ms": pred["inference_ms"],

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/inference/engine.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/inference/engine.py
@@ -18,6 +18,7 @@ MODEL_MAP = {
 
 class ECGInferenceEngine:
     def __init__(self):
+        self.device = os.getenv("ECG_DEVICE", "GPU")
         self.core = Core()
         self.compiled_models = {}
         self.preproc = ECGPreprocessor()
@@ -42,7 +43,7 @@ class ECGInferenceEngine:
 
         if length not in self.compiled_models:
             model = self.core.read_model(MODEL_MAP[length])
-            self.compiled_models[length] = self.core.compile_model(model, "CPU")
+            self.compiled_models[length] = self.core.compile_model(model, self.device)
 
         return self.compiled_models[length]
 

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/scripts/install_ubuntu_gpu_drivers.sh
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/scripts/install_ubuntu_gpu_drivers.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -x
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Script should be used only as a part of Dockerfiles
+
+# Check if INSTALL_DRIVER_VERSION is set
+# In case it is not set we reach default switch condition and leave apt in abnormal state
+if [ -z "$INSTALL_DRIVER_VERSION" ]; then
+    echo "Error: INSTALL_DRIVER_VERSION cannot be empty."
+    exit 1
+fi
+
+apt-get update && apt-get install -y libnuma1 ocl-icd-libopencl1 --no-install-recommends && rm -rf /var/lib/apt/lists/* && \
+case $INSTALL_DRIVER_VERSION in \
+"24.26.30049") \
+        mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.26.30049.6/intel-level-zero-gpu_1.3.30049.6_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.26.30049.6/intel-opencl-icd_24.26.30049.6_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.26.30049.6/libigdgmm12_22.3.20_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17193.4/intel-igc-core_1.0.17193.4_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17193.4/intel-igc-opencl_1.0.17193.4_amd64.deb ; \
+        dpkg -i *.deb && rm -Rf /tmp/gpu_deps ; \
+;; \
+"24.39.31294") \
+        mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-level-zero-gpu_1.6.31294.12_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-opencl-icd_24.39.31294.12_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/libigdgmm12_22.5.2_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-core_1.0.17791.9_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-opencl_1.0.17791.9_amd64.deb ; \
+        dpkg -i *.deb && rm -Rf /tmp/gpu_deps ; \
+;; \
+"24.52.32224") \
+        mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu_1.6.32224.5_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd_24.52.32224.5_amd64.deb ; \
+        curl -L -O https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/libigdgmm12_22.5.5_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb ; \
+        curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb ; \
+        dpkg -i *.deb && rm -Rf /tmp/gpu_deps ; \
+;; \
+"25.31.34666") \
+	mkdir /tmp/gpu_deps && cd /tmp/gpu_deps ; \
+	curl -L -O https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libze-intel-gpu1_25.31.34666.3-0_amd64.deb; \
+	curl -L -O https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-opencl-icd_25.31.34666.3-0_amd64.deb; \
+	curl -L -O https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/libigdgmm12_22.8.1_amd64.deb; \
+	curl -L -O https://github.com/intel/compute-runtime/releases/download/25.31.34666.3/intel-ocloc_25.31.34666.3-0_amd64.deb; \
+	curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-core-2_2.16.0+19683_amd64.deb; \
+	curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/v2.16.0/intel-igc-opencl-2_2.16.0+19683_amd64.deb; \
+	dpkg -i *.deb && rm -Rf /tmp/gpu_deps ; \
+;; \
+*) \
+        dpkg -P intel-gmmlib intel-igc-core intel-igc-opencl intel-level-zero-gpu intel-ocloc intel-opencl intel-opencl-icd && \
+        apt-get update && apt-get -y --no-install-recommends install dpkg-dev && rm -rf /var/lib/apt/lists/* && \
+        cd /drivers/${INSTALL_DRIVER_VERSION} && \
+            dpkg-scanpackages .  > Packages && \
+            cd - ; \
+        echo "deb [trusted=yes arch=amd64] file:/drivers/${INSTALL_DRIVER_VERSION} ./" > /etc/apt/sources.list.d/intel-graphics-${INSTALL_DRIVER_VERSION}.list ; \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            intel-opencl-icd \
+            intel-level-zero-gpu level-zero \
+            intel-media-va-driver-non-free libmfx1 && \
+            rm -rf /var/lib/apt/lists/* ; \
+esac
+
+apt-get clean && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/*

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-aggregator/aggregator/ai_ecg_client.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-aggregator/aggregator/ai_ecg_client.py
@@ -31,6 +31,7 @@ class AIECGClient:
 
             signal = data.get("signal", [])
             result = data.get("result", {})
+            filename = data.get("file")
 
             return {
                 "device_id": "ai-ecg-001",
@@ -39,6 +40,7 @@ class AIECGClient:
                 "waveform": signal,
                 "waveform_frequency_hz": 360,
                 "inference": result,
+                "file": filename, 
             }
         except Exception as e:
             print("[AI-ECG] poll_next error:", e)


### PR DESCRIPTION
In this PR:
Enabled Intel GPU acceleration for the ai-ecg service by installing OpenVINO GPU drivers and updating Docker + inference configuration to use the GPU device.