### PR TITLE
Allow ROS librealsense2 package downgrade.

### DIFF
--- a/robotics-ai-suite/docs/robotics/gsg_robot/index.md
+++ b/robotics-ai-suite/docs/robotics/gsg_robot/index.md
@@ -577,13 +577,7 @@ access to commonly used robotic functionality with ease.
    echo "deb [signed-by=/etc/apt/keyrings/librealsenseai.gpg] https://librealsense.realsenseai.com/Debian/apt-repo `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/librealsense.list
    ```
 
-3. Update your APT repository caches after setting up the repository:
-
-   ```bash
-   sudo apt update
-   ```
-
-4. Configure APT preferences to pin the RealSense version:
+3. Configure APT preferences to pin the RealSense version:
 
    This step pins the RealSense SDK to validated versions that ensure compatibility with ROS 2 and the tutorials in this documentation. This prevents automatic upgrades during ``apt upgrade`` that could introduce compatibility issues.
 
@@ -610,12 +604,36 @@ access to commonly used robotic functionality with ease.
    ::::
    :::::
 
-5. Install the RealSense drivers and libraries:
+4. Update your APT repository caches after setting up the repository:
 
    ```bash
+   sudo apt update
+   ```
+
+5. Install the RealSense drivers and libraries:
+
+   :::::{tab-set}
+   ::::{tab-item} **Jazzy**
+   :sync: jazzy
+
+   ```bash
+   sudo apt-get install -y --allow-downgrades ros-jazzy-librealsense2
    sudo apt install librealsense2-dkms
    sudo apt install librealsense2
    ```
+
+   ::::
+   ::::{tab-item} **Humble**
+   :sync: humble
+
+   ```bash
+   sudo apt-get install -y --allow-downgrades ros-humble-librealsense2
+   sudo apt install librealsense2-dkms
+   sudo apt install librealsense2
+   ```
+
+   ::::
+   :::::
 
    > **Note:** The pinned version ensures stability across tutorials. To upgrade in the future, update the version in `/etc/apt/preferences.d/librealsense` before installing.
 

--- a/robotics-ai-suite/scripts/setup-robotics-humble.sh
+++ b/robotics-ai-suite/scripts/setup-robotics-humble.sh
@@ -48,38 +48,38 @@ cleanup_handler() {
 trap 'cleanup_handler' INT
 
 step "Removing previously installed packages..."
-run sudo apt remove -y --purge "*oneapi*" "ros-*" "*openvino*" "*gazebo*" "*realsense*" || :
-run sudo apt remove -y --purge "intel-igc*" || :
-run sudo apt remove -y --purge "*level-zero*" || :
-run sudo apt remove -y --purge "libze1" || :
+run sudo apt-get remove -y --purge "*oneapi*" "ros-*" "*openvino*" "*gazebo*" "*realsense*" || :
+run sudo apt-get remove -y --purge "intel-igc*" || :
+run sudo apt-get remove -y --purge "*level-zero*" || :
+run sudo apt-get remove -y --purge "libze1" || :
 sudo rm -f "/etc/apt/sources.list.d/*" || :
 
 step "Updating package lists and cleaning up..."
-run sudo apt update
-run sudo apt autoremove -y
+run sudo apt-get update
+run sudo apt-get autoremove -y
 
 step "Installing GCC 12..."
-run sudo apt install -y gcc-12 g++-12
+run sudo apt-get install -y gcc-12 g++-12
 run sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 --slave /usr/bin/g++ g++ /usr/bin/g++-12
 
 step "Installing prerequisites..."
-run sudo apt install -y software-properties-common
+run sudo apt-get install -y software-properties-common
 run sudo add-apt-repository -y universe
 
 step "Installing curl and fetching ROS 2 apt source..."
-run sudo apt update
-run sudo apt install curl -y
+run sudo apt-get update
+run sudo apt-get install curl -y
 export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
 echo "    ROS apt source version: ${ROS_APT_SOURCE_VERSION}"
 curl $CURL_QUIET -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
 run sudo dpkg -i /tmp/ros2-apt-source.deb
 
 step "Upgrading system packages..."
-run sudo apt update
+run sudo apt-get update
 run sudo apt upgrade -y
 
 step "Installing ROS 2 Humble Desktop (this may take a while)..."
-run sudo apt install -y ros-humble-desktop
+run sudo apt-get install -y ros-humble-desktop
 
 step "Configuring ROS 2 environment in ~/.bashrc..."
 echo "source /opt/ros/humble/setup.bash" >> ~/.bashrc
@@ -111,19 +111,19 @@ echo -e "\nPackage: ros-humble-openvino-wrapper-lib\nPin: version 2025.3.0*\nPin
 echo -e "\nPackage: ros-humble-openvino-node\nPin: version 2025.3.0*\nPin-Priority: 1002" | sudo tee -a /etc/apt/preferences.d/intel-openvino > /dev/null
 
 step "Updating package lists with new repositories..."
-run sudo apt update
+run sudo apt-get update
 
 step "Installing Level Zero GPU drivers..."
-run sudo apt install -y libze1 libze-intel-gpu1
+run sudo apt-get install -y libze1 libze-intel-gpu1
 
 step "Preparing OpenVINO installation (purging old config)..."
-run sudo apt install -y debconf-utils
-run sudo apt purge -y ros-humble-openvino-node || :
-run sudo apt autoremove -y || :
+run sudo apt-get install -y debconf-utils
+run sudo apt-get purge -y ros-humble-openvino-node || :
+run sudo apt-get autoremove -y || :
 echo PURGE | sudo debconf-communicate ros-humble-openvino-node > /dev/null 2>&1 || true
 
 step "Installing OpenVINO base package..."
-run sudo apt install -y openvino
+run sudo apt-get install -y openvino
 
 step "Installing ROS 2 OpenVINO node..."
 echo "ros-humble-openvino-node openvino-node/pip-proxy select ${OPENVINO_PROXY_SELECT}" | sudo debconf-set-selections
@@ -134,14 +134,15 @@ step "Adding Intel RealSense apt repository..."
 sudo mkdir -p /etc/apt/keyrings
 curl -sSf https://librealsense.realsenseai.com/Debian/librealsenseai.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/librealsenseai.gpg > /dev/null
 echo "deb [signed-by=/etc/apt/keyrings/librealsenseai.gpg] https://librealsense.realsenseai.com/Debian/apt-repo `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/librealsense.list > /dev/null
