### PR TITLE
[content search] bug fix and optimize download stream

### DIFF
--- a/education-ai-suite/smart-classroom/content_search/api/v1/endpoints/object.py
+++ b/education-ai-suite/smart-classroom/content_search/api/v1/endpoints/object.py
@@ -6,10 +6,11 @@
 import urllib.parse
 import mimetypes
 import json
-from fastapi import APIRouter, Depends, HTTPException, File, UploadFile, BackgroundTasks, Form
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Depends, HTTPException, File, UploadFile, BackgroundTasks, Form, Request
+from fastapi.responses import StreamingResponse, Response
 from sqlalchemy.orm import Session
 from sqlalchemy import text
+import re
 from utils.database import get_db
 from utils.task_service import task_service
 from utils.storage_service import storage_service
@@ -127,33 +128,92 @@ async def file_search(payload: dict, db: Session = Depends(get_db)):
     return resp_200(data=result, message="Search completed")
 
 @router.get("/download")
-async def download_file(file_key: str, inline: bool = False):
+async def download_file(request: Request, file_key: str, inline: bool = False):
     """
-    Download or preview a file
+    Download or preview a file with HTTP Range support for video streaming
     e.g:
       - GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4  (download)
-      - GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4&inline=true  (preview)
+      - GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4&inline=true  (preview with range support)
     """
-    file_stream = await storage_service.get_file_stream(file_key)
-
     filename = file_key.split('/')[-1]
     content_type, _ = mimetypes.guess_type(filename)
     if not content_type:
         content_type = "application/octet-stream"
 
     encoded_filename = urllib.parse.quote(filename)
-
-    # Use 'inline' for preview, 'attachment' for download
     disposition_type = "inline" if inline else "attachment"
 
