### PR TITLE
fix(ui): ActionCard display when patient undetected

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/ActionCard.tsx
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/ActionCard.tsx
@@ -3,6 +3,7 @@ import type { ActionData } from '../../types/nicu';
 
 interface ActionCardProps {
   action: ActionData;
+  patientDetected?: boolean;
 }
 
 const MOTION_COLORS: Record<string, string> = {
@@ -16,7 +17,7 @@ const MOTION_COLORS: Record<string, string> = {
 // Hold movement state for this many ms so the user can read it
 const STICKY_HOLD_MS = 2000;
 
-const ActionCard: React.FC<ActionCardProps> = ({ action }) => {
+const ActionCard: React.FC<ActionCardProps> = ({ action, patientDetected = true }) => {
   const isValid = action.status === 'valid';
   const isError = action.status === 'error';
   const motionLevel = action.motion_level || 'unknown';
@@ -56,14 +57,14 @@ const ActionCard: React.FC<ActionCardProps> = ({ action }) => {
     cardMod = 'nicu-det-card--off';
     pillMod = 'nicu-det-pill--off';
     pillText = '✗ ERR';
-    subText = 'Error';
+    subText = patientDetected ? 'Action detection unavailable' : 'No patient detected';
     confColor = '#999';
     confValue = 0;
   } else if (!isValid || isStill) {
     cardMod = 'nicu-det-card--on';
     pillMod = 'nicu-det-pill--on';
     pillText = 'STILL';
-    subText = 'Patient still · No activity';
+    subText = patientDetected ? 'Patient still · No activity' : 'No patient detected';
     confColor = MOTION_COLORS.still;
     confValue = action.top_confidence;
   } else if (withinHold && sticky) {

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/NicuPanel.tsx
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/NicuPanel.tsx
@@ -85,7 +85,7 @@ const NicuPanel: React.FC<NicuPanelProps> = ({ expanded = false }) => {
                 detail={caretakerDetail}
               />
               <LatchStatusCard latch={nicu.latch} />
-              <ActionCard action={nicu.action} />
+              <ActionCard action={nicu.action} patientDetected={nicu.patient.detected} />
             </div>
 
             {/* rPPG — always below, never expandable */}
@@ -122,7 +122,7 @@ const NicuPanel: React.FC<NicuPanelProps> = ({ expanded = false }) => {
                 detail={caretakerDetail}
               />
               <LatchStatusCard latch={nicu.latch} />
-              <ActionCard action={nicu.action} />
+              <ActionCard action={nicu.action} patientDetected={nicu.patient.detected} />
             </div>
 
             <span className="nicu-section-label">Vital Signs</span>


### PR DESCRIPTION
- Add patientDetected prop to ActionCard component
- Show 'No patient detected' when patient/caregiver both unidentifiable
- Show 'Action detection unavailable' for model errors when patient present
- Pass patient.detected from NicuPanel to ActionCard
- Fixes misleading 'Patient still – No Activity' message when no detections


