### PR TITLE
 Dlstreamer-pipeline-server updated to 2026.1.0-ubuntu24-rc1

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/docker-compose.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/docker-compose.yaml
@@ -91,7 +91,7 @@ services:
     privileged: true
 
   nicu-dlsps:
-    image: ${NICU_DLSPS_IMAGE:-intel/dlstreamer-pipeline-server:2026.0.0-ubuntu24}
+    image: ${NICU_DLSPS_IMAGE:-intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc1}
     container_name: nicu-dlsps
     user: "0:0"
     profiles: ["dlsps"]


### PR DESCRIPTION
Update DLSPS image tag from 2026.0.0-ubuntu24 to 2026.1.0-ubuntu24-rc1 in NICU-Warmer docker-compose.yaml. 