### PR TITLE
[DOCS] Removed old metrices documentation from the README.

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-metrics-service/README.md
+++ b/metro-ai-suite/live-video-analysis/live-metrics-service/README.md
@@ -6,34 +6,6 @@ A reusable, containerized microservice for system metrics collection and real-ti
 
 The Metrics Service provides a decoupled solution for collecting, relaying, and visualizing system metrics in real-time. It acts as a WebSocket relay between metrics collectors (like Telegraf) and dashboard clients, enabling live visualization of CPU, memory, GPU, and other system metrics.
 
-## Quick Start
-
-### 1. Configure Environment Variables
-
-Copy the example environment file and customize as needed:
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` to configure:
-- `METRICS_PORT` - Service port (default: 9090)
-- `LOG_LEVEL` - Logging verbosity (default: INFO)
-- `CORS_ORIGINS` - CORS allowed origins (default: *)
-
-```bash
-export REGISTRY="intel/"
-export TAG="latest"
-docker compose up
-```
-
-### 2. Verify the Service
-
-```bash
-curl http://localhost:9090/health
-# Response: {"status": "healthy"}
-```
-
 ## Documentation
 
 Comprehensive documentation is available in the [user-guide](docs/user-guide/) directory:

--- a/metro-ai-suite/live-video-analysis/live-metrics-service/compose.yaml
+++ b/metro-ai-suite/live-video-analysis/live-metrics-service/compose.yaml
@@ -23,7 +23,6 @@ services:
       - CORS_ORIGINS=${CORS_ORIGINS:-*}
       # Optional: Configure target service polling
       - TARGET_SERVICE_URL=${TARGET_SERVICE_URL:-}
-      - METRICS_ENDPOINT=${METRICS_ENDPOINT:-/api/metrics/status}
       - POLL_INTERVAL_SECONDS=${POLL_INTERVAL_SECONDS:-2}
     ports:
       - "${METRICS_PORT:-9090}:9090"

--- a/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/api-reference.md
+++ b/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/api-reference.md
@@ -78,27 +78,7 @@ Detailed health with service status.
 {
   "status": "healthy",
   "collector_connected": true,
-  "clients_connected": 3,
-  "poller_active": false,
-  "poller_target": null
-}
-```
-
-### `GET /api/metrics/status`
-
-Full metrics collection status.
-
-**Response:**
-
-```json
-{
-  "collector_connected": true,
-  "clients_connected": 3,
-  "poller": {
-    "active": false,
-    "target": null,
-    "last_metrics": null
-  }
+  "clients_connected": 0
 }
 ```
 
@@ -117,35 +97,7 @@ Service information and available endpoints.
     "websocket_collector": "/ws/collector",
     "websocket_clients": "/ws/clients",
     "health": "/health",
-    "health_detailed": "/api/health",
-    "metrics_status": "/api/metrics/status"
+    "health_detailed": "/api/health"
   }
 }
-```
-
-## Configuration
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `METRICS_PORT` | `9090` | Port to run the service on |
-| `LOG_LEVEL` | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `CORS_ORIGINS` | `*` | Comma-separated list of allowed CORS origins |
-| `TARGET_SERVICE_URL` | `` | Optional: URL of service to poll for metrics |
-| `METRICS_ENDPOINT` | `/api/metrics/status` | Endpoint path on target service for polling |
-| `POLL_INTERVAL_SECONDS` | `2` | Polling interval in seconds |
-
-### Example Configuration
-
-```bash
-# Production settings
-export METRICS_PORT=9090
-export LOG_LEVEL=WARNING
-export CORS_ORIGINS=https://dashboard.example.com,https://admin.example.com
-
-# With optional polling enabled
-export TARGET_SERVICE_URL=http://my-app:8080
-export METRICS_ENDPOINT=/api/metrics
-export POLL_INTERVAL_SECONDS=2
 ```

--- a/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/known-issues.md
+++ b/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/known-issues.md
@@ -17,9 +17,8 @@
 **Symptom:** Client connects but receives no data.
 
 **Solutions:**
-1. Verify collector is connected: `curl http://localhost:9090/api/metrics/status`
-2. Check if Telegraf is actually sending data
-3. Ensure client is connected to `/ws/clients` (not `/ws/collector`)
+1. Check if Telegraf is actually sending data
+2. Ensure client is connected to `/ws/clients` (not `/ws/collector`)
 
 ### High Memory Usage
 
@@ -54,8 +53,6 @@ curl http://localhost:9090/health
 # Detailed status
 curl http://localhost:9090/api/health
 
-# Metrics status
-curl http://localhost:9090/api/metrics/status
 ```
 
 ## Limitations

--- a/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/live-video-analysis/live-metrics-service/docs/user-guide/release-notes.md
@@ -19,7 +19,6 @@
 - Single collector connection with policy enforcement
 - Multi-client broadcast support with unlimited connections
 - Health monitoring endpoints (`/health`, `/api/health`)
-- Metrics status endpoint (`/api/metrics/status`)
 - Configurable CORS support
 - Docker container with non-root user
 - Environment-based configuration


### PR DESCRIPTION
### Description

Removed old metrices documentation from the README.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested locally 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

