### PR TITLE
industrial-multimodal: Fix for the non-proxy env

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docker-compose.yml
@@ -319,10 +319,8 @@ services:
       ENABLE_WEBRTC: true
       WEBRTC_SIGNALING_SERVER: http://mediamtx:8889
       ENABLE_RTSP: true
-      http_proxy: ${http_proxy}
-      https_proxy: ${https_proxy}
-      no_proxy: ${no_proxy},${HOST_IP},${RTSP_CAMERA_IP},otel-collector,mediamtx,model_registry,${S3_STORAGE_HOST},ia-mqtt-broker
-      NO_PROXY: ${no_proxy},${HOST_IP},${RTSP_CAMERA_IP},otel-collector,mediamtx,model_registry,${S3_STORAGE_HOST},ia-mqtt-broker
+      no_proxy: ${HOST_IP},${RTSP_CAMERA_IP},otel-collector,mediamtx,model_registry,${S3_STORAGE_HOST},ia-mqtt-broker,${no_proxy}
+      NO_PROXY: ${HOST_IP},${RTSP_CAMERA_IP},otel-collector,mediamtx,model_registry,${S3_STORAGE_HOST},ia-mqtt-broker,${no_proxy}
       GST_DEBUG: "1"
       REST_SERVER_PORT: ${REST_SERVER_PORT}
       S3_STORAGE_HOST: ${S3_STORAGE_HOST}


### PR DESCRIPTION
### Description

Removed the http and https proxy envs and
properly set the no_proxy envs to get the DLS PS
working in both proxy and non proxy envs

### Any Newly Introduced Dependencies
NA

### How Has This Been Tested?

Verified in both proxy and non-proxy environment.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

