### PR TITLE
[IRD] removed mraas and model registry references in docs

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/integrate-balluff-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/integrate-balluff-sdk.md
@@ -154,7 +154,7 @@ services:
     .
     network_mode: "host"
     # networks:
-    #   - mraas
+    #   - industrial-edge-vision
 ```
 
 Additionally, add the following entries to the `/etc/hosts` file on the host machine:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/integrate-pylon-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/integrate-pylon-sdk.md
@@ -139,7 +139,7 @@ services:
     .
     network_mode: "host"
     # networks:
-    #   - mraas
+    #   - industrial-edge-vision
 ```
 
 Additionally, add the following entries to the `/etc/hosts` file on the host machine:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/integrate-balluff-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/integrate-balluff-sdk.md
@@ -174,7 +174,7 @@ services:
     .
     network_mode: "host"
     # networks:
-    #   - mraas
+    #   - industrial-edge-vision
 ```
 
 Additionally, add the following entries to the `/etc/hosts` file on the host machine:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/integrate-pylon-sdk.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/integrate-pylon-sdk.md
@@ -160,7 +160,7 @@ services:
     .
     network_mode: "host"
     # networks:
-    #   - mraas
+    #   - industrial-edge-vision
 ```
 
 Additionally, add the following entries to the `/etc/hosts` file on the host machine:

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/tests/common_library/utils.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/tests/common_library/utils.py
@@ -389,7 +389,7 @@ class utils:
             print(docker_ps_output)
             lines = docker_ps_output.strip().split('\n')[1:]
             running_containers = []
-            project_containers = ['dlstreamer-pipeline-server', 'prometheus', 'coturn', 'model-registry', 'otel-collector', 'mediamtx-server', 'mraas_postgres', 'minio', 'industrial-edge-insights-vision_vol_minio_data', 'industrial-edge-insights-vision_mr_postgres_data', 'industrial-edge-insights-vision_vol_pipeline_root']
+            project_containers = ['dlstreamer-pipeline-server', 'prometheus', 'coturn', 'otel-collector', 'mediamtx-server', 'minio', 'industrial-edge-insights-vision_vol_minio_data', 'industrial-edge-insights-vision_vol_pipeline_root']
                 
             for line in lines:
                 if line.strip():


### PR DESCRIPTION
### Description

- Updated mraas to industrial-edge-vision in integrate-balluff-sdk.md and integrate-pylon-sdk.md docs
- Removed model-registry, mraas_postgres and industrial-edge-insights-vision_mr_postgres_data from utils.py

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

