### PR TITLE
timeseries, multimodal: Update sample apps from zip to tar for UDF package uploads

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/Makefile
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/Makefile
@@ -142,22 +142,22 @@ wait_for_tsam:
 	done; \
 	echo "Time-Series Analytics microservice is accessible."
 
-upload_zip_file:
-	@echo "Creating UDF deployment zip for weld anomaly detection..."
+upload_tar_file:
+	@echo "Creating UDF deployment tar for weld anomaly detection..."
 	@config_dir=$(CURDIR)/configs/time-series-analytics-microservice; \
-	zip_file=$(CURDIR)/configs/time-series-analytics-microservice/weld_anomaly_detector.zip; \
-	rm -f $$zip_file; \
+	tar_file=$(CURDIR)/configs/time-series-analytics-microservice/weld_anomaly_detector.tar; \
+	rm -f $$tar_file; \
 	cd $$config_dir && \
 	folders="udfs tick_scripts"; \
 	if [ -d models ] && [ -n "$$(ls -A models 2>/dev/null)" ]; then folders="$$folders models"; fi; \
-	zip -r $$zip_file $$folders && \
-	echo "Created: $$zip_file"
+	tar cf $$tar_file $$folders && \
+	echo "Created: $$tar_file"
 	@$(MAKE) wait_for_tsam
-	@echo "Uploading UDF deployment zip for weld anomaly detection to Time-Series Analytics microservice..."; \
-	zip_file=$(CURDIR)/configs/time-series-analytics-microservice/weld_anomaly_detector.zip; \
+	@echo "Uploading UDF deployment tar for weld anomaly detection to Time-Series Analytics microservice..."; \
+	tar_file=$(CURDIR)/configs/time-series-analytics-microservice/weld_anomaly_detector.tar; \
 	response=$$(curl -s -o /tmp/upload_response.json -w "%{http_code}" \
 		-X POST https://localhost:${GRAFANA_PORT}/ts-api/udfs/package \
-		-F "file=@$$zip_file" \
+		-F "file=@$$tar_file" \
 		-k); \
 	if [ "$$response" = "200" ]; then \
 		echo "Upload successful (HTTP $$response)."; \
@@ -200,7 +200,7 @@ up: check_env_variables validate_host_ip down
 	else \
 		$(DOCKER_COMPOSE) up -d; \
 	fi; \
-	$(MAKE) upload_zip_file
+	$(MAKE) upload_tar_file
 
 # Status of the deployed containers
 .PHONY: status

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started/deploy-with-helm.md
@@ -137,10 +137,10 @@ this sample application in Kubernetes environment:
 
    ```bash
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-multimodal/configs/time-series-analytics-microservice # path relative to git clone folder
-   rm -f weld_anomaly_detector.zip
-   zip -r weld_anomaly_detector udfs/ models/ tick_scripts/
+   rm -f weld_anomaly_detector.tar
+   tar cf weld_anomaly_detector.tar udfs/ models/ tick_scripts/
 
-   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@weld_anomaly_detector.zip" -k
+   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@weld_anomaly_detector.tar" -k
    ```
 
 > **Note:**

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/Makefile
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/Makefile
@@ -133,22 +133,22 @@ wait_for_tsam:
 	done; \
 	echo "Time-Series Analytics microservice is accessible."
 
-upload_zip_file:
-	@echo "Creating UDF deployment zip for $(SAMPLE_APP)..."
+upload_tar_file:
+	@echo "Creating UDF deployment tar for $(SAMPLE_APP)..."
 	@config_dir=$(CURDIR)/apps/$(SAMPLE_APP)/time-series-analytics-config; \
-	zip_file=$(CURDIR)/apps/$(SAMPLE_APP)/time-series-analytics-config/$(SAMPLE_APP).zip; \
-	rm -f $$zip_file; \
+	tar_file=$(CURDIR)/apps/$(SAMPLE_APP)/time-series-analytics-config/$(SAMPLE_APP).tar; \
+	rm -f $$tar_file; \
 	cd $$config_dir && \
 	folders="udfs tick_scripts"; \
 	if [ -d models ] && [ -n "$$(ls -A models 2>/dev/null)" ]; then folders="$$folders models"; fi; \
-	zip -r $$zip_file $$folders && \
-	echo "Created: $$zip_file"
+	tar cf $$tar_file $$folders && \
+	echo "Created: $$tar_file"
 	@$(MAKE) wait_for_tsam
