### PR TITLE
[Metro-vision-ai-recipe] Updated Loitering detection video links update in helm charts

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/helm-chart/templates/dlstreamer-pipeline-server.yaml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/helm-chart/templates/dlstreamer-pipeline-server.yaml
@@ -56,10 +56,10 @@ spec:
         - -c
         - |
           mkdir -p /tmp/videos
-          curl -L https://github.com/intel/metro-ai-suite/raw/refs/heads/videos/videos/VIRAT_S_000101.mp4 -o /tmp/videos/VIRAT_S_000101.mp4
-          curl -L https://github.com/intel/metro-ai-suite/raw/refs/heads/videos/videos/VIRAT_S_000102.mp4 -o /tmp/videos/VIRAT_S_000102.mp4
-          curl -L https://github.com/intel/metro-ai-suite/raw/refs/heads/videos/videos/VIRAT_S_000103.mp4 -o /tmp/videos/VIRAT_S_000103.mp4
-          curl -L https://github.com/intel/metro-ai-suite/raw/refs/heads/videos/videos/VIRAT_S_000104.mp4 -o /tmp/videos/VIRAT_S_000104.mp4
+          curl -L https://github.com/open-edge-platform/edge-ai-resources/raw/0e0a8e62c1f397412528fb63391632c6b903650b/videos/VIRAT_S_000101.mp4 -o /tmp/videos/VIRAT_S_000101.mp4
+          curl -L https://github.com/open-edge-platform/edge-ai-resources/raw/0e0a8e62c1f397412528fb63391632c6b903650b/videos/VIRAT_S_000102.mp4 -o /tmp/videos/VIRAT_S_000102.mp4
+          curl -L https://github.com/open-edge-platform/edge-ai-resources/raw/0e0a8e62c1f397412528fb63391632c6b903650b/videos/VIRAT_S_000103.mp4 -o /tmp/videos/VIRAT_S_000103.mp4
+          curl -L https://github.com/open-edge-platform/edge-ai-resources/raw/0e0a8e62c1f397412528fb63391632c6b903650b/videos/VIRAT_S_000104.mp4 -o /tmp/videos/VIRAT_S_000104.mp4
         env:
         - name: http_proxy
           value: {{ $.Values.env.http_proxy }}


### PR DESCRIPTION
### Description

The video download links in helm charts for loitering detection is updated to point to edge-ai-resources/videos folder where the input videos are uploaded in release 2026.0.0 branch

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