-    return StreamingResponse(
-        file_stream,
-        media_type=content_type,
-        headers={
+    # Get file size
+    try:
+        file_size = storage_service.get_file_size(file_key)
+    except Exception as e:
+        raise HTTPException(status_code=404, detail=f"File not found: {str(e)}")
+
+    # Parse Range header
+    range_header = request.headers.get("range")
+
+    if range_header:
+        # Parse range like "bytes=0-1023" or "bytes=1024-"
+        range_match = re.match(r"bytes=(\d+)-(\d*)", range_header)
+        if not range_match:
+            raise HTTPException(status_code=416, detail="Invalid range")
+
+        start = int(range_match.group(1))
+        end = int(range_match.group(2)) if range_match.group(2) else file_size - 1
+
+        # Validate range
+        if start >= file_size or end >= file_size or start > end:
+            raise HTTPException(status_code=416, detail="Range not satisfiable")
+
+        content_length = end - start + 1
+
+        # Read the range from file
+        file_stream = await storage_service.get_file_stream(file_key)
+        file_stream.seek(start)
+
+        def iter_range():
+            remaining = content_length
+            chunk_size = 8192
+            try:
+                while remaining > 0:
+                    chunk = file_stream.read(min(chunk_size, remaining))
+                    if not chunk:
+                        break
+                    remaining -= len(chunk)
+                    yield chunk
+            finally:
+                file_stream.close()
+
+        headers = {
+            "Content-Range": f"bytes {start}-{end}/{file_size}",
+            "Accept-Ranges": "bytes",
+            "Content-Length": str(content_length),
             "Content-Disposition": f"{disposition_type}; filename=\"{encoded_filename}\"; filename*=UTF-8''{encoded_filename}",
-            "Access-Control-Expose-Headers": "Content-Disposition"
+            "Access-Control-Expose-Headers": "Content-Disposition, Content-Range, Accept-Ranges"
         }
-    )
+
+        return StreamingResponse(
+            iter_range(),
+            status_code=206,
+            media_type=content_type,
+            headers=headers
+        )
+    else:
+        # No range requested, return full file
+        file_stream = await storage_service.get_file_stream(file_key)
+
+        headers = {
+            "Accept-Ranges": "bytes",
+            "Content-Length": str(file_size),
+            "Content-Disposition": f"{disposition_type}; filename=\"{encoded_filename}\"; filename*=UTF-8''{encoded_filename}",
+            "Access-Control-Expose-Headers": "Content-Disposition, Accept-Ranges"
+        }
+
+        return StreamingResponse(
+            file_stream,
+            media_type=content_type,
+            headers=headers
+        )
 
 @router.delete("/cleanup-task/{task_id}")
 async def delete_specific_task(

--- a/education-ai-suite/smart-classroom/content_search/api/v1/endpoints/object.py
+++ b/education-ai-suite/smart-classroom/content_search/api/v1/endpoints/object.py
@@ -127,9 +127,12 @@ async def file_search(payload: dict, db: Session = Depends(get_db)):
     return resp_200(data=result, message="Search completed")
 
 @router.get("/download")
-async def download_file(file_key: str):
+async def download_file(file_key: str, inline: bool = False):
     """
-    e.g: GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4
+    Download or preview a file
+    e.g:
+      - GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4  (download)
+      - GET /download?file_key=runs/run_xxx/raw/video/default/test.mp4&inline=true  (preview)
     """
     file_stream = await storage_service.get_file_stream(file_key)
 
@@ -140,11 +143,14 @@ async def download_file(file_key: str):
 
     encoded_filename = urllib.parse.quote(filename)
 
+    # Use 'inline' for preview, 'attachment' for download
+    disposition_type = "inline" if inline else "attachment"
+
     return StreamingResponse(
         file_stream,
         media_type=content_type,
         headers={
-            "Content-Disposition": f"attachment; filename=\"{encoded_filename}\"; filename*=UTF-8''{encoded_filename}",
+            "Content-Disposition": f"{disposition_type}; filename=\"{encoded_filename}\"; filename*=UTF-8''{encoded_filename}",
             "Access-Control-Expose-Headers": "Content-Disposition"
         }
     )

--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
@@ -382,14 +382,14 @@ Different filter keys are always combined with `AND`. When a filter value is a `
 * Example:
 Request:
 ```
-# Example 1: Filter by tags — returns results whose tags array contains "classroom" or "student"
+# Example 1: Filter by tags — returns results whose tags array contains "test_tag1" or "test_tag2"
 curl --location 'http://127.0.0.1:9011/api/v1/object/search' \
 --header 'Content-Type: application/json' \
 --data '{
     "query": "classroom",
     "max_num_results": 2,
     "filter": {
-        "tags": ["classroom", "student"]
+        "tags": ["test_tag1", "test_tag2"]
     }
 }'
 # Example 2: Filter by type — available values: `video`, `image`, `document`. If not specified, all types are returned. Example returns only `video` or `document` results:
@@ -417,7 +417,11 @@ Response (200 OK):
                 "meta": {
                     "type": "image",
                     "file_path": "local://content-search/runs/7a4480af-3f9c-40b6-ac9e-0a698717bc45/raw/image/default/classroom.jpg",
-                    "file_name": "classroom.jpg"
+                    "file_name": "classroom.jpg",
+                    "tags": [
+                        "img_tag1",
+                        "img_tag2"
+                    ]
                 },
                 "score": 83.56
             },
@@ -437,7 +441,11 @@ Response (200 OK):
                     "doc_languages": "[\"eng\"]",
                     "doc_file_directory": "C:\\Users\\user\\AppData\\Local\\Temp\\tmpwma1e266",
                     "file_path": "local://content-search/runs/a6d3ef1f-510b-4ec9-8a16-4db2332758b0/raw/application/default/ComputerScienceOne.pdf",
-                    "file_name": "ComputerScienceOne.pdf"
+                    "file_name": "ComputerScienceOne.pdf",
+                    "tags": [
+                        "pdf_tag1",
+                        "pdf_tag2"
+                    ]
                 },
                 "score": 99.81,
                 "reranker_score": 6.28125

--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
@@ -386,8 +386,8 @@ Request:
 curl --location 'http://127.0.0.1:9011/api/v1/object/search' \
 --header 'Content-Type: application/json' \
 --data '{
