### PR TITLE
Update release tags for LVS 1.0.0 and smart-nvr 1.2.4 from -rc1 to final release versions across documentation and Helm charts

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started.md
+++ b/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started.md
@@ -37,7 +37,7 @@ Before running the application, you need to set several environment variables:
 
     ```bash
     export REGISTRY_URL=intel
-    export TAG=1.0.0-rc1
+    export TAG=1.0.0
     ```
 
     In most cases, `TAG=latest` works out of the box. Set a specific tag only when you need to pin to a particular release/version.
@@ -51,16 +51,16 @@ Before running the application, you need to set several environment variables:
     Use stack-specific tag overrides when you need different image versions for each stack:
 
      ```bash
-     export TAG=1.0.0-rc1
-     export VSS_STACK_TAG=1.3.2-rc1
-     export SMART_NVR_STACK_TAG=1.2.4-rc1
+     export TAG=1.0.0
+     export VSS_STACK_TAG=1.3.2
+     export SMART_NVR_STACK_TAG=1.2.4
      ```
 
     Why this is needed: a single shared `TAG` forces both stacks to use the same version, which does not match independent VSS and Smart NVR release cycles.
 
-    Note: `setup.sh` includes a release mapping for `TAG=1.0.0-rc1` and automatically sets:
-    - `VSS_STACK_TAG=1.3.2-rc1`
-    - `SMART_NVR_STACK_TAG=1.2.4-rc1`
+    Note: `setup.sh` includes a release mapping for `TAG=1.0.0` and automatically sets:
+    - `VSS_STACK_TAG=1.3.2`
+    - `SMART_NVR_STACK_TAG=1.2.4`
 
     You can still explicitly export `VSS_STACK_TAG` and `SMART_NVR_STACK_TAG` to override those defaults.
 

--- a/metro-ai-suite/live-video-analysis/live-video-search/setup.sh
+++ b/metro-ai-suite/live-video-analysis/live-video-search/setup.sh
@@ -109,13 +109,13 @@ export TAG=${TAG:-latest}
 export VSS_STACK_TAG=${VSS_STACK_TAG:-$TAG}
 export SMART_NVR_STACK_TAG=${SMART_NVR_STACK_TAG:-$TAG}
 
-# Release-specific tag mapping for Live Video Search 1.0.0-rc1
-if [ "$TAG" = "1.0.0-rc1" ]; then
+# Release-specific tag mapping for Live Video Search 1.0.0
+if [ "$TAG" = "1.0.0" ]; then
     if [ -z "$VSS_STACK_TAG" ] || [ "$VSS_STACK_TAG" = "$TAG" ]; then
-        export VSS_STACK_TAG="1.3.2-rc1"
+        export VSS_STACK_TAG="1.3.2"
     fi
     if [ -z "$SMART_NVR_STACK_TAG" ] || [ "$SMART_NVR_STACK_TAG" = "$TAG" ]; then
-        export SMART_NVR_STACK_TAG="1.2.4-rc1"
+        export SMART_NVR_STACK_TAG="1.2.4"
     fi
 fi
 

--- a/metro-ai-suite/smart-nvr/charts/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/Chart.yaml
@@ -1,20 +1,20 @@
 apiVersion: v2
 name: smart-nvr
 description: A Helm chart for Smart NVR 
-version: 1.2.4-rc1
+version: 1.2.4
 dependencies:
   - name: frigate
-    version: 1.2.4-rc1
+    version: 1.2.4
     repository: "file://subchart/frigate"
   - name: nvr-event-router
-    version: 1.2.4-rc1
+    version: 1.2.4
     repository: "file://subchart/nvr-event-router"
   - name: nvr-event-router-ui
-    version: 1.2.4-rc1
+    version: 1.2.4
     repository: "file://subchart/nvr-event-router-ui"
   - name: mqtt-broker
-    version: 1.2.4-rc1
+    version: 1.2.4
     repository: "file://subchart/mqtt-broker"
   - name: redis
-    version: 1.2.4-rc1
+    version: 1.2.4
     repository: "file://subchart/redis"

--- a/metro-ai-suite/smart-nvr/charts/subchart/frigate/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/frigate/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: frigate
 description: Frigate NVR component
