### PR TITLE
[Docs][Embodied] Setup Scripts

### DIFF
--- a/robotics-ai-suite/docs/embodied/installation_setup/installation/rt_linux.rst
+++ b/robotics-ai-suite/docs/embodied/installation_setup/installation/rt_linux.rst
@@ -5,8 +5,49 @@ Real-Time Linux
 
 The Embodied Intelligence SDK provides real-time capabilities to the kernel with PREEMPT_RT patch and boot parameters for real-time optimization, which aims to increase predictability and reduce scheduler latencies.
 
-Installation
-================
+Automated Installation
+=======================
+
+.. _rt_linux_automated_setup:
+
+You can automate the software setup flow on this page with:
+
+`rt_linux_setup.sh <https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.0.0/robotics-ai-suite/docs/embodied/installation_setup/installation/rt_linux_setup.sh>`_
+
+Default real-time kernel setup (includes OS setup prerequisites):
+
+.. code-block:: bash
+
+  sudo ./rt_linux_setup.sh
+
+Skip OS setup prerequisites (run RT setup steps only):
+
+.. code-block:: bash
+
+  sudo ./rt_linux_setup.sh --skip-os-setup
+
+Real-time setup with GRUB tuning and runtime options:
+
+.. code-block:: bash
+
+  sudo ./rt_linux_setup.sh --apply-rt-grub-tuning --disable-timer-migration --disable-swap --disable-cstate-cpus 13-13
+
+For all available options:
+
+.. code-block:: bash
+
+  ./rt_linux_setup.sh --help
+
+When using the automated script, it logs which sections from this page are skipped for the selected options.
+
+The following three sections are always skipped because they require manual, platform-specific actions:
+
+- ``Select [Experimental] ECI Ubuntu`` boot entry after reboot
+- ``Use Cache Allocation Technology``
+- ``Use Dynamic Voltage and Frequency``
+
+Manual Installation
+====================
 
 1. Install GRUB customizations
 