-    "query": "student in classroom",
-    "max_num_results": 1,
+    "query": "classroom",
+    "max_num_results": 2,
     "filter": {
         "tags": ["classroom", "student"]
     }
@@ -408,36 +408,44 @@ Response (200 OK):
 {
     "code": 20000,
     "data": {
+        "task_id": "4d3159df-93d1-44a9-8592-bc48eb561b05",
+        "status": "COMPLETED",
         "results": [
             {
-                "id": "1680138485034402529",
-                "distance": 0.47685748,
+                "id": "435369449869751787",
+                "distance": 0.7416173,
                 "meta": {
-                    "start_frame": 0,
-                    "chunk_text": "The video depicts a classroom setting with four individuals seated at desks arranged in a U-shape. The room has a modern design with blue chairs, white tables, and a whiteboard on the right side. The walls are adorned with various posters and a large mirror reflecting part of the room. The lighting is bright, creating a well-lit environment. The individuals appear to be engaged in a discussion or presentation, with one person standing and gesturing towards the others. The overall atmosphere suggests an educational or collaborative activity taking place.",
-                    "reused": false,
-                    "start_time": 0.0,
-                    "asset_id": "classroom_8.mp4",
-                    "file_path": "local://content-search/runs/81802f9e-0a28-4486-bad2-2e05c1086326/derived/video/classroom_8.mp4/chunksum-v1/summaries/chunk_0001/summary.txt",
-                    "run_id": "81802f9e-0a28-4486-bad2-2e05c1086326",
+                    "type": "image",
+                    "file_path": "local://content-search/runs/7a4480af-3f9c-40b6-ac9e-0a698717bc45/raw/image/default/classroom.jpg",
+                    "file_name": "classroom.jpg"
+                },
+                "score": 83.56
+            },
+            {
+                "id": "3898473585704952476",
+                "distance": 0.19918823,
+                "meta": {
+                    "doc_filename": "ComputerScienceOne.pdf",
+                    "doc_is_continuation": true,
+                    "doc_last_modified": "2026-04-14T20:56:13",
+                    "doc_sequence_number": 448,
+                    "chunk_text": "tegral. Instead, Computer Science is the study of computers and computation. It involves studying and understanding computational processes and the development of algorithms and techniques and how they apply to problems.",
+                    "chunk_index": 448,
                     "type": "document",
-                    "end_time": 0.32,
-                    "summary_key": "runs/81802f9e-0a28-4486-bad2-2e05c1086326/derived/video/classroom_8.mp4/chunksum-v1/summaries/chunk_0001/summary.txt",
-                    "doc_filetype": "text/plain",
-                    "chunk_id": "chunk_0001",
-                    "file_key": "runs/c9a34e33-284a-48af-8d41-2b0d7d2989a7/raw/video/default/classroom_8.mp4",
-                    "chunk_index": 0,
-                    "tags": [
-                        "class",
-                        "student"
-                    ],
-                    "end_frame": 8
-                }
+                    "doc_filetype": "application/pdf",
+                    "doc_page_number": 36,
+                    "doc_languages": "[\"eng\"]",
+                    "doc_file_directory": "C:\\Users\\user\\AppData\\Local\\Temp\\tmpwma1e266",
+                    "file_path": "local://content-search/runs/a6d3ef1f-510b-4ec9-8a16-4db2332758b0/raw/application/default/ComputerScienceOne.pdf",
+                    "file_name": "ComputerScienceOne.pdf"
+                },
+                "score": 99.81,
+                "reranker_score": 6.28125
             }
         ]
     },
     "message": "Search completed",
-    "timestamp": 1774877744
+    "timestamp": 1776171542
 }
 ```
 #### Resource Download (Video/Image/Document)

--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
@@ -441,16 +441,30 @@ Response (200 OK):
 }
 ```
 #### Resource Download (Video/Image/Document)
-Download existing resources from storage.
+Download or preview existing resources from storage.
 
