### PR TITLE
industrial-edge-insights-timeseries: Trivy file scan fix (#1867)

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
@@ -44,7 +44,7 @@ services:
 
   ia-influxdb:
     user: "${TIMESERIES_UID}:${TIMESERIES_UID}"
-    image: influxdb:1.11.8
+    image: influxdb:1.12.2
     container_name: ia-influxdb
     hostname: ia-influxdb
     restart: unless-stopped

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/broker.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/broker.yaml
@@ -37,6 +37,13 @@ spec:
       labels:
         app: ia-mqtt-broker
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: ia-mqtt-broker
         image: eclipse-mosquitto:2.0.22
@@ -44,6 +51,7 @@ spec:
         securityContext:
           runAsUser: {{ $.Values.env.TIMESERIES_UID }}
           runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+          runAsNonRoot: true
           readOnlyRootFilesystem: true 
           allowPrivilegeEscalation: false
           capabilities:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/coturn.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/coturn.yaml
@@ -49,6 +49,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: coturn
         image: coturn/coturn:4.8.0

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/dlstreamer-pipeline-server.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/dlstreamer-pipeline-server.yaml
@@ -39,6 +39,10 @@ spec:
         app: dlstreamer-pipeline-server
     spec:
       securityContext:
+        runAsNonRoot: true
+        runAsUser: 1999
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups: [109,110,992]  # render group IDs for ubuntu 20.04, 22.04 and 24.04 host OS
       {{- if and $.Values.DOCKER_USERNAME $.Values.DOCKER_PASSWORD }}
       imagePullSecrets:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/fusion-analytics.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/fusion-analytics.yaml
@@ -25,6 +25,13 @@ spec:
       imagePullSecrets:
       - name: registryauth
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: fusion-analytics
         image: {{ .Values.DOCKER_REGISTRY }}{{ .Values.images.fusion_analytics_image }}:{{ .Values.images.image_suffix | default "latest" }}{{ if .Values.images.weekly_build_date }}-{{ .Values.images.weekly_build_date }}-weekly{{ end }}
@@ -34,6 +41,7 @@ spec:
           runAsGroup: {{ .Values.env.TIMESERIES_UID }}
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop:
               - ALL

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/grafana.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/grafana.yaml
@@ -35,6 +35,13 @@ spec:
       labels:
         app: ia-grafana
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- if and $.Values.DOCKER_USERNAME $.Values.DOCKER_PASSWORD }}
       imagePullSecrets:
       - name: registryauth
@@ -44,6 +51,9 @@ spec:
         image: grafana/grafana-oss:12.3.3-ubuntu
         imagePullPolicy: {{ $.Values.imagePullPolicy }}
         securityContext:
+          runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+          runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/influxdb.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/influxdb.yaml
@@ -33,17 +33,25 @@ spec:
       labels:
         app: influxdb
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- if and .Values.DOCKER_USERNAME .Values.DOCKER_PASSWORD }}
       imagePullSecrets:
       - name: registryauth
       {{- end }}
       containers:
       - name: ia-influxdb
-        image: influxdb:1.11.8
+        image: influxdb:1.12.2
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
           runAsUser: {{ $.Values.env.TIMESERIES_UID }}
           runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           capabilities:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/mediamtx.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/mediamtx.yaml
@@ -57,6 +57,8 @@ spec:
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: mediamtx
         env:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/nginx.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/nginx.yaml
@@ -40,6 +40,12 @@ spec:
       labels:
         app: nginx
     spec:
+      securityContext:
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: nginx-proxy
         image: nginx:1.29.1-bookworm-perl
