### PR TITLE
industrial-multimodal: Updated the gvawatermark pipeline

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/configs/dlstreamer-pipeline-server/config.json
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/configs/dlstreamer-pipeline-server/config.json
@@ -5,7 +5,7 @@
                 "name": "weld_defect_classification",
                 "source": "gstreamer",
                 "queue_maxsize": 50,
-                "pipeline": "rtspsrc add-reference-timestamp-meta=true location=\"rtsp://mediamtx:8554/live.stream\" latency=100 name=source ! rtph264depay ! h264parse ! decodebin ! videoconvert ! video/x-raw,format=BGR ! gvaclassify inference-region=full-frame name=classification ! gvawatermark ! gvametaconvert add-empty-results=true add-rtp-timestamp=true name=metaconvert ! queue ! gvafpscounter ! appsink name=destination",
+                "pipeline": "rtspsrc add-reference-timestamp-meta=true location=\"rtsp://mediamtx:8554/live.stream\" latency=100 name=source ! rtph264depay ! h264parse ! decodebin ! videoconvert ! video/x-raw,format=BGR ! gvaclassify inference-region=full-frame name=classification ! gvawatermark displ-cfg=\"font-scale=1.5,thickness=3,color-idx=2,font-type=plain\" ! gvametaconvert add-empty-results=true add-rtp-timestamp=true name=metaconvert ! queue ! gvafpscounter ! appsink name=destination",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -26,7 +26,8 @@
                         },
                         "frame": [{
                             "type": "webrtc",
-                            "peer-id": "samplestream"
+                            "peer-id": "samplestream",
+                            "overlay": false
                         },
                         {
                             "type": "s3_write",

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started.md
@@ -143,7 +143,8 @@ curl -k https://localhost:30001/dsps-api/pipelines/user_defined_pipelines/weld_d
         },
         "frame": [{
                             "type": "webrtc",
-                            "peer-id": "samplestream"
+                            "peer-id": "samplestream",
+                            "overlay": false
                         },
                         {
                             "type": "s3_write",

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started/deploy-with-helm.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/get-started/deploy-with-helm.md
@@ -174,7 +174,8 @@ curl -k https://localhost:30001/dsps-api/pipelines/user_defined_pipelines/weld_d
         },
         "frame": [{
                             "type": "webrtc",
-                            "peer-id": "samplestream"
+                            "peer-id": "samplestream",
+                            "overlay": false
                         },
                         {
                             "type": "s3_write",

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/how-to-guides/how-to-configure-rtsp-camera.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/how-to-guides/how-to-configure-rtsp-camera.md
@@ -69,7 +69,7 @@ Update the RTSP URL in the pipeline and replace the placeholders with your camer
 - `<FEED>`: stream path (varies by camera model/vendor)
 
 ```json
-"pipeline": "rtspsrc add-reference-timestamp-meta=true location=\"rtsp://<USERNAME>:<PASSWORD>@<RTSP_CAMERA_IP>:<PORT>/<FEED>\" latency=100 name=source ! rtph264depay ! h264parse ! decodebin ! videoconvert ! video/x-raw,format=BGR ! gvaclassify inference-region=full-frame name=classification ! gvawatermark ! gvametaconvert add-empty-results=true add-rtp-timestamp=true name=metaconvert ! queue ! gvafpscounter ! appsink name=destination"
+"pipeline": "rtspsrc add-reference-timestamp-meta=true location=\"rtsp://<USERNAME>:<PASSWORD>@<RTSP_CAMERA_IP>:<PORT>/<FEED>\" latency=100 name=source ! rtph264depay ! h264parse ! decodebin ! videoconvert ! video/x-raw,format=BGR ! gvaclassify inference-region=full-frame name=classification ! gvawatermark displ-cfg=\"font-scale=1.5,thickness=3,color-idx=2,font-type=plain\" ! gvametaconvert add-empty-results=true add-rtp-timestamp=true name=metaconvert ! queue ! gvafpscounter ! appsink name=destination"
 ```
 
 ### 3. Update environment variables with RTSP Camera IP

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/weld-defect-detection/index.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/weld-defect-detection/index.md
@@ -89,6 +89,7 @@ An array defining one or more video output destinations. Each entry requires a `
 |------------|---------------------------------------------------|------------------|
 | `type`     | Frame destination type.                           | `"webrtc"`       |
 | `peer-id`  | Unique identifier for the WebRTC peer connection. | `"samplestream"` |
+| `overlay`  | It's an optional field. By default, it is true. If true, it draws overlay and if false the gvawatermark DLStreamer configuration would be used as is | `false` |
 
 **S3 Storage (`type: "s3_write"`)**:
 


### PR DESCRIPTION
### Description

Updated gvawatermark property to display the defect results at a better font size and background color

### Any Newly Introduced Dependencies

NA

### How Has This Been Tested?

Verified. Snapshot is as below:
<img width="2553" height="1329" alt="image" src="https://github.com/user-attachments/assets/69c96dd6-2235-4eea-aaaf-e7ddafe8ddef" />


### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