-* URL: /api/v1/object/download/{resource_id}
+* URL: /api/v1/object/download
 * Method: GET
 * Pattern: SYNC
+* Parameters:
+
+| Field | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `file_key` | `string` | Yes | The full path of the file in storage (e.g., "runs/xxx/raw/video/default/file.mp4"). |
+| `inline` | `boolean` | No | If `true`, sets `Content-Disposition: inline` for browser preview (PDF, video, image). If `false` or omitted, forces download with `Content-Disposition: attachment`. Defaults to `false`. |
+
 Request:
+```bash
+# Example 1: Download file (default behavior)
+curl --location 'http://127.0.0.1:9011/api/v1/object/download?file_key=runs%2Fc9a34e33-284a-48af-8d41-2b0d7d2989a7%2Fraw%2Fvideo%2Fdefault%2Fclassroom_8.mp4'
+
+# Example 2: Preview file in browser (PDF, video, image)
+curl --location 'http://127.0.0.1:9011/api/v1/object/download?file_key=runs%2Fc9a34e33-284a-48af-8d41-2b0d7d2989a7%2Fraw%2Fapplication%2Fdefault%2Fdocument.pdf&inline=true'
 ```
-curl --location 'http://127.0.0.1:9011/api/v1/object/download?file_key=runs%2Fc9a34e33-284a-48af-8d41-2b0d7d2989a7%2Fraw%2Fvideo%2Fdefault%2Fclassroom_8.mp4' \
---header 'Content-Type: application/json'
-```
+
+**Usage Notes**:
+- Use `inline=true` for embedding resources in `<iframe>`, `<video>`, or `<img>` tags for in-browser preview.
+- Use `inline=false` (or omit) when you need to trigger a download prompt in the browser.
 
 #### Cleanup file storage and record
 Removes all physical and logical footprints associated with a specific task, including local storage files, indexed vectors in ChromaDB, and metadata records in the database.

--- a/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
@@ -18,7 +18,10 @@ class AssetService:
         if not meta_str:
             return {}
         try:
-            return json.loads(meta_str)
+            parsed = json.loads(meta_str)
+            if isinstance(parsed, str):
+                parsed = json.loads(parsed)
+            return parsed
         except (json.JSONDecodeError, TypeError):
             return {"info": meta_str}
 

--- a/education-ai-suite/smart-classroom/content_search/utils/storage_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/storage_service.py
@@ -82,6 +82,20 @@ class StorageService:
             logger.error(f"Error checking existence for {file_key}: {str(e)}")
             return False
 
+    def get_file_size(self, file_key: str) -> int:
+        """Get the size of a file in bytes"""
+        if not self.is_available:
+            raise RuntimeError(f"Storage Service is unavailable: {self._error_msg}")
+        try:
+            # For LocalStore, we can get the file path and check its size
+            file_path = self._store._object_path(file_key)
+            if not file_path.is_file():
+                raise RuntimeError(f"File not found: {file_key}")
+            return file_path.stat().st_size
+        except Exception as e:
+            logger.error(f"Failed to get file size for {file_key}: {str(e)}")
+            raise e
+
     def delete_file(self, file_key: str, missing_ok: bool = True) -> bool:
         if not self.is_available:
             raise RuntimeError(f"Storage Service is unavailable: {self._error_msg}")

--- a/education-ai-suite/smart-classroom/content_search/utils/task_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/task_service.py
@@ -161,8 +161,9 @@ class TaskService:
 
                 else:
                     ai_result = asyncio.run(search_service.trigger_ingest(
-                        file_path=file_key, 
-                        bucket_name=bucket_name
+                        file_path=file_key,
+                        bucket_name=bucket_name,
+                        meta=task.payload.get("meta")
                     ))
 
                 if is_video and ai_result and "error" not in ai_result:


### PR DESCRIPTION
### Description

1. Fix the issue: `search` response don't have tags
2. Add `inline` parameter to download API: When the `inline` parameter is set, the browser attempts to render the file directly rather than triggering a download.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