@@ -49,6 +55,7 @@ spec:
           runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
           capabilities:
             drop:
               - ALL

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-filer.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-filer.yaml
@@ -40,6 +40,9 @@ spec:
         fsGroup: {{ .Values.env.TIMESERIES_UID | int }}
         runAsUser: {{ .Values.env.TIMESERIES_UID | int }}
         runAsGroup: {{ .Values.env.TIMESERIES_UID | int }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: seaweedfs-filer
         image: {{ .Values.images.seaweedfs_image }}

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-master.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-master.yaml
@@ -40,6 +40,9 @@ spec:
         fsGroup: {{ .Values.env.TIMESERIES_UID | int }}
         runAsUser: {{ .Values.env.TIMESERIES_UID | int }}
         runAsGroup: {{ .Values.env.TIMESERIES_UID | int }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: seaweedfs-master
         image: {{ .Values.images.seaweedfs_image }}

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-s3.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-s3.yaml
@@ -38,6 +38,9 @@ spec:
         fsGroup: {{ .Values.env.TIMESERIES_UID | int }}
         runAsUser: {{ .Values.env.TIMESERIES_UID | int }}
         runAsGroup: {{ .Values.env.TIMESERIES_UID | int }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: seaweedfs-s3
         image: {{ .Values.images.seaweedfs_image }}

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-volume.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/seaweedfs-volume.yaml
@@ -40,6 +40,9 @@ spec:
         fsGroup: {{ .Values.env.TIMESERIES_UID | int }}
         runAsUser: {{ .Values.env.TIMESERIES_UID | int }}
         runAsGroup: {{ .Values.env.TIMESERIES_UID | int }}
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: seaweedfs-volume
         image: {{ .Values.images.seaweedfs_image }}

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/telegraf.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/telegraf.yaml
@@ -21,6 +21,13 @@ spec:
       labels:
         app: telegraf
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- if and .Values.DOCKER_USERNAME .Values.DOCKER_PASSWORD }}
       imagePullSecrets:
       - name: registryauth
@@ -34,6 +41,7 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
             drop:
               - ALL

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/time-series-analytics-microservice.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/time-series-analytics-microservice.yaml
@@ -41,6 +41,12 @@ spec:
       - name: registryauth
       {{- end }}
       securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups: [109,110,992]  # render group IDs for ubuntu 20.04, 22.04 and 24.04 host OS
       containers:
       - name: ia-time-series-analytics-microservice
@@ -54,6 +60,7 @@ spec:
           privileged: false
           allowPrivilegeEscalation: false
           {{- end }}
+          runAsNonRoot: true
           readOnlyRootFilesystem: true
           capabilities:
             drop:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/weld-data-simulator.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/helm/templates/weld-data-simulator.yaml
@@ -21,6 +21,13 @@ spec:
       labels:
         app: ia-weld-data-simulator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+        runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        fsGroup: {{ $.Values.env.TIMESERIES_UID }}
+        seccompProfile:
+          type: RuntimeDefault
       {{- if and .Values.DOCKER_USERNAME .Values.DOCKER_PASSWORD }}
       imagePullSecrets:
       - name: registryauth
@@ -30,8 +37,11 @@ spec:
         image: {{ .Values.DOCKER_REGISTRY }}{{ .Values.images.weld_data_simulator_image }}:{{ .Values.images.image_suffix | default "latest" }}{{ if .Values.images.weekly_build_date }}-{{ .Values.images.weekly_build_date }}-weekly{{ end }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
+          runAsUser: {{ $.Values.env.TIMESERIES_UID }}
+          runAsGroup: {{ $.Values.env.TIMESERIES_UID }}
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
           capabilities:
             drop:
               - ALL

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docker-compose.yml
@@ -45,7 +45,7 @@ services:
 
   ia-influxdb:
     user: "${TIMESERIES_UID}:${TIMESERIES_UID}"
-    image: influxdb:1.11.8
+    image: influxdb:1.12.2
     container_name: ia-influxdb
     hostname: ia-influxdb
     restart: unless-stopped

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/influxdb.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/helm/templates/influxdb.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
       - name: ia-influxdb
-        image: influxdb:1.11.8
+        image: influxdb:1.12.2
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         securityContext:
           runAsUser: {{ $.Values.env.TIMESERIES_UID }}

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/simulator/opcua-server/requirements.txt
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/simulator/opcua-server/requirements.txt
@@ -1,3 +1,3 @@
 pandas==2.2.3
 asyncua==1.1.5
-cryptography==44.0.1
+cryptography==46.0.5


### PR DESCRIPTION
### Description

- Updated cryptography package from 44.0.1 to 46.0.5 to address security vulnerabilities
- Updated influxdb image from 1.11.8 to 1.12.2 across docker-compose and Helm deployments
- Added comprehensive pod-level and container-level security contexts (runAsNonRoot, seccompProfile) to 11 Helm templates for compliance with security best practices

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