-	@echo "Uploading UDF deployment zip for $(SAMPLE_APP) to Time-Series Analytics microservice..."; \
-	zip_file=$(CURDIR)/apps/$(SAMPLE_APP)/time-series-analytics-config/$(SAMPLE_APP).zip; \
+	@echo "Uploading UDF deployment tar for $(SAMPLE_APP) to Time-Series Analytics microservice..."; \
+	tar_file=$(CURDIR)/apps/$(SAMPLE_APP)/time-series-analytics-config/$(SAMPLE_APP).tar; \
 	response=$$(curl -s -o /tmp/upload_response.json -w "%{http_code}" \
 		-X POST https://localhost:${GRAFANA_PORT}/ts-api/udfs/package \
-		-F "file=@$$zip_file" \
+		-F "file=@$$tar_file" \
 		-k); \
 	if [ "$$response" = "200" ]; then \
 		echo "Upload successful (HTTP $$response)."; \
@@ -202,7 +202,7 @@ up_mqtt_ingestion: check_env_variables down
 		done; \
 		$(DOCKER_COMPOSE) up --scale ia-opcua-server=0 -d $(shell $(DOCKER_COMPOSE) config --services | grep -v ia-mqtt-publisher); \
 	fi; \
-	$(MAKE) upload_zip_file app=$(SAMPLE_APP);
+	$(MAKE) upload_tar_file app=$(SAMPLE_APP);
 
 # Run Docker containers
 .PHONY: up_opcua_ingestion
@@ -223,7 +223,7 @@ up_opcua_ingestion: check_env_variables down
 	else \
 		$(DOCKER_COMPOSE) up --scale ia-opcua-server=$(num_of_streams) --scale ia-mqtt-publisher=0 -d; \
 	fi; \
-	$(MAKE) upload_zip_file app=$(SAMPLE_APP);
+	$(MAKE) upload_tar_file app=$(SAMPLE_APP);
 
 
 # Status of the deployed containers

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/get-started/deploy-with-helm.md
@@ -189,10 +189,10 @@ To copy your own or existing model into Time Series Analytics Microservice in or
    ```sh
    export SAMPLE_APP="wind-turbine-anomaly-detection"
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/apps/wind-turbine-anomaly-detection/time-series-analytics-config # path relative to git clone folder
-   rm -f ${SAMPLE_APP}.zip
-   zip -r ${SAMPLE_APP}.zip models/ tick_scripts/ udfs/
+   rm -f ${SAMPLE_APP}.tar
+   tar cf ${SAMPLE_APP}.tar models/ tick_scripts/ udfs/
 
-   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.zip" -k
+   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.tar" -k
    ```
 
 <!--hide_directive:::
@@ -219,10 +219,10 @@ To copy your own or existing model into Time Series Analytics Microservice in or
    ```sh
    export SAMPLE_APP="weld-anomaly-detection"
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/apps/weld-anomaly-detection/time-series-analytics-config # path relative to git clone folder
-   rm -f ${SAMPLE_APP}.zip
-   zip -r ${SAMPLE_APP}.zip models/ tick_scripts/ udfs/
+   rm -f ${SAMPLE_APP}.tar
+   tar cf ${SAMPLE_APP}.tar models/ tick_scripts/ udfs/
 
-   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.zip" -k
+   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.tar" -k
    ```
 
 <!--hide_directive:::

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/how-to-guides/configure-alerts.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/how-to-guides/configure-alerts.md
@@ -185,9 +185,9 @@ cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/ap
 cd time-series-analytics-config
 export SAMPLE_APP="wind-turbine-anomaly-detection"
 
-rm -f ${SAMPLE_APP}.zip
-zip -r ${SAMPLE_APP}.zip models/ tick_scripts/ udfs/
-curl -X POST https://localhost:3000/ts-api/udfs/package -F "file=@${SAMPLE_APP}.zip" -k
+rm -f ${SAMPLE_APP}.tar
+tar cf ${SAMPLE_APP}.tar models/ tick_scripts/ udfs/
+curl -X POST https://localhost:3000/ts-api/udfs/package -F "file=@${SAMPLE_APP}.tar" -k
 ```
 
 #### 2. Configuring OPC-UA Alert in config.json
@@ -326,10 +326,10 @@ To enable OPC-UA alerts in `Time Series Analytics Microservice`, please follow b
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-time-series/apps/wind-turbine-anomaly-detection # path relative to git  clone   folder
    cd time-series-analytics-config
    export SAMPLE_APP="wind-turbine-anomaly-detection"
-   rm -f ${SAMPLE_APP}.zip
-   zip -r ${SAMPLE_APP}.zip models/ tick_scripts/ udfs/
+   rm -f ${SAMPLE_APP}.tar
+   tar cf ${SAMPLE_APP}.tar models/ tick_scripts/ udfs/
 
-   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.zip" -k
+   curl -X POST https://localhost:30001/ts-api/udfs/package -F "file=@${SAMPLE_APP}.tar" -k
    ```
 
 3. Configuring OPC-UA Alert in `config.json`

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/helm_utils.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/helm_utils.py
@@ -1622,14 +1622,14 @@ def with_model_registry(chart_path, input):
             logger.error(f"Error copying files: {result.stderr.decode('utf-8')}")
         tar_command = f"tar cf windturbine_anomaly_detector.tar udfs models tick_scripts"
         result = subprocess.run(tar_command, shell=True, capture_output=True, text=True, check=True)
