### PR TITLE
fix: add fallback default for runner_label on schedule trigger

### DIFF
--- a/.github/workflows/industrial-edge-insights-time-series-tests.yml
+++ b/.github/workflows/industrial-edge-insights-time-series-tests.yml
@@ -81,7 +81,7 @@ permissions: {}
 jobs:
   functional-tests:
     name: Functional Tests for Multimodal and TimeSeries
-    runs-on: ${{ inputs.runner_label }}
+    runs-on: ${{ inputs.runner_label || 'ubuntu-24.04' }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
### Description

When triggered by schedule (cron), the inputs context is empty so inputs.runner_label evaluates to empty string. Add || 'ubuntu-24.04' fallback consistent with how other inputs are handled in the workflow.

Agent-Logs-Url: https://github.com/vkb1/edge-ai-suites/sessions/28a28f08-c692-4921-bce7-dd0ad22e76d0


### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

This should work as it is working for other non input params 

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

