### PR TITLE
Content Search: update summary score, add video start & end time

### DIFF
--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/Content_search_API.md
@@ -412,6 +412,20 @@ Response (200 OK):
         "status": "COMPLETED",
         "results": [
             {
+                "id": "197972195449837430",
+                "distance": 0.8402439,
+                "meta": {
+                    "type": "video",
+                    "file_path": "local://content-search/runs/2a6e14b6-da45-4e20-93a1-2291ab01d6f6/raw/video/default/store-aisle-detection.mp4",
+                    "file_name": "store-aisle-detection.mp4",
+                    "video_pin_second": 11.01,
+                    "video_start_second": 7.76,
+                    "video_end_second": 14.26,
+                    "summary_text": "The video depicts a scene inside a store filled with shelves of white ceramic dishes, including bowls, plates, mugs, and cups. The store appears to be a pottery or ceramics shop, as evidenced by the variety of items available for purchase.\n\nIn the foreground, a man wearing a brown jacket is browsing through the shelves, examining the ceramic dishes. He seems interested in the selection and is carefully inspecting each item. Nearby, a woman in a green jacket is also looking at the dishes, possibly considering purchasing some. Another person, dressed in a blue jacket, is seen walking past the shelves, seemingly uninterested in the products.\n\nAs the camera pans around the store, more people can be observed engaging with the ceramic items. Some individuals are standing near the shelves, closely examining the dishes, while others are walking through the aisles, browsing the available options. The store has a well-lit environment, making it easy for customers to see the details of the ceramic pieces.\n\nThroughout the video, the focus remains on the interaction between the customers and the ceramic dishes, showcasing the variety of items available for purchase. The store's layout and organization allow customers to easily navigate through the aisles and find their desired items."
+                },
+                "score": 53.65
+            },
+            {
                 "id": "435369449869751787",
                 "distance": 0.7416173,
                 "meta": {

--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/file_ingest_and_retrieve/reranker.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/file_ingest_and_retrieve/reranker.md
@@ -20,19 +20,26 @@
 
 ### `process_text_query_results(query, visual_results, doc_results, top_k)`
 
-Pipeline: **dedup → rerank → allocate slots → format**
+Pipeline: **dedup → attach summaries → rerank all docs → percentage scores → drop attached summaries → allocate slots → summary→video → format**
 
-```
-visual_results (ChromaDB) ──→ flatten → _dedup_video_frames ──┐
-                                                               ├─→ _allocate_slots → _to_chroma_format
-doc_results    (ChromaDB) ──→ flatten → _rerank_documents ────┘
+```mermaid
+graph LR
+    VR[visual_results] --> F1[flatten] --> dedup[_dedup_video_frames] --> attach[_attach_best_summary_texts]
+    DR[doc_results] --> F2[flatten] --> rerank[_rerank_documents]
+
+    attach --> pct1[_compute_percentage_scores]
+    rerank --> pct2[_compute_percentage_scores] --> drop[drop attached summaries]
+
+    pct1 --> alloc[_allocate_slots]
+    drop --> alloc
+    alloc --> conv[_convert_selected_summaries_to_video] --> fmt[_to_chroma_format]
 ```
 
 ### `process_image_query_results(visual_results, top_k)`
 
-Pipeline: **dedup → trim → assign RRF by rank → format**
+Pipeline: **dedup → attach summaries → trim → assign RRF by rank → percentage scores → format**
 
-No cross-encoder is invoked. `scores` are assigned purely by distance rank so the output format is consistent with the text path.
+No cross-encoder is invoked. After dedup, summary texts are attached to video results via `_attach_best_summary_texts`. Results are trimmed to `top_k`, assigned RRF scores by rank, then scored with `_compute_percentage_scores` (using the image-to-image sigmoid center) so the output format is consistent with the text path.
 
 ---
 
@@ -46,30 +53,27 @@ No cross-encoder is invoked. `scores` are assigned purely by distance rank so th
   - Otherwise, emit the cluster leader and start a new cluster.
 - Final output is sorted by `distance` ascending (lower = more relevant). This ordering is relied on by `_allocate_slots` for RRF ranking.
 
-### 2. `_rerank_documents`
+### 2. `_attach_best_summary_texts`
 
-- Documents with `meta.chunk_text` are scored by the cross-encoder as `[query, chunk_text]` pairs in a single batched inference call (max length 512 tokens).
+- Iterates over deduped visual results; skips non-video items.
+- Groups video results by `file_path`, then looks up precomputed summary IDs from `video_summary_id_map` and fetches their metadata from the document collection via `chroma_client.get()`.
+- For each video result, finds the summary whose time range midpoint (`(start_time + end_time) / 2`) is closest to `video_pin_second` and attaches its `chunk_text` as `meta.summary_text`.
+- This gives each video frame a textual description that can be displayed alongside the visual result.
+
+### 3. `_rerank_documents`
+
+- **All** document results (including video summaries) are scored by the cross-encoder as `[query, chunk_text]` pairs in a single batched inference call (max length 512 tokens).
 - The raw logit is stored as `reranker_score` on each result.
 - Scored documents are sorted by `reranker_score` descending. Documents without `chunk_text` are appended at the end in their original order without a score.
-
-### 3. `_allocate_slots`
-
-Merges `visual` and `document` groups into a single ranked list of `top_k` items.
-
-**RRF scoring** — each group is ranked independently (visual: by distance, document: by reranker_score). RRF score is assigned per item:
-
-$$\text{rrf\_score} = \frac{1}{k + \text{rank}}, \quad k = \text{RRF\_K} = 60$$
-
-**Two-pass selection:**
-
-1. **Guarantee pass** — each group gets at least `min_per_group = max(1, top_k // (num_groups × 2))` slots, preventing a dominant group from starving others entirely.
-2. **Fill pass** — remaining slots are filled globally by descending `rrf_score`.
-
-After both passes, `selected` is re-sorted by `rrf_score` descending to produce a globally consistent ranking (the guarantee pass can insert items out of global order).
+- Summaries compete alongside regular documents on an equal footing throughout the remaining pipeline steps.
 
 ### 4. `_compute_percentage_scores`
 
-Assigns a 0-100 **absolute relevance** score to each result. Because documents and visual results come from fundamentally different scoring systems, each type has its own formula:
+- Run on visual and document groups **separately, before allocation**.
+- Since percentage scores are independent of RRF (they only depend on each result's own raw score), computing them before or after allocation produces identical values.
+- Computing them early means scores are already present on items entering `_allocate_slots`, which allows a later step (drop attached summaries) to remove items without losing their scores.
+
+Assigns a 0-100 **absolute relevance** score to each result. Each type has its own formula:
 
 **Documents** (have `reranker_score` from the cross-encoder):
 
@@ -97,7 +101,35 @@ Typical score ranges for relevant results:
 | Visual text-to-image   | 80-95    | 30-80    | 0-20       |
 | Visual image-to-image  | 80-97    | 30-80    | 0-20       |
 
-### 5. `_to_chroma_format`
+### 5. Drop attached summaries
+
+- Summaries whose `chunk_text` already appears as `summary_text` on a visual frame are removed from the document group **before allocation**.
+- This prevents attached summaries from consuming document slots in `_allocate_slots`, ensuring allocation uses all `top_k` slots for genuinely distinct content.
+
+### 6. `_allocate_slots`
+
+Merges `visual` and `document` groups into a single ranked list of `top_k` items.
+
+**RRF scoring** — each group is ranked independently (visual: by distance, document: by reranker_score). RRF score is assigned per item:
+
+$$\text{rrf\_score} = \frac{1}{k + \text{rank}}, \quad k = \text{RRF\_K} = 60$$
+
+**Two-pass selection:**
+
+1. **Guarantee pass** — each group gets at least `min_per_group = max(1, top_k // (num_groups × 2))` slots, preventing a dominant group from starving others entirely.
+2. **Fill pass** — remaining slots are filled globally by descending `rrf_score`.
+
+After both passes, `selected` is re-sorted by `rrf_score` descending to produce a globally consistent ranking (the guarantee pass can insert items out of global order).
+
+### 7. `_convert_selected_summaries_to_video`
+
+- Runs **after** allocation. Attached summaries were already removed in step 5, so every summary here is unattached and should be converted.
+- For each result whose metadata contains a `summary_key`:
+  - Resolves `file_path` from `file_key`/bucket, sets `video_pin_second` to the midpoint of `[start_time, end_time]`, replaces metadata with `type: "video"` and `original_type: "constructed_from_summary"`, preserves `reranker_score`.
+  - If `file_key`/bucket cannot be resolved, the summary is dropped.
+- After this step, no `summary_key` documents remain in the output.
+
+### 8. `_to_chroma_format`
 
 Converts the flat result list back to ChromaDB nested format. Preserves the RRF ordering from `_allocate_slots` (does not re-sort by score, since scores are not comparable across types). Output fields:
 

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/indexer.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/indexer.py
@@ -295,8 +295,11 @@ class Indexer:
                     extracted_count += 1
                     image = Image.fromarray(frame)
                     seconds = frame_counter / fps
+                    half_window = frame_extract_interval / fps / 2 + 3
                     meta_data = copy.deepcopy(meta)
-                    meta_data["video_pin_second"] = seconds
+                    meta_data["video_pin_second"] = round(seconds, 2)
+                    meta_data["video_start_second"] = round(max(0, seconds - half_window), 2)
+                    meta_data["video_end_second"] = round(min(video.duration, seconds + half_window), 2)
                     if do_detect_and_crop:
                         for crop in self.detector.get_cropped_images(image):
                             embedding = self.get_image_embedding(crop)

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
@@ -68,7 +68,7 @@ class PostProcessor:
     def process_text_query_results(
         self, query: str, visual_results: dict, doc_results: dict, top_k: int,
     ) -> dict:
-        """Full post-processing for text queries: dedup → attach summaries → rerank → allocate slots."""
+        """Full post-processing for text queries: dedup → attach summaries → rerank → scores → drop attached summaries → allocate slots → summary to video → format."""
         visual_flat = _flatten_chroma_results(visual_results)
         doc_flat = _flatten_chroma_results(doc_results)
         logger.debug("[PostProcessor] Text query: %r | visual candidates: %d | doc candidates: %d | top_k: %d",
@@ -80,58 +80,21 @@ class PostProcessor:
 
         self._attach_best_summary_texts(visual_deduped)
 
-        summaries, non_summaries = self._split_summaries(doc_flat)
-        logger.debug("[PostProcessor] Doc split: %d summaries, %d non-summaries",
-                     len(summaries), len(non_summaries))
+        doc_reranked = self._rerank_documents(query, doc_flat)
 
-        doc_reranked = self._rerank_documents(query, non_summaries)
+        self._compute_percentage_scores(visual_deduped)
+        self._compute_percentage_scores(doc_reranked)
 
-        # For summaries whose chunk_text is not already attached to a visual result, construct video results
-        attached_texts = {
-            r["meta"].get("summary_text", "")
-            for r in visual_deduped
-            if r.get("meta", {}).get("summary_text")
-        }
-        constructed_count = 0
-        for s in summaries:
-            meta = s.get("meta", {})
-            chunk_text = meta.get("chunk_text", "")
-            if not chunk_text or chunk_text in attached_texts:
-                continue
-            file_key = meta.get("file_key", "")
-            bucket = extract_bucket_name(meta.get("file_path", ""))
-            if not bucket or not file_key:
-                continue
-            video_fp = file_key_to_path(file_key, bucket)
-            start_time = meta.get("start_time", 0)
-            end_time = meta.get("end_time", 0)
-            mid_time = start_time + (end_time - start_time) / 2
-            video_result = {
-                "id": s["id"],
-                "distance": s["distance"],
-                "meta": {
-                    "file_path": video_fp,
-                    "type": "video",
-                    "original_type": "constructed_from_summary",
-                    "video_pin_second": mid_time,
-                    "summary_text": chunk_text,
-                },
-            }
-            visual_deduped.append(video_result)
-            attached_texts.add(chunk_text)
-            constructed_count += 1
-        if constructed_count:
-            logger.debug("[PostProcessor] Constructed %d video results from unattached summaries",
-                         constructed_count)
+        doc_filtered = self._remove_attached_summaries(doc_reranked, visual_deduped)
 
         groups = {}
         if visual_deduped:
             groups["visual"] = visual_deduped
-        if doc_reranked:
-            groups["document"] = doc_reranked
+        if doc_filtered:
+            groups["document"] = doc_filtered
 
         merged = self._allocate_slots(groups, top_k)
-        self._compute_percentage_scores(merged)
+        self._convert_summaries_to_video(merged)
         logger.debug("[PostProcessor] Final merged results: %d", len(merged))
         return self._to_chroma_format(merged)
 
@@ -270,20 +233,62 @@ class PostProcessor:
         return best
 
     @staticmethod
-    def _split_summaries(doc_results: list[dict]) -> tuple[list[dict], list[dict]]:
-        """Split document results into video summaries and non-summaries.
-
-        A document is considered a video summary if its metadata contains
-        a ``summary_key``.  Returns ``(summaries, non_summaries)``.
-        """
-        summaries: list[dict] = []
-        non_summaries: list[dict] = []
+    def _remove_attached_summaries(doc_results: list[dict], visual_results: list[dict]) -> list[dict]:
+        """Remove summaries whose chunk_text is already attached to a visual frame."""
+        attached_texts = {
+            r["meta"].get("summary_text", "")
+            for r in visual_results
+            if r.get("meta", {}).get("summary_text")
+        }
+        filtered = []
+        removed_count = 0
         for r in doc_results:
-            if "summary_key" in r.get("meta", {}):
-                summaries.append(r)
+            if "summary_key" in r.get("meta", {}) and r["meta"].get("chunk_text", "") in attached_texts:
+                removed_count += 1
             else:
-                non_summaries.append(r)
-        return summaries, non_summaries
+                filtered.append(r)
+        if removed_count:
+            logger.debug("[PostProcessor] Removed %d attached summaries from doc group", removed_count)
+        return filtered
+
+    @staticmethod
+    def _convert_summaries_to_video(results: list[dict]) -> None:
+        """Convert remaining summary documents in the final result list to video results in-place.
+
+        Attached summaries are already removed before allocation, so every
+        summary here should be converted.  Any that cannot be converted
+        (missing file_key/bucket) are dropped.
+        """
+        converted_count = 0
+        remove_indices: list[int] = []
+        for i, r in enumerate(results):
+            meta = r.get("meta", {})
+            if "summary_key" not in meta:
+                continue
+            chunk_text = meta.get("chunk_text", "")
+            file_key = meta.get("file_key", "")
+            bucket = extract_bucket_name(meta.get("file_path", ""))
+            if not bucket or not file_key:
+                remove_indices.append(i)
+                continue
+            video_fp = file_key_to_path(file_key, bucket)
+            start_time = meta.get("start_time", 0)
+            end_time = meta.get("end_time", 0)
+            mid_time = start_time + (end_time - start_time) / 2
+            r["meta"] = {
+                "file_path": video_fp,
+                "type": "video",
+                "original_type": "constructed_from_summary",
+                "video_pin_second": mid_time,
+                "summary_text": chunk_text,
+                "reranker_score": r.get("reranker_score"),
+            }
+            converted_count += 1
+        for i in reversed(remove_indices):
+            results.pop(i)
+        if converted_count or remove_indices:
+            logger.debug("[PostProcessor] Summaries: %d converted to video, %d dropped (missing file_key)",
+                         converted_count, len(remove_indices))
 
     def _rerank_documents(self, query: str, doc_results: list[dict]) -> list[dict]:
         """Re-score documents with BAAI/bge-reranker-large cross-encoder.

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
@@ -279,7 +279,9 @@ class PostProcessor:
                 "file_path": video_fp,
                 "type": "video",
                 "original_type": "constructed_from_summary",
-                "video_pin_second": mid_time,
+                "video_pin_second": round(mid_time, 2),
+                "video_start_second": round(start_time, 2),
+                "video_end_second": round(end_time, 2),
                 "summary_text": chunk_text,
                 "reranker_score": r.get("reranker_score"),
             }


### PR DESCRIPTION
### Description

Video converted from summary will use summary score. This avoid comparing text-text(bge-small) distance to text-image(CLIP) distance.
Add `video_start_second` and `video_start_second` field for video results.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

