### PR TITLE
Enable host.docker.internal access in container networking

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-captioning/compose.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/compose.yaml
@@ -32,6 +32,8 @@ services:
     privileged: true
     tty: true
     entrypoint: [ "./run.sh" ]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       - mediamtx
       - mqtt-broker
@@ -39,8 +41,8 @@ services:
       - "${EVAM_HOST_PORT:-8040}:${EVAM_PORT:-8080}"
       - "8556:8554"
     environment:
-      - no_proxy=localhost,127.0.0.1,mediamtx,coturn,dlstreamer-pipeline-server,video-caption-service,collector,mqtt-broker,${no_proxy}
-      - NO_PROXY=localhost,127.0.0.1,mediamtx,coturn,dlstreamer-pipeline-server,video-caption-service,collector,mqtt-broker,${NO_PROXY}
+      - no_proxy=localhost,127.0.0.1,mediamtx,coturn,dlstreamer-pipeline-server,video-caption-service,collector,mqtt-broker,host.docker.internal,${no_proxy}
+      - NO_PROXY=localhost,127.0.0.1,mediamtx,coturn,dlstreamer-pipeline-server,video-caption-service,collector,mqtt-broker,host.docker.internal,${NO_PROXY}
       - http_proxy=$http_proxy
       - HTTP_PROXY=$http_proxy
       - https_proxy=$https_proxy


### PR DESCRIPTION
### Description

When running the application locally with USB cameras whose feeds are streamed via an RTSP server on the host machine, the dlstreamer-pipeline-server container cannot reach the host's RTSP endpoint because Docker containers are network-isolated from the host by default. This change adds extra_hosts: "host.docker.internal:host-gateway" to the container so it can resolve the host IP, and includes host.docker.internal in the no_proxy environment variable to ensure the connection bypasses any corporate proxy settings. With this fix, users can point the pipeline to rtsp://host.docker.internal:\<port>/\<path> and the container will correctly connect to the locally running RTSP server.

Fixes # N/A

### Any Newly Introduced Dependencies

None. This change only modifies Docker Compose configuration (extra_hosts and environment variables).

### How Has This Been Tested?

Tested locally by running an RTSP server on the host machine streaming USB camera feeds, then starting the application with docker compose up. Verified that dlstreamer-pipeline-server can successfully connect to the host RTSP stream using rtsp://host.docker.internal:\<port>/\<path> as the source URL. Before the fix, the container could not resolve or reach the host RTSP server; after the fix, the video pipeline starts and processes frames as expected.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

