### PR TITLE
Content Search: upgrades the embedding models used for both document and visual search to support multilingual and cross-lingual capabilities

### DIFF
--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -439,7 +439,7 @@ content_search:
     port: 9990
     collection_name: "content-search"
     doc_embedding_device: "CPU"
-    visual_embedding_model: "CLIP/clip-vit-b-16"
+    visual_embedding_model: "CLIP/clip-xlm-roberta-base-vit-b-32"
     doc_embedding_model: "intfloat/multilingual-e5-small"
     frame_extract_interval: 30      # for video: extract a frame every N frames
     do_detect_and_crop: false        # for video/image: run object detection and crop before embedding

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -440,7 +440,7 @@ content_search:
     collection_name: "content-search"
     doc_embedding_device: "CPU"
     visual_embedding_model: "CLIP/clip-vit-b-16"
-    doc_embedding_model: "BAAI/bge-small-en-v1.5"
+    doc_embedding_model: "intfloat/multilingual-e5-small"
     frame_extract_interval: 30      # for video: extract a frame every N frames
     do_detect_and_crop: false        # for video/image: run object detection and crop before embedding
     document_parser:

--- a/education-ai-suite/smart-classroom/content_search/docs/dev_guide/file_ingest_and_retrieve/reranker.md
+++ b/education-ai-suite/smart-classroom/content_search/docs/dev_guide/file_ingest_and_retrieve/reranker.md
@@ -85,21 +85,22 @@ $$score = \sigma\bigl(k \cdot (cosine\\_sim - center)\bigr) \times 100$$
 
 where `cosine_sim = 1 - distance` (ChromaDB cosine distance is in [0, 2]).
 
-CLIP text-to-image and image-to-image similarities occupy very different ranges, so each query type uses its own sigmoid center:
+Text-to-image and image-to-image CLIP similarities occupy very different ranges, so each query type uses its own sigmoid steepness (`k`) and center. Parameters were calibrated on `xlm-roberta-base-ViT-B-32 / laion5b_s13b_b90k` (multilingual CLIP) using real test data with both English and Chinese queries.
 
-| Constant                       | Value  | Purpose                                             |
-| ------------------------------ | ------ | --------------------------------------------------- |
-| `VISUAL_SIGMOID_K`             | `15.0` | Steepness (shared)                                  |
-| `VISUAL_SIGMOID_CENTER_TEXT`   | `0.15` | Center for text-to-image queries (sim ~0.05-0.35)   |
-| `VISUAL_SIGMOID_CENTER_IMAGE`  | `0.70` | Center for image-to-image queries (sim ~0.5-0.95)   |
+| Constant                      | Value  | Purpose                                                         |
+| ----------------------------- | ------ | --------------------------------------------------------------- |
+| `VISUAL_SIGMOID_K_TEXT`       | `18.7` | Steepness for text-to-image (narrower sim range needs higher k) |
+| `VISUAL_SIGMOID_CENTER_TEXT`  | `0.14` | Center for text-to-image queries (sim ~0.10-0.24)               |
+| `VISUAL_SIGMOID_K_IMAGE`      | `8.1`  | Steepness for image-to-image (wider sim range needs lower k)    |
+| `VISUAL_SIGMOID_CENTER_IMAGE` | `0.52` | Center for image-to-image queries (sim ~0.33-1.0)               |
 
 Typical score ranges for relevant results:
 
 | Type                   | Relevant | Moderate | Irrelevant |
 | ---------------------- | -------- | -------- | ---------- |
 | Document               | 85-99    | 50-85    | 0-30       |
-| Visual text-to-image   | 80-95    | 30-80    | 0-20       |
-| Visual image-to-image  | 80-97    | 30-80    | 0-20       |
+| Visual text-to-image   | 75-90    | 40-75    | 5-30       |
+| Visual image-to-image  | 75-98    | 30-75    | 15-30      |
 
 ### 5. Drop attached summaries
 
