### PR TITLE
industrial-edge-insights-multimodal: Added 172.30.x subnet in docker compose

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
@@ -541,8 +541,8 @@ networks:
     ipam:
       driver: default
       config:
-       - subnet: 172.30.0.0/24
-         gateway: 172.30.0.1
+        - subnet: 172.30.0.0/24
+          gateway: 172.30.0.1
 
 volumes:
   vol_influxdb_conf:

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/troubleshooting.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/troubleshooting.md
@@ -122,7 +122,7 @@ PID=$(docker inspect --format '.State.Pid' ia-mqtt-broker)
 sudo nsenter -t "$PID" -m -u -i -n -p mosquitto_sub -h localhost -v -t alerts/wind_turbine -p 1883
 ```
 
-## 6. Docker Network Subnet Conflict -- `make up` Fails with "Pool overlaps with other one on this address space"
+## 5. Docker Network Subnet Conflict -- `make up` Fails with "Pool overlaps with other one on this address space"
 
 **Issue**
 
@@ -171,6 +171,4 @@ The subnet configured for the Docker network (in `docker-compose.yml`) is alread
              gateway: 172.29.0.1
    ```
 
-4. Run `make up` again.
-
-> **Note:** All subnets in the `172.16.0.0/12` range are covered by the standard `no_proxy=172.16.0.0/12` setting, so proxy bypass will continue to work regardless of which block you choose within this range.
+4. Run `make up` again from `edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-multimodal` directory.


### PR DESCRIPTION

### Description

Changes:
 1.docker-compose.yml - Added 172.30.x.x subnet
 2.troubleshooting.md - Added step to change subnet if it overlaps with existing network.

Fixes # (issue)

### Any Newly Introduced Dependencies

no

### How Has This Been Tested?

yes

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