-version: 1.2.4-rc1
+version: 1.2.4

--- a/metro-ai-suite/smart-nvr/charts/subchart/mqtt-broker/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/mqtt-broker/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: mqtt-broker
 description: MQTT Broker service
-version: 1.2.4-rc1
+version: 1.2.4

--- a/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router-ui/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router-ui/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nvr-event-router-ui
 description: NVR Event Router UI
-version: 1.2.4-rc1
+version: 1.2.4

--- a/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router-ui/values.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router-ui/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: intel/nvr-event-router
-  tag: 1.2.4-rc1
+  tag: 1.2.4
 
 replicaCount: 1
 

--- a/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: nvr-event-router
 description: NVR Event Router service
-version: 1.2.4-rc1
+version: 1.2.4

--- a/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router/values.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/nvr-event-router/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: intel/nvr-event-router
-  tag: 1.2.4-rc1
+  tag: 1.2.4
 
 replicaCount: 1
 

--- a/metro-ai-suite/smart-nvr/charts/subchart/redis/Chart.yaml
+++ b/metro-ai-suite/smart-nvr/charts/subchart/redis/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: redis
 description: Redis cache
-version: 1.2.4-rc1
+version: 1.2.4

--- a/metro-ai-suite/smart-nvr/charts/values.yaml
+++ b/metro-ai-suite/smart-nvr/charts/values.yaml
@@ -34,7 +34,7 @@ frigate:
 nvr-event-router:
   image:
     repository: intel/nvr-event-router
-    tag: 1.2.4-rc1
+    tag: 1.2.4
 
   replicaCount: 1
 
@@ -66,7 +66,7 @@ nvr-event-router:
 nvr-event-router-ui:
   image:
     repository: intel/nvr-event-router
-    tag: 1.2.4-rc1
+    tag: 1.2.4
   env:
     MODE: "ui"
     API_BASE_URL: "http://nvr-event-router:8000"

--- a/metro-ai-suite/smart-nvr/docs/user-guide/get-started.md
+++ b/metro-ai-suite/smart-nvr/docs/user-guide/get-started.md
@@ -69,7 +69,7 @@ Set up the required environment variables:
 ```bash
 # Docker Registry Details
 export REGISTRY_URL="intel"
-export TAG="1.2.4-rc1"
+export TAG="1.2.4"
 
 # VSS Service Endpoints
 export http_proxy=<http-proxy>

--- a/metro-ai-suite/smart-nvr/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/smart-nvr/docs/user-guide/get-started/deploy-with-helm.md
@@ -52,7 +52,7 @@ There are two options to get the charts in your workspace:
 Use the following command to pull the Helm chart from Docker Hub:
 
 ```bash
-helm pull oci://registry-1.docker.io/intel/smart-nvr --version 1.2.4-rc1
+helm pull oci://registry-1.docker.io/intel/smart-nvr --version 1.2.4
 ```
 
 Refer to the [release notes](../release-notes.md) for details on the latest version number to
@@ -63,7 +63,7 @@ use for the sample application.
 After pulling the chart, extract the `.tgz` file:
 
 ```bash
-tar -xvf smart-nvr-1.2.4-rc1.tgz
+tar -xvf smart-nvr-1.2.4.tgz
 ```
 
 This will create a directory named `smart-nvr` containing the chart files. Navigate to the

--- a/metro-ai-suite/smart-nvr/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/smart-nvr/docs/user-guide/release-notes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-- [Version 1.2.4-rc1](#version-124-rc1)
+- [Version 1.2.4](#version-124)
 - [Version 1.2.3](#version-123)
 - [Version 1.2.2](#version-122)
 - [Version 1.2.1](#version-121)
@@ -9,9 +9,9 @@
 
 ## Current Release
 
-### Version 1.2.4-rc1
+### Version 1.2.4
 
-**Release Date**: 17 Feb 2026  
+**Release Date**: 23 Mar 2026  
 
 **New Features**:
 


### PR DESCRIPTION
### Description

- Updating release notes to reflect the final release of smart-nvr 1.2.4
- Updating environment variable defaults in get-started.md to use the final release tags
- Updating Helm chart versions and image tags in values.yaml and Chart.yaml files to reflect the final release versions.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

tested in dev env

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