-run sudo apt update
-echo -e "Package: librealsense2*\nPin: version 2.55.1-0~realsense.12474\nPin-Priority: 1001\n" | sudo tee /etc/apt/preferences.d/librealsense > /dev/null
-echo -e "Package: ros-humble-librealsense2*\nPin: version 2.56.4*\nPin-Priority: 1001\n" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
-echo -e "Package: ros-humble-realsense2*\nPin: version 4.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: librealsense2*\nPin: version 2.55.1-0~realsense.12474\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: ros-humble-librealsense2*\nPin: version 2.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: ros-humble-realsense2*\nPin: version 4.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+run sudo apt-get update
 
 step "Installing Intel RealSense SDK..."
-run sudo apt install -y librealsense2-dkms
-run sudo apt install -y librealsense2
+run sudo apt-get install -y --allow-downgrades ros-humble-librealsense2
+run sudo apt-get install -y librealsense2-dkms
+run sudo apt-get install -y librealsense2
 
 step "Adding Gazebo apt repository..."
 run sudo apt-get update
@@ -152,13 +153,13 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 
 step "Installing ROS 2 Robotics SDK..."
 run sudo apt-get update
-run sudo apt install -y ros-humble-robotics-sdk
+run sudo apt-get install -y ros-humble-robotics-sdk
 
 step "Installing Collaborative SLAM (requires Intel Xe/UHD Graphics)..."
 run sudo apt-get install -y ros-humble-collab-slam-lze
 
 step "Installing Linux firmware..."
-run sudo apt install -y linux-firmware
+run sudo apt-get install -y linux-firmware
 
 step "Installing Intel NPU drivers and configuring permissions..."
 run sudo apt-get install -y intel-level-zero-npu intel-driver-compiler-npu

--- a/robotics-ai-suite/scripts/setup-robotics-jazzy.sh
+++ b/robotics-ai-suite/scripts/setup-robotics-jazzy.sh
@@ -48,34 +48,34 @@ cleanup_handler() {
 trap 'cleanup_handler' INT
 
 step "Removing previously installed packages..."
-run sudo apt remove -y --purge "*oneapi*" "ros-*" "intel-igc*" "*openvino*" "*gazebo*" "*realsense*" "*level-zero*" "libze1" || :
-run sudo apt remove -y --purge "intel-igc*" || :
-run sudo apt remove -y --purge "*level-zero*" || :
-run sudo apt remove -y --purge "libze1" || :
+run sudo apt-get remove -y --purge "*oneapi*" "ros-*" "intel-igc*" "*openvino*" "*gazebo*" "*realsense*" "*level-zero*" "libze1" || :
+run sudo apt-get remove -y --purge "intel-igc*" || :
+run sudo apt-get remove -y --purge "*level-zero*" || :
+run sudo apt-get remove -y --purge "libze1" || :
 sudo rm -f "/etc/apt/sources.list.d/*" || :
 
 step "Updating package lists and cleaning up..."
-run sudo apt update
-run sudo apt autoremove -y
+run sudo apt-get update
+run sudo apt-get autoremove -y
 
 step "Installing prerequisites..."
-run sudo apt install -y software-properties-common
+run sudo apt-get install -y software-properties-common
 run sudo add-apt-repository -y universe
 
 step "Installing curl and fetching ROS 2 apt source..."
-run sudo apt update
-run sudo apt install curl -y
+run sudo apt-get update
+run sudo apt-get install curl -y
 export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
 echo "    ROS apt source version: ${ROS_APT_SOURCE_VERSION}"
 curl $CURL_QUIET -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo ${UBUNTU_CODENAME:-${VERSION_CODENAME}})_all.deb"
 run sudo dpkg -i /tmp/ros2-apt-source.deb
 
 step "Upgrading system packages..."