--- a/robotics-ai-suite/docs/embodied/installation_setup/installation/rt_linux_setup.sh
+++ b/robotics-ai-suite/docs/embodied/installation_setup/installation/rt_linux_setup.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OS_SETUP_SCRIPT="${SCRIPT_DIR}/../prerequisites/os_setup_install.sh"
+
+KERNEL_FLAVOR="rt"
+RUN_OS_SETUP=true
+OS_SET_DATE=""
+OS_DISABLE_AUTO_UPGRADES=false
+OS_FIX_RAW_GITHUB_HOST=false
+APPLY_RT_GRUB_TUNING=false
+INSTALL_RT_TESTS=false
+DISABLE_TIMER_MIGRATION=false
+DISABLE_SWAP=false
+CSTATE_CPU_RANGE=""
+
+print_usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [options]
+
+Automates the setup flow in docs/embodied/installation_setup/installation/rt_linux.rst
+and linked prerequisites/docs references, including invoking os_setup_install.sh.
+
+Options:
+  --skip-os-setup                  Skip calling os_setup_install.sh
+  --os-set-date "YYYY-MM-DD HH:MM" Pass date setting to os_setup_install.sh
+  --os-disable-auto-upgrades       Pass auto-upgrade disable to os_setup_install.sh
+  --os-fix-raw-github-host         Pass DNS workaround to os_setup_install.sh
+
+  --kernel rt|generic              Kernel flavor to install (default: rt)
+  --apply-rt-grub-tuning           Apply grub sed tuning from rt_linux.rst and run update-grub
+
+  --disable-timer-migration        Set /proc/sys/kernel/timer_migration to 0
+  --disable-swap                   Run swapoff -a
+  --disable-cstate-cpus START-END  Disable cpuidle states (state1..max) for CPU range
+
+  --install-rt-tests               Install deps and build rt-tests-2.6 (cyclictest)
+  -h, --help                       Show this help
+
+Notes:
+  - Requires Ubuntu with sudo/root privileges.
+  - Reboot and selecting the target grub entry are manual steps.
+  - CAT/DVFS MSR examples in the guide are platform-specific and not auto-applied.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-os-setup)
+      RUN_OS_SETUP=false
+      ;;
+    --os-set-date)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing value for --os-set-date" >&2; exit 1; }
+      OS_SET_DATE="$1"
+      ;;
+    --os-disable-auto-upgrades)
+      OS_DISABLE_AUTO_UPGRADES=true
+      ;;
+    --os-fix-raw-github-host)
+      OS_FIX_RAW_GITHUB_HOST=true
+      ;;
+    --kernel)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing value for --kernel" >&2; exit 1; }
+      KERNEL_FLAVOR="$1"
+      ;;
+    --apply-rt-grub-tuning)
+      APPLY_RT_GRUB_TUNING=true
+      ;;
+    --install-rt-tests)
+      INSTALL_RT_TESTS=true
+      ;;
+    --disable-timer-migration)
+      DISABLE_TIMER_MIGRATION=true
+      ;;
+    --disable-swap)
+      DISABLE_SWAP=true
+      ;;
+    --disable-cstate-cpus)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing value for --disable-cstate-cpus" >&2; exit 1; }
+      CSTATE_CPU_RANGE="$1"
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case "$KERNEL_FLAVOR" in
+  rt|generic)
+    ;;
+  *)
+    echo "Invalid --kernel value: $KERNEL_FLAVOR (must be rt or generic)" >&2
+    exit 1
+    ;;
+esac
+
+log() {
+  echo "[rt-linux-setup] $*"
+}
+
+log_skipped_section() {
+  log "Skipped section: $1"
+}
+
+run_sudo() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Required command not found: $1" >&2
+    exit 1
+  }
+}
+
+log "Selected flow: kernel=${KERNEL_FLAVOR}, run-os-setup=${RUN_OS_SETUP}, apply-rt-grub-tuning=${APPLY_RT_GRUB_TUNING}, disable-timer-migration=${DISABLE_TIMER_MIGRATION}, disable-swap=${DISABLE_SWAP}, disable-cstate-cpus=${CSTATE_CPU_RANGE:-none}, install-rt-tests=${INSTALL_RT_TESTS}"
+
+# Log sections from rt_linux.rst that are intentionally skipped in this run.
+[[ "$RUN_OS_SETUP" == false ]] && log_skipped_section "Prerequisites OS setup script invocation"
+[[ "$KERNEL_FLAVOR" != "rt" ]] && log_skipped_section "Install the real-time Linux kernel (linux-intel-rt-experimental)"
+[[ "$KERNEL_FLAVOR" != "generic" ]] && log_skipped_section "Install generic kernel alternative (linux-intel-experimental note)"
+[[ "$APPLY_RT_GRUB_TUNING" == false ]] && log_skipped_section "GRUB cmdline tuning edits in /etc/grub.d/10_eci_experimental"
+[[ "$DISABLE_TIMER_MIGRATION" == false ]] && log_skipped_section "Timer Migration Disable runtime tuning"
+[[ "$DISABLE_SWAP" == false ]] && log_skipped_section "Disable Swap runtime tuning"
+[[ -z "$CSTATE_CPU_RANGE" ]] && log_skipped_section "Per-core C-State Disable runtime tuning"
+[[ "$INSTALL_RT_TESTS" == false ]] && log_skipped_section "Verify Benchmark Performance helper (rt-tests download/build)"
+log_skipped_section "Select [Experimental] ECI Ubuntu boot entry after reboot (manual)"
+log_skipped_section "Use Cache Allocation Technology example (manual/platform specific)"
+log_skipped_section "Use Dynamic Voltage and Frequency example (manual/platform specific)"
+
+if [[ "$RUN_OS_SETUP" == true ]]; then
+  if [[ ! -x "$OS_SETUP_SCRIPT" ]]; then
+    echo "Cannot execute OS setup script: $OS_SETUP_SCRIPT" >&2
+    exit 1
+  fi
+
+  log "Running prerequisite OS setup script"
+  os_args=()
+  [[ -n "$OS_SET_DATE" ]] && os_args+=(--set-date "$OS_SET_DATE")
+  [[ "$OS_DISABLE_AUTO_UPGRADES" == true ]] && os_args+=(--disable-auto-upgrades)
+  [[ "$OS_FIX_RAW_GITHUB_HOST" == true ]] && os_args+=(--fix-raw-github-host)
+  "$OS_SETUP_SCRIPT" "${os_args[@]}"
+else
+  log "Skipping OS setup script (--skip-os-setup)"
+fi
+
+require_cmd apt
+require_cmd dpkg
+
+log "Installing GRUB customizations and linux-firmware"
+run_sudo apt update
+run_sudo apt install -y customizations-grub linux-firmware
+
+if [[ -d /lib/firmware/i915/experimental ]]; then
+  if ls /lib/firmware/i915/experimental/mtl_{guc_70.bin,dmc.bin,gsc_1.bin} >/dev/null 2>&1; then
+    log "Detected expected i915 experimental firmware files"
+  else
+    log "Warning: i915 experimental firmware files not fully found in /lib/firmware/i915/experimental/"
+    log "If needed, install the firmware version documented in rt_linux.rst"
+  fi
+else
+  log "Warning: /lib/firmware/i915/experimental/ not found"
+fi
+
+if [[ "$KERNEL_FLAVOR" == "rt" ]]; then
+  log "Installing real-time kernel package: linux-intel-rt-experimental"
+  run_sudo apt install -y linux-intel-rt-experimental
+else
+  log "Installing generic kernel package: linux-intel-experimental"
+  run_sudo apt install -y linux-intel-experimental
+fi
+
+if [[ "$APPLY_RT_GRUB_TUNING" == true ]]; then
+  GRUB_FILE="/etc/grub.d/10_eci_experimental"
+  if [[ -f "$GRUB_FILE" ]]; then
+    log "Applying rt_linux.rst GRUB tuning to ${GRUB_FILE}"
+    run_sudo sed -i 's/intel_pstate=disable intel.max_cstate=0 intel_idle.max_cstate=0 processor.max_cstate=0 processor_idle.max_cstate=0/intel_pstate=enable/g' "$GRUB_FILE"
+    run_sudo sed -i 's/irqaffinity=0 /irqaffinity=0-9 /g' "$GRUB_FILE"
+    run_sudo sed -i 's/isolcpus=${isolcpus} rcu_nocbs=${isolcpus} nohz_full=${isolcpus}/isolcpus=10-13 rcu_nocbs=10-13 nohz_full=10-13/g' "$GRUB_FILE"
+    run_sudo update-grub
+  else
+    log "Warning: ${GRUB_FILE} not found; skipping GRUB tuning"
+  fi
+fi
+
+if [[ "$DISABLE_TIMER_MIGRATION" == true ]]; then
+  log "Disabling timer migration"
+  run_sudo sh -c 'echo 0 > /proc/sys/kernel/timer_migration'
+fi
+
+if [[ "$DISABLE_SWAP" == true ]]; then
+  log "Disabling swap"
+  run_sudo swapoff -a
+fi
+
+if [[ -n "$CSTATE_CPU_RANGE" ]]; then
+  if [[ "$CSTATE_CPU_RANGE" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+    cpu_start="${BASH_REMATCH[1]}"
+    cpu_end="${BASH_REMATCH[2]}"
+  else
+    echo "Invalid --disable-cstate-cpus value: $CSTATE_CPU_RANGE (expected START-END)" >&2
+    exit 1
+  fi
+
+  log "Disabling per-core C-states for CPUs ${cpu_start}-${cpu_end}"
+  for ((cpu=cpu_start; cpu<=cpu_end; cpu++)); do
+    cpuidle_dir="/sys/devices/system/cpu/cpu${cpu}/cpuidle"
+    if [[ ! -d "$cpuidle_dir" ]]; then
+      log "Warning: ${cpuidle_dir} not found; skipping CPU ${cpu}"
+      continue
+    fi
+
+    max_state_index="$(ls "$cpuidle_dir" | grep -o 'state[0-9]*' | sed 's/state//' | sort -n | tail -1 || true)"
+    if [[ -z "$max_state_index" ]]; then
+      log "Warning: no cpuidle states found for CPU ${cpu}"
+      continue
+    fi
+
+    for ((state=1; state<=max_state_index; state++)); do
+      disable_file="${cpuidle_dir}/state${state}/disable"
+      if [[ -f "$disable_file" ]]; then
+        run_sudo sh -c "echo 1 > '$disable_file'"
+      fi
+    done
+  done
+fi
+
+if [[ "$INSTALL_RT_TESTS" == true ]]; then
+  log "Installing cyclictest build dependency"
+  run_sudo apt install -y libnuma-dev
+
+  work_dir="${PWD}/rt-tests-2.6"
+  tarball="${PWD}/rt-tests-2.6.tar.gz"
+  if [[ ! -d "$work_dir" ]]; then
+    log "Downloading and building rt-tests-2.6"
+    require_cmd wget
+    require_cmd tar
+    require_cmd make
+    wget -O "$tarball" https://web.git.kernel.org/pub/scm/utils/rt-tests/rt-tests.git/snapshot/rt-tests-2.6.tar.gz
+    tar zxvf "$tarball"
+    (cd "$work_dir" && make)
+  else
+    log "Found existing ${work_dir}; skipping download/build"
+  fi
+fi
+
+log "Setup complete. Reboot and select [Experimental] ECI Ubuntu entry in GRUB."
+log "After reboot, verify with: uname -r && cat /proc/cmdline"

--- a/robotics-ai-suite/docs/embodied/installation_setup/prerequisites/os_setup.rst
+++ b/robotics-ai-suite/docs/embodied/installation_setup/prerequisites/os_setup.rst
@@ -23,6 +23,41 @@ Do the following to prepare the target system:
 
    .. include:: bios-generic.rst
 
+Automated Setup Script
+-----------------------
+
+You can automate the software setup flow on this page with:
+
+`os_setup_install.sh <https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.0.0/robotics-ai-suite/docs/embodied/installation_setup/prerequisites/os_setup_install.sh>`_
+
+Default OS setup automation (locale + APT repositories):
+
+.. code-block:: bash
+
+   sudo ./os_setup_install.sh
+
+Set date/time during setup:
+
+.. code-block:: bash
+
+   sudo ./os_setup_install.sh --set-date "2026-03-17 12:00"
+
+Enable additional options:
+
+.. code-block:: bash
+
+   sudo ./os_setup_install.sh --disable-auto-upgrades --fix-raw-github-host
+
+For all available options:
+
+.. code-block:: bash
+
+   ./os_setup_install.sh --help
+
+This script only automates software configuration. Ubuntu installation and BIOS setup remain manual.
+
+If you prefer, you can skip this script and run the real-time setup script directly from :ref:`Real-Time Linux automated setup <rt_linux_automated_setup>`.
+
 Set locale
 -----------
 

--- a/robotics-ai-suite/docs/embodied/installation_setup/prerequisites/os_setup_install.sh
+++ b/robotics-ai-suite/docs/embodied/installation_setup/prerequisites/os_setup_install.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+print_usage() {
+  cat <<EOF
+Usage: $SCRIPT_NAME [options]
+
+Automates the software steps from docs/embodied/installation_setup/prerequisites/os_setup.rst
+and its included pages (locale + APT repositories).
+
+Options:
+  --set-date "YYYY-MM-DD HH:MM"   Set system date/time via: date -s
+  --disable-auto-upgrades          Disable Ubuntu auto-upgrade settings
+  --fix-raw-github-host            Add 185.199.108.133 raw.githubusercontent.com to /etc/hosts
+  -h, --help                       Show this help message
+
+Notes:
+  - Ubuntu installation and BIOS setup are manual and cannot be automated by script.
+  - Script is designed for Ubuntu 22.04 Desktop and requires sudo/root.
+EOF
+}
+
+SET_DATE=""
+DISABLE_AUTO_UPGRADES=false
+FIX_RAW_GITHUB_HOST=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --set-date)
+      shift
+      [[ $# -gt 0 ]] || { echo "Missing value for --set-date" >&2; exit 1; }
+      SET_DATE="$1"
+      ;;
+    --disable-auto-upgrades)
+      DISABLE_AUTO_UPGRADES=true
+      ;;
+    --fix-raw-github-host)
+      FIX_RAW_GITHUB_HOST=true
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      print_usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+log() {
+  echo "[os-setup] $*"
+}
+
+run_sudo() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Required command not found: $1" >&2
+    exit 1
+  }
+}
+
+log "Manual prerequisites from guide:"
+log "1) Install Ubuntu 22.04 Desktop (64-bit)"
+log "2) Configure BIOS according to bios-generic.rst"
+
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  source /etc/os-release
+  if [[ "${ID:-}" != "ubuntu" || "${VERSION_ID:-}" != "22.04" ]]; then
+    log "Warning: detected ${PRETTY_NAME:-unknown}. Guide targets Ubuntu 22.04 Desktop."
+  else
+    log "Detected supported OS: ${PRETTY_NAME}"
+  fi
+fi
+
+require_cmd apt
+require_cmd dpkg
+require_cmd tee
+
+log "Setting locale prerequisites"
+run_sudo apt update
+run_sudo apt install -y locales wget software-properties-common curl gnupg
+run_sudo locale-gen en_US en_US.UTF-8
+run_sudo update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+if [[ -n "$SET_DATE" ]]; then
+  log "Setting date/time to: $SET_DATE"
+  run_sudo date -s "$SET_DATE"
+else
+  log "Current date/time: $(date)"
+  log "Skip setting date/time (use --set-date to configure it)"
+fi
+
+log "Configuring Intel ECI APT repository key"
+run_sudo mkdir -p /usr/share/keyrings
+run_sudo wget -O- https://eci.intel.com/repos/gpg-keys/GPG-PUB-KEY-INTEL-ECI.gpg | run_sudo tee /usr/share/keyrings/eci-archive-keyring.gpg >/dev/null
+
+log "Configuring Intel ECI APT repository list"
+ECI_CODENAME="$(source /etc/os-release && echo "$VERSION_CODENAME")"
+run_sudo tee /etc/apt/sources.list.d/eci.list >/dev/null <<EOF
+deb [signed-by=/usr/share/keyrings/eci-archive-keyring.gpg] https://eci.intel.com/repos/${ECI_CODENAME} isar main
+deb-src [signed-by=/usr/share/keyrings/eci-archive-keyring.gpg] https://eci.intel.com/repos/${ECI_CODENAME} isar main
+EOF
+
+if [[ "$DISABLE_AUTO_UPGRADES" == true ]]; then
+  log "Disabling auto-upgrades in /etc/apt/apt.conf.d/20auto-upgrades"
+  run_sudo sed -i 's/APT::Periodic::Update-Package-Lists "1"/APT::Periodic::Update-Package-Lists "0"/g' /etc/apt/apt.conf.d/20auto-upgrades || true
+  run_sudo sed -i 's/APT::Periodic::Unattended-Upgrade "1"/APT::Unattended-Upgrade "0"/g' /etc/apt/apt.conf.d/20auto-upgrades || true
+fi
+
+log "Configuring APT pin priorities"
+run_sudo tee /etc/apt/preferences.d/isar >/dev/null <<'EOF'
+Package: *
+Pin: origin eci.intel.com
+Pin-Priority: 1000
+
+Package: libze-intel-gpu1,libze1,intel-opencl-icd,libze-dev,intel-ocloc
+Pin: origin repositories.intel.com/gpu/ubuntu
+Pin-Priority: 1000
+EOF
+
+log "Enabling Ubuntu universe repository"
+run_sudo add-apt-repository -y universe
+
+log "Installing ROS 2 key"
+run_sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+if [[ "$FIX_RAW_GITHUB_HOST" == true ]]; then
+  log "Applying raw.githubusercontent.com hosts workaround"
+  if ! grep -qE '^[[:space:]]*185\.199\.108\.133[[:space:]]+raw\.githubusercontent\.com([[:space:]]|$)' /etc/hosts; then
+    echo '185.199.108.133 raw.githubusercontent.com' | run_sudo tee -a /etc/hosts >/dev/null
+  fi
+fi
+
+log "Configuring ROS 2 APT repository list"
+ROS_CODENAME="$(. /etc/os-release && echo "$UBUNTU_CODENAME")"
+ARCH="$(dpkg --print-architecture)"
+run_sudo tee /etc/apt/sources.list.d/ros2.list >/dev/null <<EOF
+deb [arch=${ARCH} signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu ${ROS_CODENAME} main
+EOF
+
+log "Refreshing apt package indexes"
+run_sudo apt update
+
+log "Locale after setup:"
+locale || true
+
+log "OS setup script completed"


### PR DESCRIPTION
### Description

Added 2 scripts: 1 for OS Setup page (Embodied Installation and Setup) and 1 for RT Linux page (Embodied Installation and Setup) . Updates to docs on how to use the scripts included.

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

Tested each script on Intel network:
sudo ./rt_linux_setup.sh --apply-rt-grub-tuning --disable-timer-migration --disable-swap --disable-cstate-cpus 13-13

./os_setup_install.sh --help # list all parameters
./rt_linux_setup.sh --help # list all parameters

The rt_linux_setup script invokes os_setup_install.sh unless --skip-os-setup is passed as parameter.


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

