### PR TITLE
fix(multi-modal): HuBERT-ECG model conversion crash 

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-assets/requirements.txt
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-assets/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-tqdm
+tqdm==4.67.1
 
 # TensorFlow (needed to load Keras HDF5 rPPG model for conversion)
 tensorflow-cpu==2.16.1
@@ -9,15 +9,16 @@ tensorflow-cpu==2.16.1
 torch==2.8.0
 
 # Hugging Face Transformers for HuBERT-ECG backbone
-transformers>=4.45.0
+# Pinned: unpinned transformers>=4.45 caused RuntimeError during
+# ov.convert_model (torch.jit.trace) due to new attention masking.
+transformers==4.51.3
 
 # Conversion deps
-onnx>=1.14.0
-onnxscript
-PyYAML
+onnx==1.17.0
+onnxscript==0.2.5
+PyYAML==6.0.2
 
 # OpenVINO (model conversion)
-# Use the runtime package; dev tools are not needed for these scripts
-openvino>=2024.6.0,<2025.0
+openvino==2024.6.0
 
 

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-assets/scripts/ecg_model_convert.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/patient-monitoring-assets/scripts/ecg_model_convert.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import logging
+import tempfile
 from pathlib import Path
 
 import torch
@@ -81,12 +82,28 @@ def main() -> int:
     logger.info("Converting HuBERT-ECG to OpenVINO IR at %s", ov_model_path)
     with torch.no_grad():
         example_input = torch.zeros([1, 5000], dtype=torch.float32)
-        ov_model = ov.convert_model(
+
+        # Export via ONNX to avoid torch.jit.trace incompatibility with
+        # transformers>=4.45 attention masking (q_length/q_offset).
+        with tempfile.NamedTemporaryFile(suffix=".onnx", delete=False) as tmp:
+            onnx_path = Path(tmp.name)
+
+        torch.onnx.export(
             hubert,
-            example_input=example_input,
-            input=[1, 5000],
+            (example_input,),
+            str(onnx_path),
+            input_names=["input_values"],
+            output_names=["last_hidden_state"],
+            dynamic_axes={
+                "input_values": {0: "batch", 1: "seq_len"},
+                "last_hidden_state": {0: "batch"},
+            },
+            opset_version=17,
         )
+
+        ov_model = ov.convert_model(str(onnx_path))
         ov.save_model(ov_model, ov_model_path)
+        onnx_path.unlink(missing_ok=True)
 
     logger.info("HuBERT-ECG OpenVINO IR saved: %s", ov_model_path)
     return 0


### PR DESCRIPTION
https://jira.devtools.intel.com/browse/ITEP-91288
Fix:
- Use torch.onnx.export -> ov.convert_model(onnx) path instead of direct PyTorch -> OpenVINO conversion that relies on JIT tracing
- Pin all dependencies to exact versions to prevent future breakage from upstream PyPI releases

Tested: Verified end-to-end conversion produces valid IR files (hubert_ecg_small_fp16.xml + .bin) on Intel Meteor Lake.

Fixes: patient-monitoring-assets exit 1 blocking all downstream services (ai-ecg, 3dpose-estimation, rppg, ui).