-run sudo apt update
+run sudo apt-get update
 run sudo apt upgrade -y
 
 step "Installing ROS 2 Jazzy Desktop (this may take a while)..."
-run sudo apt install -y ros-jazzy-desktop
+run sudo apt-get install -y ros-jazzy-desktop
 
 step "Configuring ROS 2 environment in ~/.bashrc..."
 echo "source /opt/ros/jazzy/setup.bash" >> ~/.bashrc
@@ -107,19 +107,19 @@ echo -e "\nPackage: ros-jazzy-openvino-wrapper-lib\nPin: version 2025.3.0*\nPin-
 echo -e "\nPackage: ros-jazzy-openvino-node\nPin: version 2025.3.0*\nPin-Priority: 1002" | sudo tee -a /etc/apt/preferences.d/intel-openvino > /dev/null
 
 step "Updating package lists with new repositories..."
-run sudo apt update
+run sudo apt-get update
 
 step "Installing Level Zero GPU drivers..."
-run sudo apt install -y libze1 libze-intel-gpu1
+run sudo apt-get install -y libze1 libze-intel-gpu1
 
 step "Preparing OpenVINO installation (purging old config)..."
-run sudo apt install -y debconf-utils
-run sudo apt purge -y ros-jazzy-openvino-node || :
-run sudo apt autoremove -y || :
+run sudo apt-get install -y debconf-utils
+run sudo apt-get purge -y ros-jazzy-openvino-node || :
+run sudo apt-get autoremove -y || :
 echo PURGE | sudo debconf-communicate ros-jazzy-openvino-node > /dev/null 2>&1 || true
 
 step "Installing OpenVINO base package..."
-run sudo apt install -y openvino
+run sudo apt-get install -y openvino
 
 step "Installing ROS 2 OpenVINO node..."
 echo "ros-jazzy-openvino-node openvino-node/pip-proxy select ${OPENVINO_PROXY_SELECT}" | sudo debconf-set-selections
@@ -130,14 +130,15 @@ step "Adding Intel RealSense apt repository..."
 sudo mkdir -p /etc/apt/keyrings
 curl -sSf https://librealsense.realsenseai.com/Debian/librealsenseai.asc | gpg --dearmor | sudo tee /etc/apt/keyrings/librealsenseai.gpg > /dev/null
 echo "deb [signed-by=/etc/apt/keyrings/librealsenseai.gpg] https://librealsense.realsenseai.com/Debian/apt-repo `lsb_release -cs` main" | sudo tee /etc/apt/sources.list.d/librealsense.list > /dev/null
-run sudo apt update
-echo -e "Package: librealsense2*\nPin: version 2.56.5-0~realsense.17055\nPin-Priority: 1001\n" | sudo tee /etc/apt/preferences.d/librealsense > /dev/null
-echo -e "Package: ros-jazzy-librealsense2*\nPin: version 2.56.4*\nPin-Priority: 1001\n" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
-echo -e "Package: ros-jazzy-realsense2*\nPin: version 4.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: librealsense2*\nPin: version 2.56.5-0~realsense.17055\nPin-Priority: 1001" | sudo tee /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: ros-jazzy-librealsense2*\nPin: version 2.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+echo -e "\nPackage: ros-jazzy-realsense2*\nPin: version 4.56.4*\nPin-Priority: 1001" | sudo tee -a /etc/apt/preferences.d/librealsense > /dev/null
+run sudo apt-get update
 
 step "Installing Intel RealSense SDK..."
-run sudo apt install -y librealsense2-dkms
-run sudo apt install -y librealsense2
+run sudo apt-get install -y --allow-downgrades ros-jazzy-librealsense2
+run sudo apt-get install -y librealsense2-dkms
+run sudo apt-get install -y librealsense2
 
 step "Adding Gazebo apt repository..."
 run sudo apt-get update
@@ -150,13 +151,13 @@ run sudo apt-get update
 run sudo apt-get install -y gz-harmonic
 
 step "Installing ROS 2 Robotics SDK..."
-run sudo apt install -y ros-jazzy-robotics-sdk
+run sudo apt-get install -y ros-jazzy-robotics-sdk
 
 step "Installing Collaborative SLAM (requires Intel Xe/UHD Graphics)..."
 run sudo apt-get install -y ros-jazzy-collab-slam-lze
 
 step "Installing Linux firmware..."
-run sudo apt install -y linux-firmware
+run sudo apt-get install -y linux-firmware
 
 step "Installing Intel NPU drivers and configuring permissions..."
 run sudo apt-get install -y intel-level-zero-npu intel-driver-compiler-npu


### PR DESCRIPTION
### Description

Allow ROS librealsense2 package downgrade.
Use `apt-get` in scripts instead of `apt`

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Tested locally

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

