### PR TITLE
[Release] [STIA] Removed resource constraints from helm template

### DIFF
--- a/metro-ai-suite/smart-traffic-intersection-agent/chart/values.yaml
+++ b/metro-ai-suite/smart-traffic-intersection-agent/chart/values.yaml
@@ -61,12 +61,6 @@ trafficAgent:
     timeoutSeconds: 10
     failureThreshold: 3
   resources:
-    limits:
-      cpu: "2"
-      memory: "2Gi"
-    requests:
-      cpu: "500m"
-      memory: "512Mi"
   # Volume for persistent agent data
   persistence:
     enabled: true
@@ -129,12 +123,8 @@ vlmServing:
     timeoutSeconds: 10
     failureThreshold: 180
   resources:
-    limits:
-      cpu: "32"
-      memory: "32Gi"
     requests:
-      cpu: "16"
-      memory: "16Gi"
+      memory: "12Gi"
   # Volume for model cache
   persistence:
     enabled: true


### PR DESCRIPTION
### Description

1. Removed CPU and memory resource constraints from Helm charts for traffic-agent.
2. Decreased min memory limit for vlm-openvino-serving chart a little bit and removed CPU constraints. 

Fixes # (issue)

Fixes the issue of charts failing to install on nodes with less than or equal to 16 cores and less than or equal to 16GB of memory.

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Verified end to end by installing the chart on nodes having less compute and memory.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

