### PR TITLE
[Smart-Route-Planner] Docfix: Remove unused name field from examples

### DIFF
--- a/metro-ai-suite/smart-route-planning-agent/docs/user-guide/get-started.md
+++ b/metro-ai-suite/smart-route-planning-agent/docs/user-guide/get-started.md
@@ -95,17 +95,12 @@ edge nodes:
     "api_endpoint": "/api/v1/traffic/current?images=false",
     "api_hosts": [
         {
-            "name": "Intersection-1",
             "host": "http://<edge-node-1-ip>:8081"
         },
         {
-
-            "name": "Intersection-2",
             "host": "http://<edge-node-2-ip>:8082"
         },
         {
-
-            "name": "Intersection-3",
             "host": "http://<edge-node-3-ip>:8083"
         }
     ]


### PR DESCRIPTION
### Description

The api_hosts entries in the route planner config example included a "name" field that is not part of the required API schema. Remove these fields to keep the configuration example accurate and minimal.

Changes:
- get-started.md: remove "name" key from each api_hosts entry in the edge node configuration example

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

NA

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

