### PR TITLE
Update dlstreamer-pipeline-server image tag to 2026.0.0-ubuntu24-rc1

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-captioning/compose.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/compose.yaml
@@ -23,7 +23,7 @@ services:
       - app_network
 
   dlstreamer-pipeline-server:
-    image: intel/dlstreamer-pipeline-server:2026.0.0-20260210-weekly-ubuntu24
+    image: intel/dlstreamer-pipeline-server:2026.0.0-ubuntu24-rc1
     hostname: dlstreamer-pipeline-server
     container_name: dlstreamer-pipeline-server
     read_only: false


### PR DESCRIPTION
### Description

Update dlstreamer-pipeline-server image tag to 2026.0.0-ubuntu24-rc1

Fixes # (issue)

N/A
### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.