### PR TITLE
fix(mqtt-broker): use conditional password file creation to prevent overwrite on restart

### DIFF
--- a/metro-ai-suite/smart-nvr/charts/subchart/mqtt-broker/templates/deployment.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/mqtt-broker/templates/deployment.yaml
@@ -90,8 +90,11 @@ spec:
             - sh
             - -c
             - |
-              touch {{ .Values.auth.passwordFilePath }} && \
-              mosquitto_passwd -c -b {{ .Values.auth.passwordFilePath }} $${MQTT_USER} $${MQTT_PASSWORD} && \
+              if [ ! -f {{ .Values.auth.passwordFilePath }} ]; then
+                mosquitto_passwd -c -b {{ .Values.auth.passwordFilePath }} $${MQTT_USER} $${MQTT_PASSWORD}
+              else
+                mosquitto_passwd -b {{ .Values.auth.passwordFilePath }} $${MQTT_USER} $${MQTT_PASSWORD}
+              fi && \
               chmod 0700 {{ .Values.auth.passwordFilePath }} && \
               chown {{ $runUser }}:{{ $runGroup }} {{ .Values.auth.passwordFilePath }} && \
               mosquitto -c /mosquitto/config/mosquitto.conf


### PR DESCRIPTION
### Description

Previously, the MQTT broker startup command used `touch` + `mosquitto_passwd -c` 
unconditionally, which always recreated and overwrote the password file on every 
container start.

Replace with an if/else check:
- If the password file does not exist, create it fresh with `-c`
- If it already exists, update only the specified user with `-b` (no `-c`), 
  preserving any other entries

This is a no-op change under the current `emptyDir` volume configuration, but 
makes the logic correct and safe if the auth volume is ever backed by a PVC.
Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

