### PR TITLE
Updated DLStreamer to rc3 tags

### DIFF
--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/get-started.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/get-started.md
@@ -76,7 +76,7 @@ docker run --rm -it --name dlstreamer \
   -v $PWD:/data \
   -e DISPLAY=$DISPLAY \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
-  intel/dlstreamer
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3
 ```
 
 ```bash

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-1.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-1.md
@@ -57,7 +57,7 @@ Download the YOLO11s model using the DL Streamer container:
 docker run --rm --user=root \
   -e http_proxy -e https_proxy -e no_proxy \
   -v "${PWD}:/home/dlstreamer/" \
-  intel/dlstreamer:2026.0.0-ubuntu24-rc1 \
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 \
   bash -c "export MODELS_PATH=/home/dlstreamer && /opt/intel/dlstreamer/samples/download_public_models.sh yolo11s"
 ```
 

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-2.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-2.md
@@ -254,7 +254,7 @@ docker run -it --rm --net=host \
   -v $HOME/.Xauthority:/home/dlstreamer/.Xauthority:ro \
   -v $PWD/videos:/home/dlstreamer/videos:ro \
   -v $PWD/decode.sh:/home/dlstreamer/decode.sh:ro \
-  intel/dlstreamer:2025.1.2-ubuntu24 \
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 \
   /home/dlstreamer/decode.sh
 ```
 

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-3.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-3.md
@@ -79,7 +79,7 @@ Download the YOLOv10s object detection model and convert it to OpenVINO format:
 docker run --rm --user=root \
   -e http_proxy -e https_proxy -e no_proxy \
   -v "${PWD}:/home/dlstreamer/" \
-  intel/dlstreamer:2026.0.0-ubuntu24-rc1 \
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 \
   bash -c "export MODELS_PATH=/home/dlstreamer && /opt/intel/dlstreamer/samples/download_public_models.sh yolov10s"
 ```
 

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-4.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-4.md
@@ -116,7 +116,7 @@ docker run -it --rm --net=host \
   -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
   -v ${PWD}:/home/dlstreamer/data \
   -v $HOME/.Xauthority:/home/dlstreamer/.Xauthority:ro \
-  intel/dlstreamer:2026.0.0-ubuntu24-rc1 \
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 \
   bash -c "export MODELS_PATH=/home/dlstreamer/data/models && \
            /opt/intel/dlstreamer/samples/gstreamer/gst_launch/human_pose_estimation/human_pose_estimation.sh \
            /home/dlstreamer/data/face-demographics-walking.mp4"

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-5.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/metro-vision-ai-sdk/tutorial-5.md
@@ -56,7 +56,7 @@ wget -O bottle-detection.mp4 https://storage.openvinotoolkit.org/test_data/video
 docker run --rm --user=root \
   -e http_proxy -e https_proxy -e no_proxy \
   -v "${PWD}:/home/dlstreamer/" \
-  intel/dlstreamer:2026.0.0-ubuntu24-rc1 \
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 \
   bash -c "export MODELS_PATH=/home/dlstreamer && /opt/intel/dlstreamer/samples/download_public_models.sh yolov10s"
 
 # Create a continuous DL Streamer pipeline script
@@ -103,7 +103,7 @@ while true; do
         --env no_proxy=$no_proxy \
         --user root \
         -w /workspace \
-        intel/dlstreamer:2026.0.0-ubuntu24-rc1  \
+        intel/dlstreamer:2026.0.0-ubuntu24-rc3  \
         gst-launch-1.0 \
             filesrc location=/workspace/bottle-detection.mp4 ! \
             qtdemux ! h264parse ! avdec_h264 ! \

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/visual-ai-demo-kit/tutorial-1.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/visual-ai-demo-kit/tutorial-1.md
@@ -85,7 +85,7 @@ Create and run the model download script to install all required AI models:
 docker run --rm --user=root \
   -e http_proxy -e https_proxy -e no_proxy \
   -v "$PWD:/home/dlstreamer/metro-suite" \
-  intel/dlstreamer:2026.0.0-ubuntu24-rc1 bash -c "$(cat <<EOF
+  intel/dlstreamer:2026.0.0-ubuntu24-rc3 bash -c "$(cat <<EOF
 
 cd /home/dlstreamer/metro-suite/
 

--- a/metro-ai-suite/metro-sdk-manager/scripts/metro-vision-ai-sdk.sh
+++ b/metro-ai-suite/metro-sdk-manager/scripts/metro-vision-ai-sdk.sh
@@ -25,8 +25,8 @@ repositories=(
 images=(
   "openvino/model_server:2026.0"
   "openvino/ubuntu24_dev:2026.0.0"
-  "intel/dlstreamer:2026.0.0-ubuntu24-rc1"
-  "intel/dlstreamer-pipeline-server:2026.0.0-extended-ubuntu24-rc1"
+  "intel/dlstreamer:2026.0.0-ubuntu24-rc3"
+  "intel/dlstreamer-pipeline-server:2026.0.0-extended-ubuntu24-rc3"
 )
 
 NAME="Metro Vision AI SDK"

--- a/metro-ai-suite/metro-sdk-manager/scripts/visual-ai-demo-kit.sh
+++ b/metro-ai-suite/metro-sdk-manager/scripts/visual-ai-demo-kit.sh
@@ -23,7 +23,7 @@ repositories=(
 
 images=(
   eclipse-mosquitto:2.0.21
-  intel/dlstreamer-pipeline-server:2026.0.0-extended-ubuntu24-rc1
+  intel/dlstreamer-pipeline-server:2026.0.0-extended-ubuntu24-rc3
   bluenviron/mediamtx:1.11.3
   coturn/coturn:4.7
   grafana/grafana:11.5.4


### PR DESCRIPTION
### Description

This pull request updates all references to the DL Streamer and DL Streamer Pipeline Server Docker images throughout documentation and scripts to use the latest `2026.0.0-ubuntu24-rc3` and `2026.0.0-extended-ubuntu24-rc3` tags, replacing previous release candidate tags. 

Fixes # (issue)
N/A

### Any Newly Introduced Dependencies
No

### How Has This Been Tested?
Manual Testing 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