@@ -149,7 +150,7 @@ Converts the flat result list back to ChromaDB nested format. Preserves the RRF 
 
 The system retrieves results from two fundamentally different modalities:
 
-- **Visual** (video frames, images) — scored by CLIP cosine distance, where good text-to-image matches typically have similarity 0.15-0.35.
+- **Visual** (video frames, images) — scored by multilingual CLIP (`xlm-roberta-base-ViT-B-32`) cosine distance, where good text-to-image matches typically have similarity 0.10-0.24.
 - **Documents** (text chunks) — scored by a cross-encoder reranker, producing logits that map to sigmoid scores of 85-99 for relevant results.
 
 These raw scores are **not comparable**. Sorting by raw score would push all documents above all visual results (or vice versa), regardless of actual relevance. A user searching for "Newton's first law" should see a relevant video clip alongside a relevant textbook passage, not ten text results followed by ten videos.

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/document_parser.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/document_parser.py
@@ -239,6 +239,8 @@ class DocumentParser:
                 )
             for _n in nodes:
                 _n.set_content(_clean_text(_n.get_content()))
+                _n.metadata.pop("filename", None)
+                _n.metadata.pop("file_directory", None)
             return nodes
         except Exception as e:
             raise RuntimeError(f"Failed to parse {file_path}: {str(e)}")
@@ -249,6 +251,13 @@ class DocumentParser:
         elements = partition(filename=file_path, **unstructured_kwargs)
         if not elements:
             return []
+
+        file_meta = {
+            k: v for k, v in elements[0].metadata.to_dict().items()
+            if k not in {"orig_elements", "page_number", "coordinates", "languages", "file_directory", "filename"}
+               and isinstance(v, (str, int, float, type(None)))
+        }
+        file_meta["file_path"] = file_path
 
         pages: Dict[int, list] = {}
         for el in elements:
@@ -265,12 +274,7 @@ class DocumentParser:
 
             doc = Document(
                 text=text,
-                metadata={
-                    "file_path": file_path,
-                    "page_number": page_num,
-                    "excluded_embed_metadata_keys": self.excluded_embed_metadata_keys,
-                    "excluded_llm_metadata_keys": self.excluded_llm_metadata_keys,
-                },
+                metadata={**file_meta, "page_number": page_num},
                 excluded_embed_metadata_keys=self.excluded_embed_metadata_keys,
                 excluded_llm_metadata_keys=self.excluded_llm_metadata_keys,
             )

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/embedding/registry.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/embedding/registry.py
@@ -27,6 +27,11 @@ CLIP_CONFIGS: Dict[str, Dict[str, Any]] = {
         "pretrained": "openai",
         "image_size": 224,
     },
