### PR TITLE
DOCS metro vision app recipe link fix 26.0

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/index.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/index.md
@@ -71,6 +71,5 @@ tutorial-1.md
 tutorial-2.md
 tutorial-3.md
 tutorial-4.md
-support.md
 :::
 hide_directive-->

--- a/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/support.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/support.md
@@ -1,8 +1,0 @@
-# Get Help
-
-This page provides troubleshooting steps, FAQs, and resources to help you resolve common issues.
-
-## Support
-- **Developer Forum**: [Join the community forum](#)
-- **Raise an Issue on GitHub**: [GitHub Issues](https://github.com/open-edge-platform/edge-ai-suites/issues)
-- **Contact Support**: [Support Page](#)


### PR DESCRIPTION
### Description

the "get help" page is broken and empty, removing for clarity.
port: https://github.com/open-edge-platform/edge-ai-suites/pull/2317