### PR TITLE
[Robotics] Fix Docker image reference in license-check target of Makefile

### DIFF
--- a/robotics-ai-suite/components/adbscan/Makefile
+++ b/robotics-ai-suite/components/adbscan/Makefile
@@ -34,7 +34,7 @@ PACKAGES = ROS2_node \
 
 license-check:
 	@# Help: Perform a REUSE license check using docker container https://hub.docker.com/r/fsfe/reuse
-	docker run --rm --volume ${ROOT_DIR}:/data amr-registry.caas.intel.com/cache/fsfe/reuse:5.0.2 lint
+	docker run --rm --volume ${ROOT_DIR}:/data fsfe/reuse:5.0.2 lint
 
 package:
 	@# Help: Build Debian packages


### PR DESCRIPTION
### Description

Fix Docker image reference in license-check target of Makefile

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

