### PR TITLE
fix: custom rviz panel failed to launch for rvc sample

### DIFF
--- a/robotics-ai-suite/robot-vision-control/src/rvc_panel_rviz2_plugin/CMakeLists.txt
+++ b/robotics-ai-suite/robot-vision-control/src/rvc_panel_rviz2_plugin/CMakeLists.txt
@@ -62,7 +62,10 @@ set(SRC_FILES
 ## "rviz_plugin_tutorials", or whatever your version of this project
 ## is called) and specify the list of source files we collected above
 ## in ``${SRC_FILES}``. We also add the needed dependencies.
-add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
+qt5_wrap_cpp(MOC_FILES
+  src/rvc_panel.hpp
+)
+add_library(${PROJECT_NAME} SHARED ${SRC_FILES} ${MOC_FILES})
 ament_target_dependencies(${PROJECT_NAME}
   geometry_msgs
   rclcpp


### PR DESCRIPTION
### Description

Edit CMakeLists.txt file for generate the proper Qt files for the custom RVIZ panel in RVC

Fixes #2373 

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

With the RVC setup, rerun the [Run examples](https://github.com/open-edge-platform/edge-ai-suites/blob/main/robotics-ai-suite/robot-vision-control/README.md#run-examples) section.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