+    "clip-xlm-roberta-base-vit-b-32": {
+        "model_name": "xlm-roberta-base-ViT-B-32",
+        "pretrained": "laion5b_s13b_b90k",
+        "image_size": 224,
+    },
     "clip-vit-l-14": {
         "model_name": "ViT-L-14",
         "pretrained": "datacomp_xl_s13b_b90k",

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/models.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/models.py
@@ -46,7 +46,7 @@ def get_document_embedding_model():
     if _document_embedding_model is None:
         from llama_index.embeddings.huggingface_openvino import OpenVINOEmbedding
 
-        doc_model_path = os.getenv("DOC_EMBEDDING_MODEL", "BAAI/bge-small-en-v1.5")
+        doc_model_path = os.getenv("DOC_EMBEDDING_MODEL", "intfloat/multilingual-e5-small")
         run_device = os.getenv("INGEST_DEVICE", "CPU")
 
         local_path = Path(os.getcwd()).parent / "models" / "openvino" / doc_model_path
@@ -55,12 +55,16 @@ def get_document_embedding_model():
             _document_embedding_model = OpenVINOEmbedding(
                 model_id_or_path=str(local_path),
                 device=run_device,
+                query_instruction="query: ",
+                text_instruction="passage: ",
             )
         else:
             logger.info(f"Converting document embedding model {doc_model_path} to OV IR and saving to {local_path}")
             _document_embedding_model = OpenVINOEmbedding(
                 model_id_or_path=doc_model_path,
                 device=run_device,
+                query_instruction="query: ",
+                text_instruction="passage: ",
             )
             local_path.mkdir(parents=True, exist_ok=True)
             _document_embedding_model._model.save_pretrained(str(local_path))

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/models.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/models.py
@@ -24,7 +24,7 @@ def get_visual_embedding_model():
     if _visual_embedding_model is None:
         from providers.file_ingest_and_retrieve.embedding import get_model_handler, EmbeddingModel
 
-        visual_model_name = os.getenv("VISUAL_EMBEDDING_MODEL", "CLIP/clip-vit-b-16")
+        visual_model_name = os.getenv("VISUAL_EMBEDDING_MODEL", "CLIP/clip-xlm-roberta-base-vit-b-32")
         logger.info(f"Initializing visual embedding model: {visual_model_name}")
 
         handler = get_model_handler(visual_model_name)

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/reranker.py
@@ -18,12 +18,11 @@ logger = logging.getLogger(__name__)
 
 RRF_K = 60  # RRF constant — higher means scores drop off more slowly with rank, increasing diversity
 
-# Sigmoid parameters for visual score rescaling: sigmoid(k * (sim - center)) * 100.
-# Text→image and image→image have very different similarity distributions, so each
-# query type needs its own center.
-VISUAL_SIGMOID_K = 15.0               # steepness (shared)
-VISUAL_SIGMOID_CENTER_TEXT = 0.15     # text→image: CLIP sim clusters ~0.05–0.35
-VISUAL_SIGMOID_CENTER_IMAGE = 0.70   # image→image: CLIP sim clusters ~0.5–0.95
+# Sigmoid params for visual score rescaling, calibrated on xlm-roberta-base-ViT-B-32.
+VISUAL_SIGMOID_K_TEXT = 18.7          # text→image
+VISUAL_SIGMOID_CENTER_TEXT = 0.14
+VISUAL_SIGMOID_K_IMAGE = 8.1          # image→image
+VISUAL_SIGMOID_CENTER_IMAGE = 0.52
 
 
 def _flatten_chroma_results(chroma_results: dict) -> list[dict]:
@@ -115,7 +114,7 @@ class PostProcessor:
         # Assign RRF scores by rank so distances field is consistent with text query path (higher = better)
         for rank, item in enumerate(trimmed):
             item["rrf_score"] = 1.0 / (RRF_K + rank)
-        self._compute_percentage_scores(trimmed, visual_sigmoid_center=VISUAL_SIGMOID_CENTER_IMAGE)
+        self._compute_percentage_scores(trimmed, visual_sigmoid_k=VISUAL_SIGMOID_K_IMAGE, visual_sigmoid_center=VISUAL_SIGMOID_CENTER_IMAGE)
         return self._to_chroma_format(trimmed)
 
 
@@ -427,19 +426,18 @@ class PostProcessor:
 
 
     @staticmethod
-    def _compute_percentage_scores(results: list[dict], visual_sigmoid_center: float = VISUAL_SIGMOID_CENTER_TEXT) -> None:
-        """Compute a 0-100% absolute relevance score for each result in-place.
-
-        - Documents (reranker_score present): sigmoid(reranker_score) * 100
-        - Visual (no reranker_score): sigmoid(k * (cosine_sim - center)) * 100
-          where cosine_sim = 1 - distance (ChromaDB cosine distance in [0, 2])
-        """
+    def _compute_percentage_scores(
+        results: list[dict],
+        visual_sigmoid_k: float = VISUAL_SIGMOID_K_TEXT,
+        visual_sigmoid_center: float = VISUAL_SIGMOID_CENTER_TEXT,
+    ) -> None:
+        """Assign 0-100 relevance score: sigmoid(reranker logit) for docs, sigmoid(k*(sim-center)) for visual."""
         for r in results:
             if r.get("reranker_score") is not None:
                 r["score"] = round(1.0 / (1.0 + math.exp(-r["reranker_score"])) * 100, 2)
             else:
                 similarity = 1.0 - r["distance"]
-                r["score"] = round(1.0 / (1.0 + math.exp(-VISUAL_SIGMOID_K * (similarity - visual_sigmoid_center))) * 100, 2)
+                r["score"] = round(1.0 / (1.0 + math.exp(-visual_sigmoid_k * (similarity - visual_sigmoid_center))) * 100, 2)
 
     @staticmethod
     def _to_chroma_format(results: list[dict]) -> dict:

--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/retriever.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/retriever.py
@@ -51,15 +51,15 @@ class ChromaRetriever:
         self.video_summary_id_map = video_summary_id_map if video_summary_id_map is not None else {}
         self._embed_lock = doc_embed_lock or threading.Lock()
 
-    def get_text_embedding(self, query):
+    def get_visual_query_embedding(self, query):
         embedding_tensor = self.visual_embedding_model.handler.encode_text(query)
         return embedding_tensor.cpu().numpy().tolist()
 
-    def get_document_embedding(self, text):
+    def get_document_query_embedding(self, query):
         if not self.document_embedding_model:
             raise RuntimeError("Document embedding model not available.")
         with self._embed_lock:
-            return self.document_embedding_model.get_text_embedding(text)
+            return self.document_embedding_model.get_query_embedding(query)
 
     def get_image_embedding(self, image_base64):
         img_data = base64.b64decode(image_base64)
@@ -120,13 +120,13 @@ class ChromaRetriever:
             raise ValueError("Provide only one of 'query' or 'image_base64', not both.")
 
         if query:
-            embedding = self.get_text_embedding(query)
-            document_embedding = self.get_document_embedding(query)
+            visual_embedding = self.get_visual_query_embedding(query)
+            document_embedding = self.get_document_query_embedding(query)
         else:
-            embedding = self.get_image_embedding(image_base64)
+            visual_embedding = self.get_image_embedding(image_base64)
 
-        if embedding is None:
-            raise Exception("Failed to get embedding for the input.")
+        if visual_embedding is None:
+            raise Exception("Failed to get visual embedding for the input.")
 
         where = self._build_where_clause(filters, list_filter_mode) if filters else None
 
@@ -136,7 +136,7 @@ class ChromaRetriever:
         # Search visual collection
         results = self.client.query(
             collection_name=self.visual_collection_name,
-            query_embeddings=embedding,
+            query_embeddings=visual_embedding,
             where=where,
             n_results=fetch_k,
         )


### PR DESCRIPTION
### Description

This pull request upgrades the embedding models used for both document and visual search to support multilingual and cross-lingual capabilities, refines the scoring and reranking logic for improved relevance across languages, and cleans up metadata handling and API naming for clarity. The changes ensure better support for non-English content and improve the quality and interpretability of search results.

**Embedding Model Upgrades:**

- Switched the visual embedding model from `CLIP/clip-vit-b-16` to `CLIP/clip-xlm-roberta-base-vit-b-32` (multilingual CLIP), and the document embedding model from `BAAI/bge-small-en-v1.5` to `intfloat/multilingual-e5-small`, both in config and model initialization. 
- Added `query_instruction` and `text_instruction` parameters to the document embedding model for correct input formatting.

**Scoring and Reranking Improvements:**

- Calibrated and updated sigmoid parameters for visual similarity scoring to match the new multilingual CLIP model, with separate steepness (`k`) and center values for text-to-image and image-to-image queries.

**Metadata and Parsing Adjustments:**

- Cleaned up metadata in parsed document nodes by removing duplicated `doc_filename` and `doc_file_directory`, and streamlined how file-level metadata is propagated to page-level chunks. 

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

