### PR TITLE
README fix 

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/README.md
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/README.md
@@ -60,7 +60,9 @@ Healthy services will show:
 
 
 ## Access the Frontend UI
-Check Ingress resource:
+### 1. Check the Ingress Resource
+
+Run the following command to view the ingress configuration:
 
 ```bash
 kubectl get ingress -n multi-modal-patient-monitoring
@@ -72,13 +74,34 @@ Example output:
 NAME       HOSTS               PATHS   ADDRESS         PORTS
 multi-modal-patient-monitoring  multi-modal-patient-monitoring.local       /       xx.xx.xx.xx   80
 ```
+### 2. If an IP Address Appears in ADDRESS
 
-Add an entry on your Linux host (replace <IP> with the one you found):
+Add the hostname mapping to your local machine:
 ```bash
 echo "<IP> multi-modal-patient-monitoring.local" | sudo tee -a /etc/hosts
 ```
+Replace <IP> with the value shown in the ADDRESS column.
 
-Open your browser and go to:
+### 3. If the ADDRESS Field is Empty (Common in Minikube)
+Some local Kubernetes environments (such as Minikube) do not automatically populate the ingress IP.
+
+Retrieve the Minikube cluster IP:
+```bash
+minikube ip
+```
+Then map the hostname to the IP:
+```bash
+echo "$(minikube ip) multi-modal-patient-monitoring.local" | sudo tee -a /etc/hosts
+```
+
+### 4. Enable Ingress in Minikube (if not already enabled)
+```bash
+minikube addons enable ingress
+```
+Wait a few moments for the ingress controller to start.
+
+### 5.Open the Application
+Open your browser and navigate to:
 ```bash
 http://<host-or-ip>/
 ``` 
@@ -86,10 +109,7 @@ Example:
 ```bash
 http://multi-modal-patient-monitoring.local/
 ``` 
-If using Minikube, you may need to enable the ingress addon:
-```bash
-minikube addons enable ingress
-``` 
+
 This will open the Health AI Suite frontend dashboard.
 
 From here you can access:

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/ai-ecg-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/ai-ecg-deployment.yaml
@@ -12,6 +12,20 @@ spec:
       labels:
         app: ai-ecg
     spec:
+      initContainers:
+        - name: wait-for-ecg-model
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - >-
+              until [ -f /models/ai-ecg/hubert_ecg_small_fp16.xml ]; do
+                echo "Waiting for HuBERT-ECG model asset...";
+                sleep 5;
+              done
+          volumeMounts:
+            - name: models
+              mountPath: /models
       containers:
         - name: ai-ecg
           image: "{{ .Values.aiEcg.image.repository }}/{{ .Values.aiEcg.image.name }}:{{ .Values.aiEcg.image.tag }}"
@@ -21,6 +35,25 @@ spec:
           envFrom:
             - configMapRef:
                 name: device-config
+          startupProbe:
+            tcpSocket:
+              port: 8000
+            periodSeconds: 5
+            failureThreshold: 24
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            failureThreshold: 3
           ports:
             - containerPort: 8000
           volumeMounts:


### PR DESCRIPTION
In this PR:

Updated documentation to include instructions for retrieving the ingress IP when the ADDRESS field is empty (common in Minikube/local Kubernetes environments).