+        logger.info("TAR archive created successfully.")
         if result.stdout:
             logger.info(f"TAR command output: {result.stdout}")
-            logger.info("TAR archive created successfully.")
-        elif result.stderr:
-            logger.error(f"TAR command errors: {result.stderr}")
+        if result.stderr:
+            logger.error(f"TAR command stderr: {result.stderr}")
         
 
-        # Step 2: Upload the ZIP file using kubectl exec to avoid port-forwarding
+        # Step 2: Upload the tar file using kubectl exec to avoid port-forwarding
         # Find the model registry pod
         model_registry_pod_command = (
             f"kubectl get pods -n {namespace} "

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/helm_utils.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/helm_utils.py
@@ -1620,13 +1620,13 @@ def with_model_registry(chart_path, input):
             logger.info("Files copied successfully to 'wind-turbine-anomaly-detection' directory.")
         elif result.stderr:
             logger.error(f"Error copying files: {result.stderr.decode('utf-8')}")
-        zip_command = f"zip -r windturbine_anomaly_detector.zip udfs models tick_scripts"
-        result = subprocess.run(zip_command, shell=True, capture_output=True, text=True, check=True)
+        tar_command = f"tar cf windturbine_anomaly_detector.tar udfs models tick_scripts"
+        result = subprocess.run(tar_command, shell=True, capture_output=True, text=True, check=True)
         if result.stdout:
-            logger.info(f"ZIP command output: {result.stdout}")
-            logger.info("ZIP archive created successfully.")
+            logger.info(f"TAR command output: {result.stdout}")
+            logger.info("TAR archive created successfully.")
         elif result.stderr:
-            logger.error(f"ZIP command errors: {result.stderr}")
+            logger.error(f"TAR command errors: {result.stderr}")
         
 
         # Step 2: Upload the ZIP file using kubectl exec to avoid port-forwarding
@@ -1644,16 +1644,16 @@ def with_model_registry(chart_path, input):
             logger.error("Model registry pod not found.")
             return False
 
-        # Copy the ZIP file to the model registry pod first
+        # Copy the TAR file to the model registry pod first
         kubectl_cp_command = [
-            'kubectl', 'cp', 'windturbine_anomaly_detector.zip',
-            f'{model_registry_pod}:/tmp/windturbine_anomaly_detector.zip',
+            'kubectl', 'cp', 'windturbine_anomaly_detector.tar',
+            f'{model_registry_pod}:/tmp/windturbine_anomaly_detector.tar',
             '-n', namespace
         ]
-        logger.info(f"Copying ZIP file to model registry pod: {' '.join(kubectl_cp_command)}")
+        logger.info(f"Copying TAR file to model registry pod: {' '.join(kubectl_cp_command)}")
         result = subprocess.run(kubectl_cp_command, capture_output=True, text=True)
         if result.returncode != 0:
-            logger.error(f"Error copying ZIP file to pod: {result.stderr}")
+            logger.error(f"Error copying TAR file to pod: {result.stderr}")
             return False
 
         # Upload using curl from within the pod (in-cluster call)
@@ -1663,7 +1663,7 @@ def with_model_registry(chart_path, input):
             '-H', 'Content-Type: multipart/form-data',
             '-F', 'name="windturbine_anomaly_detector"',
             '-F', 'version="1.0"',
-            '-F', 'file=@/tmp/windturbine_anomaly_detector.zip;type=application/zip'
+            '-F', 'file=@/tmp/windturbine_anomaly_detector.tar;type=application/x-tar'
         ]
         logger.info(f"Uploading model via kubectl exec: {' '.join(upload_command)}")
         result = subprocess.run(upload_command, capture_output=True, text=True)


### PR DESCRIPTION
### Description

Aligns with time-series-analytics microservice changes from open-edge-platform/edge-ai-libraries#2100 which migrated the /udfs/package endpoint from zip-based to tar-based file uploads.

Updated files:
- Time Series: Makefile, deploy-with-helm.md, configure-alerts.md, helm_utils.py
- Multimodal: Makefile, deploy-with-helm.md

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Locally validated and the PR workflow once TSAM PR is merged should work

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

