### PR TITLE
[DOCS] extend branch checkout by 26.0 for all get started guides

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started.md
@@ -15,7 +15,7 @@ If not, follow the [installation guide for docker engine](https://docs.docker.co
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started/deploy-multiple-instances-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started/deploy-multiple-instances-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -766,8 +766,8 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    kubectl cp resources/pallet-defect-detection/models/* $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
    ```
 
-4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline. 
-   
+4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline.
+
    Below is an example for pallet-defect-detection. Please modify the payload for other sample applications.
 
    ```json
@@ -796,7 +796,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ]
    ```
 
-5. Start the pipeline with the above payload. 
+5. Start the pipeline with the above payload.
 
    Below is an example for starting an instance for pallet-defect-detection:
 
@@ -819,7 +819,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Copy the new model to the `dlstreamer-pipeline-server` pod to make it available for application while launching pipeline.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n <INSTANCE_NAME> -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
@@ -833,7 +833,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ```
 
 9. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline with this new model.
-   
+
    Below is an example for pallet-defect-detection. Please modify the payload for other sample applications.
 
    ```json

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/get-started/deploy-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -171,7 +171,7 @@
    ```
 
    > **Note:**- This would start the pipeline. You can view the inference stream on WebRTC by opening a browser and navigating to https://<HOST_IP>:30443/mediamtx/pdd/ for Pallet Defect Detection. If you're running helm using an `NGINX_HTTPS_PORT` other than the default 30443, replace `<HOST_IP>` with `<HOST_IP>:<NGINX_HTTPS_PORT>`.
-   
+
    ### Starting GPU and NPU based pipelines
    For GPU and NPU based pipelines, ensure you have done the necessary [setup](../how-to-guides/use-gpu-for-inference.md#deploying-with-helm) from here, and start the respective pipelines as following.
 
@@ -352,7 +352,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    }'
    ```
 
-7. Go to MinIO console on `https://<HOST_IP>:30443/minio/` and login with `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` provided in `helm/values.yaml` file. After logging into console, you can go to `ecgdemo` bucket and check the frames stored. 
+7. Go to MinIO console on `https://<HOST_IP>:30443/minio/` and login with `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` provided in `helm/values.yaml` file. After logging into console, you can go to `ecgdemo` bucket and check the frames stored.
 >Note: If you're running helm using an NGINX_HTTPS_PORT other than the default 30443, replace 30443 with <NGINX_HTTPS_PORT>.
 
    ![S3 minio image storage](../_assets/s3-minio-storage.png)
@@ -434,7 +434,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Copy the new model to the `dlstreamer-pipeline-server` pod to make it available for application while launching pipeline.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n apps -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n apps
@@ -473,11 +473,11 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
        }
    ]
 
-10. View the WebRTC streaming on `https://<HOST_IP>:30443/mediamtx/<peer-str-id>/` by replacing `<peer-str-id>` with the value used in the original cURL command to start the pipeline. 
+10. View the WebRTC streaming on `https://<HOST_IP>:30443/mediamtx/<peer-str-id>/` by replacing `<peer-str-id>` with the value used in the original cURL command to start the pipeline.
 >Note: If you're running helm using an `NGINX_HTTPS_PORT` other than the default 30443, replace `<HOST_IP>` with `<HOST_IP>:<NGINX_HTTPS_PORT>`.
 
    ![WebRTC streaming](../_assets/webrtc-streaming.png)
-   
+
 ## Troubleshooting
 
 - [Troubleshooting Guide](../troubleshooting.md)

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/run-multiple-apps.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/run-multiple-apps.md
@@ -22,7 +22,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 1. Clone the **edge-ai-suites** repository and navigate to the `industrial-edge-insights-vision` directory:
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -53,7 +53,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 
    > **Note:** A sample configuration file `sample_config.yml` is provided to help users understand the multi-instance setup and get started. This configuration defines three example instances with identifiers: pdd1, pdd2, and weld1. The accompanying sample scripts utilize these identifiers to perform operations on individual application instances.
 
-3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml. 
+3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml.
 
    For the example above, modify the envs for pallet-defect-detection and weld-porosity i.e. env_pallet-defect-detection and .env_weld-porosity
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started.md
@@ -15,7 +15,7 @@ If not, follow the [installation guide for docker engine](https://docs.docker.co
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites.git
+    git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
     cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
     ```
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started/deploy-multiple-instances-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started/deploy-multiple-instances-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -765,8 +765,8 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    kubectl cp  resources/pcb-anomaly-detection/models/* $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
    ```
 
-4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline. 
-   
+4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline.
+
    Below is an example for pcb-anomaly-detection. Please modify the payload for other sample applications.
 
    ```json
@@ -795,7 +795,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ]
    ```
 
-5. Start the pipeline with the above payload. 
+5. Start the pipeline with the above payload.
 
    Below is an example for starting an instance for pcb-anomaly-detection:
 
@@ -818,7 +818,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Copy the new model to the `dlstreamer-pipeline-server` pod to make it available for application while launching pipeline.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n <INSTANCE_NAME> -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
@@ -832,7 +832,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ```
 
 9. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline with this new model.
-   
+
    Below is an example for pcb-anomaly-detection. Please modify the payload for other sample applications.
 
    ```json

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/get-started/deploy-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -164,10 +164,10 @@
    > **Note:** This would start the pipeline. You can view the inference stream on WebRTC by
    > opening a browser and navigating to `https://<HOST_IP>:30443/mediamtx/anomaly/` for PCB Anomaly Detection.
    > If you're running helm using an NGINX_HTTPS_PORT other than the default 30443, replace 30443 with <NGINX_HTTPS_PORT>.
-   
+
    ### Starting GPU and NPU based pipelines
    For GPU and NPU based pipelines, ensure you have done the necessary [setup](../how-to-guides/use-gpu-for-inference.md#deploying-with-helm) from here, and start the respective pipelines as following.
-   
+
       **For GPU-based pipelines:**
 
       ```sh
@@ -344,7 +344,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    }'
    ```
 
-7. Go to MinIO console on `https://<HOST_IP>:30443/minio/` and login with `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` provided in `helm/values.yaml` file. After logging into console, you can go to `ecgdemo` bucket and check the frames stored. 
+7. Go to MinIO console on `https://<HOST_IP>:30443/minio/` and login with `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` provided in `helm/values.yaml` file. After logging into console, you can go to `ecgdemo` bucket and check the frames stored.
 >Note: If you're running helm using an NGINX_HTTPS_PORT other than the default 30443, replace 30443 with <NGINX_HTTPS_PORT>.
 
    ![S3 minio image storage](../_assets/s3-minio-storage.png)
@@ -426,7 +426,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Copy the new model to the `dlstreamer-pipeline-server` pod to make it available for application while launching pipeline.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n apps -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n apps
@@ -467,7 +467,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ]
    ```
 
-10. View the WebRTC streaming on `https://<HOST_IP>:30443/mediamtx/<peer-str-id>/` by replacing `<peer-str-id>` with the value used in the original cURL command to start the pipeline. 
+10. View the WebRTC streaming on `https://<HOST_IP>:30443/mediamtx/<peer-str-id>/` by replacing `<peer-str-id>` with the value used in the original cURL command to start the pipeline.
 >Note: If you're running helm using an `NGINX_HTTPS_PORT` other than the default 30443, replace `<HOST_IP>` with `<HOST_IP>:<NGINX_HTTPS_PORT>`.
 
    ![WebRTC streaming](../_assets/webrtc-streaming.png)

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/how-to-guides/run-multiple-apps.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pcb-anomaly-detection/how-to-guides/run-multiple-apps.md
@@ -22,7 +22,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 1. Clone the **edge-ai-suites** repository and navigate to the `industrial-edge-insights-vision` directory:
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -53,7 +53,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 
    > **Note:** A sample configuration file `sample_config.yml` is provided to help users understand the multi-instance setup and get started. This configuration defines three example instances with identifiers: pdd1, pdd2, and weld1. The accompanying sample scripts utilize these identifiers to perform operations on individual application instances.
 
-3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml. 
+3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml.
 
    For the example above, modify the envs for pcb-anomaly-detection and weld-porosity i.e. env_pcb-anomaly-detection and .env_weld-porosity
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started.md
@@ -15,7 +15,7 @@ If not, follow the [installation guide for docker engine](https://docs.docker.co
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites.git
+    git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
     cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
     ```
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started/deploy-multiple-instances-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started/deploy-multiple-instances-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -774,7 +774,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
     kubectl cp resources/weld-porosity/models/* $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
    ```
 
-4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline. 
+4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline.
 
    ```json
     [
@@ -798,7 +798,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
     ]
    ```
 
-5. Start the pipeline with the above payload. 
+5. Start the pipeline with the above payload.
 
    ```sh
    ./sample_start.sh helm -i <INSTANCE_NAME> -p weld_porosity_classification_mlops
@@ -832,7 +832,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ```
 
 9. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline with this new model.
-   
+
    Below is an example for weld-porosity-classification. Please modify the payload for other sample applications.
 
    ```json

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/get-started/deploy-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -161,7 +161,7 @@
 
    > **Note:**- This would start the pipeline. You can view the inference stream on WebRTC by opening a browser and navigating to https://<HOST_IP>:30443/mediamtx/weld/
    >If you're running helm using an `NGINX_HTTPS_PORT` other than the default 30443, replace `<HOST_IP>` with `<HOST_IP>:<NGINX_HTTPS_PORT>`.
-   
+
    ### Starting GPU and NPU based pipelines
    For GPU and NPU based pipelines, ensure you have done the necessary [setup](../how-to-guides/use-gpu-for-inference.md#deploying-with-helm) from here, and start the respective pipelines as following.
 
@@ -421,7 +421,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Run the following curl command to upload the local model.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n apps -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n apps

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/how-to-guides/run-multiple-apps.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/weld-porosity/how-to-guides/run-multiple-apps.md
@@ -22,7 +22,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 1. Clone the **edge-ai-suites** repository and navigate to the `industrial-edge-insights-vision` directory:
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -53,7 +53,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 
    > **Note:** A sample configuration file `sample_config.yml` is provided to help users understand the multi-instance setup and get started. This configuration defines three example instances with identifiers: pdd1, pdd2, and weld1. The accompanying sample scripts utilize these identifiers to perform operations on individual application instances.
 
-3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml. 
+3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml.
 
    For the example above, modify the envs for weld-porosity and pallet-defect-detection i.e. env_weld-porosity and .env_pallet-defect-detection
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started.md
@@ -15,7 +15,7 @@ If not, follow the [installation guide for docker engine](https://docs.docker.co
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started/deploy-multiple-instances-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started/deploy-multiple-instances-with-helm.md
@@ -14,7 +14,7 @@
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
 
    ```sh
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -780,8 +780,8 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
     kubectl cp resources/worker-safety-gear-detection/models/* $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n <INSTANCE_NAME>
    ```
 
-4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline. 
-   
+4. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline.
+
    Below is an example for worker-safety-gear-detection. Please modify the payload for other sample applications.
 
    ```json
@@ -810,7 +810,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
     ]
    ```
 
-5. Start the pipeline with the above payload. 
+5. Start the pipeline with the above payload.
 
    Below is an example for starting an instance for worker-safety-gear-detection:
 
@@ -846,7 +846,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
    ```
 
 9. Modify the payload in `helm/temp_apps/<SAMPLE_APP>/<INSTANCE_NAME>/payload.json` to launch an instance for the mlops pipeline with this new model.
-   
+
    Below is an example for worker-safety-gear-detection. Please modify the payload for other sample applications.
 
    ```json

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/get-started/deploy-with-helm.md
@@ -14,7 +14,7 @@
 
 1. Clone the **edge-ai-suites** repository and change into industrial-edge-insights-vision directory. The directory contains the utility scripts required in the instructions that follows.
     ```sh
-    git clone https://github.com/open-edge-platform/edge-ai-suites.git
+    git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
     cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
     ```
 2. Set app specific values.yaml file.
@@ -159,7 +159,7 @@
    > **Note:** This would start the pipeline. You can view the inference stream on WebRTC by
    > opening a browser and navigating to `https://<HOST_IP>:30443/mediamtx/worker_safety/` for Worker Safety gear detection.
    > If you're running helm using an NGINX_HTTPS_PORT other than the default 30443, replace 30443 with <NGINX_HTTPS_PORT>.
-   
+
    ### Starting GPU and NPU based pipelines
    For GPU and NPU based pipelines, ensure you have done the necessary [setup](../how-to-guides/use-gpu-for-inference.md#deploying-with-helm) from here, and start the respective pipelines as following.
 
@@ -419,7 +419,7 @@ Applications can take advantage of S3 publish feature from DL Streamer Pipeline 
 7. Run the following curl command to upload the local model.
 
    ```sh
-   
+
    POD_NAME=$(kubectl get pods -n apps -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep deployment-dlstreamer-pipeline-server | head -n 1)
 
    kubectl cp new-model $POD_NAME:/home/pipeline-server/resources/models/ -c dlstreamer-pipeline-server -n apps

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/run-multiple-apps.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/worker-safety-gear-detection/how-to-guides/run-multiple-apps.md
@@ -22,7 +22,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 1. Clone the **edge-ai-suites** repository and navigate to the `industrial-edge-insights-vision` directory:
 
    ```bash
-   git clone https://github.com/open-edge-platform/edge-ai-suites.git
+   git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
    cd edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/
    ```
 
@@ -53,7 +53,7 @@ This tutorial demonstrates how to simultaneously deploy and manage multiple indu
 
    > **Note:** A sample configuration file `sample_config.yml` is provided to help users understand the multi-instance setup and get started. This configuration defines three example instances with identifiers: pdd1, pdd2, and weld1. The accompanying sample scripts utilize these identifiers to perform operations on individual application instances.
 
-3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml. 
+3. Edit the environment variables below in `.env_<SAMPLE_APP>` files for all sample apps present in config.yml.
 
    For the example above, modify the envs for worker-safety-gear-detection and pallet-defect-detection i.e. env_worker-safety-gear-detection and .env_pallet-defect-detection
 

--- a/metro-ai-suite/image-based-video-search/docs/user-guide/get-started.md
+++ b/metro-ai-suite/image-based-video-search/docs/user-guide/get-started.md
@@ -19,7 +19,7 @@ By following this guide, you will learn how to:
 1. **Clone the Repository and update `.env` file**:
     - Create and navigate to directory:
       ```bash
-        git clone https://github.com/open-edge-platform/edge-ai-suites.git
+        git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
         cd edge-ai-suites/metro-ai-suite/image-based-video-search
       ```
 
@@ -127,19 +127,19 @@ By following this guide, you will learn how to:
 
         if [ ! -e "src/dlstreamer-pipeline-server/models/public/yolo11s/FP16/yolo11s.xml" ]; then
           for attempt in 1 2 3; do
-            
+
             if /home/dlstreamer/dlstreamer/samples/download_public_models.sh yolo11s coco128; then
-              
+
               break
             else
-              
+
               sleep 2
             fi
           done
         fi
         '@
 
-      
+
       ```
 
       </details>

--- a/metro-ai-suite/image-based-video-search/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/image-based-video-search/docs/user-guide/get-started/deploy-with-helm.md
@@ -37,13 +37,13 @@ Before You Begin, ensure the following:
     ```bash
     cd image-based-video-search
     ```
-    
+
 ## Steps to Deploy
 
 1. **Clone the repo**:
   - Clone the repo and go to helm directory
     ```bash
-    git clone https://github.com/open-edge-platform/edge-ai-suites.git
+    git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
     cd edge-ai-suites/metro-ai-suite/image-based-video-search/chart
     ```
 

--- a/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/docs/user-guide/get-started.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/docs/user-guide/get-started.md
@@ -22,7 +22,7 @@ Enable running docker without "sudo": [Post Install](https://docs.docker.com/eng
 1. **Clone the Repository**:
    - Run:
      ```bash
-     git clone https://github.com/open-edge-platform/edge-ai-suites.git
+     git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
      cd edge-ai-suites/metro-ai-suite/metro-vision-ai-app-recipe/
      ```
 

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/get-started.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/get-started.md
@@ -29,7 +29,7 @@ To get started:
 1. **Clone the Repository**:
    - Run:
      ```bash
-     git clone https://github.com/open-edge-platform/edge-ai-suites.git
+     git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
      cd edge-ai-suites/metro-ai-suite/metro-vision-ai-app-recipe/
      ```
 

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/docs/user-guide/get-started.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/docs/user-guide/get-started.md
@@ -32,7 +32,7 @@ By following this guide, you will learn how to:
 1. **Clone the Repository**:
    - Run:
      ```bash
-     git clone https://github.com/open-edge-platform/edge-ai-suites.git
+     git clone https://github.com/open-edge-platform/edge-ai-suites.git -b release-2026.0.0
      cd edge-ai-suites/metro-ai-suite/metro-vision-ai-app-recipe/
      ```
 

--- a/robotics-ai-suite/docs/embodied/openvino_optimization.rst
+++ b/robotics-ai-suite/docs/embodied/openvino_optimization.rst
@@ -3,7 +3,7 @@
 OpenVINO™ Optimization of Robotics VLA Model Pi0.5
 ##################################################
 
-This example shows how to optimize the Vision-Language-Action (VLA) model Pi0.5 with Intel® OpenVINO™, compress model weights to INT8 and benchmark using the OpenVINO benchmark_app tool. 
+This example shows how to optimize the Vision-Language-Action (VLA) model Pi0.5 with Intel® OpenVINO™, compress model weights to INT8 and benchmark using the OpenVINO benchmark_app tool.
 
 What Steps VLA Models Perform
 =============================
@@ -24,12 +24,12 @@ Overview
 This tutorial covers:
 
 - Converting the Pi0.5 model from PyTorch to ONNX
-- Exporting the ONNX model to OpenVINO intermediate representation 
+- Exporting the ONNX model to OpenVINO intermediate representation
 - Compressing model weights to INT8 using NNCF
 - Benchmarking the model using the OpenVINO benchmark tool
 - Validating the optimized model outputs
 
-Source Code 
+Source Code
 ===========
 
 The source code for this sample can be found here: `VLA-Pi0.5-OpenVINO <https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.0.0/robotics-ai-suite/pipelines/vla-pi0.5-openvino>`_
@@ -44,8 +44,8 @@ Environment and Model Setup
       sudo apt install python3-venv
       python3 -m venv pi05_env
       source pi05_env/bin/activate
-        
-#. Install LeRobot from source with the following command:  
+
+#. Install LeRobot from source with the following command:
 
    .. code-block:: bash
 
@@ -53,15 +53,15 @@ Environment and Model Setup
       cd lerobot
       pip install -e ".[pi]"
 
-#. Install additional dependencies including OpenVINO and NNCF: 
-   
+#. Install additional dependencies including OpenVINO and NNCF:
+
    .. code-block:: bash
 
       pip install onnx==1.20.0 openvino==2025.4.0 nncf==2.19.0
-       
+
 #. Within the LeRobot Pi0.5 source code, there are some operations which are not supported by ONNX and must be modified to ensure successful model conversion.
-   
-   Navigate to the ``modeling_pi05.py`` file found at ``lerobot/src/lerobot/policies/pi05/modeling_pi05.py`` and find the ``sample_noise()`` method as shown below.  This method samples from a normal distribution which will cause the ONNX conversion to fail. 
+
+   Navigate to the ``modeling_pi05.py`` file found at ``lerobot/src/lerobot/policies/pi05/modeling_pi05.py`` and find the ``sample_noise()`` method as shown below.  This method samples from a normal distribution which will cause the ONNX conversion to fail.
 
    .. code-block:: python
 
@@ -73,7 +73,7 @@ Environment and Model Setup
               dtype=torch.float32,
               device=device,
           )
-            
+
    Now, modify this method set generated noise vector to instead initialize noise vector as zeros as shown below:
 
    .. code-block:: python
@@ -98,12 +98,12 @@ Environment and Model Setup
 
       def sample_time(self, bsize, device):
           time = torch.full((bsize,), 1.5 / (1.5 + 1.0), device=device, dtype=torch.float32)  # Beta mean
-          time = time * 0.999 + 0.001        
+          time = time * 0.999 + 0.001
           return time.to(dtype=torch.float32, device=device)
 
 .. _pi05_model_conversion:
 
-Model Conversion and OpenVINO™ Optimization 
+Model Conversion and OpenVINO™ Optimization
 ===========================================
 
 #. Clone the edge-ai-suites repository and then run the :file:`convert_pytorch_onnx.py` script. This will download the HuggingFace Pi0.5 model taken from `here <https://huggingface.co/lerobot/pi05_base>`_ and will convert it to ONNX using the ``torch.onnx.export`` method.
@@ -111,41 +111,41 @@ Model Conversion and OpenVINO™ Optimization
    .. code-block:: bash
 
       cd ..
-      git clone https://github.com/open-edge-platform/edge-ai-suites
+      git clone https://github.com/open-edge-platform/edge-ai-suites -b release-2026.0.0
       cd edge-ai-suites/robotics-ai-suite/pipelines/vla-pi0.5-openvino
       python convert_pytorch_onnx.py
 
-#. Next, run the :file:`onnx_to_ov_ir.py` script. This will then generate the OV IR form of the model. 
-   
+#. Next, run the :file:`onnx_to_ov_ir.py` script. This will then generate the OV IR form of the model.
+
    .. code-block:: bash
 
       python onnx_to_ov_ir.py
 
    The snippet below shows how in this script the ONNX representation of the model is converted to OpenVINO using the ``openvino.convert_model`` method:
-  
+
    .. code-block:: python
 
       ov_model = ov.convert_model("pi05_onnx/pi05.onnx")
-    
+
 #. Optionally, to compress the model to FP16 modify the ``openvino.save_model`` method in the :file:`onnx_to_ov_ir.py` by setting ``compress_to_fp16=True``:
 
    .. code-block:: python
 
-      ov.save_model(ov_model, 
-                  output_model=f"{output_dir}/model.xml", 
-                  compress_to_fp16=True) 
+      ov.save_model(ov_model,
+                  output_model=f"{output_dir}/model.xml",
+                  compress_to_fp16=True)
 
-#. Run the :file:`nncf_int8_compression.py` file to quantize the OpenVINO Pi0.5 model to INT8. 
-   
+#. Run the :file:`nncf_int8_compression.py` file to quantize the OpenVINO Pi0.5 model to INT8.
+
    The snippet below shows how the uncompressed OpenVINO model is compressed to INT8 using Intel Neural Network Compression (NNCF):
 
    .. code-block:: python
 
       from nncf import compress_weights
-      compression_mode = CompressWeightsMode.INT8_ASYM 
+      compression_mode = CompressWeightsMode.INT8_ASYM
       uncompressed_model = core.read_model(model=model_xml_path)
       compressed_model = compress_weights(
-          model=uncompressed_model, 
+          model=uncompressed_model,
           mode=compression_mode,
           all_layers=True
       )


### PR DESCRIPTION
### Description
By a request to align clone commands in get started guides, so that the cloned branch is the release one and not main.