### PR TITLE
fix(mdpnp): upgrade JDK from 17 to 25 to match submodule requirements

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/mdpnp/Dockerfile
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/mdpnp/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Stage 1: Builder
 ############################
-FROM eclipse-temurin:17-jdk AS builder
+FROM eclipse-temurin:25-jdk AS builder
 
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
@@ -48,7 +48,7 @@ RUN ./gradlew --no-daemon --info :interop-lab:demo-apps:makeFlatRuntime
 ############################
 # Stage 2: Runtime
 ############################
-FROM eclipse-temurin:17-jre
+FROM eclipse-temurin:25-jre
 
 # Create non-root user
 RUN useradd -m mdpnpuser


### PR DESCRIPTION
The mdpnp submodule now sets JAVA_VERSION_SOURCE=25 and uses Gradle 9.0 which requires JDK 21+. The Dockerfile was still using eclipse-temurin:17 causing 'error: invalid source release: 25' during build.

Fixes: ITEP-91511 https://jira.devtools.intel.com/browse/ITEP-91511



