### PR TITLE
[DOCS][Education][HealthLS] Release branch references for 2026.1

### DIFF
--- a/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
@@ -13,7 +13,7 @@ Download from [https://ffmpeg.org/download.html](https://ffmpeg.org/download.htm
 ### B. Install DL Streamer
 
 Download the installer from [DL Streamer assets on GitHub](https://github.com/open-edge-platform/dlstreamer/releases).
-For details, refer to the [Install Guide](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/get_started/install/install_guide_windows.html).
+For details, refer to the [Install Guide](https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer/get_started/install/install_guide_windows.html).
 
 > Note: DL Streamer 2026.0.0 is lastest verified version, please also update your [NPU driver](/education-ai-suite/smart-classroom/docs/user-guide/get-started/system-requirements.md#software-and-hardware-requirements) to latest for compatability.
 
@@ -22,11 +22,11 @@ For details, refer to the [Install Guide](https://docs.openedgeplatform.intel.co
 ### C. Clone Repository
 
 Go to the target directory of your choice and clone the suite.
-If you want to clone a specific release branch, replace `main` with the desired tag.
-To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/dev/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
+<!--If you want to clone a specific release branch, replace `release-2026.1.0` with the desired tag.-->
+To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
 ```bash
-  git clone --filter=blob:none --sparse --branch main https://github.com/open-edge-platform/edge-ai-suites.git
+  git clone --filter=blob:none --sparse --branch release-2026.1.0 https://github.com/open-edge-platform/edge-ai-suites.git
   cd edge-ai-suites
   git sparse-checkout set education-ai-suite
   cd education-ai-suite
@@ -54,7 +54,7 @@ If you need OCR functionality for document text extraction, install PaddleOCR se
 pip install paddleocr==2.7.0.3 --no-deps
 ```
 
-> **Note:** The `--no-deps` flag is required because PaddleOCR declares an outdated `PyMuPDF` dependency that has no pre-built wheel for Python 3.12 on Windows. 
+> **Note:** The `--no-deps` flag is required because PaddleOCR declares an outdated `PyMuPDF` dependency that has no pre-built wheel for Python 3.12 on Windows.
 
 Then enable OCR in `config.yaml`:
 
@@ -289,7 +289,7 @@ models:
 - **URL fails from another device:**
   Confirm you used `--host 0.0.0.0` and replaced `<HOST_IP>` correctly.
 
-- **Nothing at http://localhost:5173:**
+- **Nothing at `http://localhost:5173`:**
   Check that the frontend terminal shows the Vite server running and no port conflict.
 
 - **Firewall blocks access:**

--- a/education-ai-suite/smart-classroom/docs/user-guide/index.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/main/education-ai-suite/smart-classroom">
+   <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.1.0/education-ai-suite/smart-classroom">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/main/education-ai-suite/smart-classroom/README.md">
+   <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.1.0/education-ai-suite/smart-classroom/README.md">
      Readme
   </a>
 </div>

--- a/education-ai-suite/smart-classroom/docs/user-guide/release-notes.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/release-notes.md
@@ -35,7 +35,7 @@ The Education AI Suite now also includes built-in telemetry hooks and benchmarki
 
 ## Documentation and Source Code
 
-- [GitHub](https://github.com/open-edge-platform/edge-ai-suites/tree/main/education-ai-suite)
+- [GitHub](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.0.0/education-ai-suite)
 
 ## Previous releases
 

--- a/education-ai-suite/smart-classroom/docs/user-guide/release-notes/release-notes-2025.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/release-notes/release-notes-2025.md
@@ -22,4 +22,4 @@ In this release, the **Smart Classroom** application is added. It is an extensib
 
 ## Documentation and Source Code
 
-- [GitHub](https://github.com/open-edge-platform/edge-ai-suites/tree/main/education-ai-suite)
+- [GitHub](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2025.2.0/education-ai-suite)

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/get-started.md
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/get-started.md
@@ -9,11 +9,11 @@ Ensure your system meets the [System Requirements](./get-started/system-requirem
 ## 1. Clone the Repository
 
 Use sparse checkout to download only the NICU Warmer component.
-If you want to clone a specific release branch, replace `main` with the desired tag.
-To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/dev/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
+<!--If you want to clone a specific release branch, replace `release-2026.1.0` with the desired tag.-->
+To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
 ```bash
-git clone --filter=blob:none --sparse --branch main \
+git clone --filter=blob:none --sparse --branch release-2026.1.0 \
   https://github.com/open-edge-platform/edge-ai-suites.git
 cd edge-ai-suites
 git sparse-checkout set health-and-life-sciences-ai-suite/NICU-Warmer

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/index.md
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/main/health-and-life-sciences-ai-suite/NICU-Warmer">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.1.0/health-and-life-sciences-ai-suite/NICU-Warmer">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/main/health-and-life-sciences-ai-suite/NICU-Warmer/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.1.0/health-and-life-sciences-ai-suite/NICU-Warmer/README.md">
      Readme
   </a>
 </div>

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/get-started.md
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/get-started.md
@@ -11,11 +11,11 @@ Ensure your environment meets the [System Requirements](./get-started/system-req
 ## 1. Clone the Repository
 
 Go to the target directory of your choice and clone the suite.
-If you want to clone a specific release branch, replace `main` with the desired tag.
-To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/dev/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
+<!--If you want to clone a specific release branch, replace `release-2026.1.0` with the desired tag.-->
+To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
 ```bash
-git clone --filter=blob:none --sparse --branch main https://github.com/open-edge-platform/edge-ai-suites.git
+git clone --filter=blob:none --sparse --branch release-2026.1.0 https://github.com/open-edge-platform/edge-ai-suites.git
 cd edge-ai-suites
 git sparse-checkout set health-and-life-sciences-ai-suite
 cd health-and-life-sciences-ai-suite/multi_modal_patient_monitoring

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/index.md
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/index.md
@@ -2,10 +2,10 @@
 
 <!--hide_directive
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/main/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.1.0/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/main/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.1.0/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/README.md">
      Readme
   </a>
 </div>

--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/release-notes/release-notes-2025.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/docs/user-guide/release-notes/release-notes-2025.md
@@ -50,7 +50,7 @@ case by detecting the anomalous power generation patterns relative to wind speed
 - Generic Time Series AI stack supporting the data ingestion, data analytics,
   data storage and data visualization.
 - Data Analytics is powered by
-  [Time Series Analytics Microservice](https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/time-series-analytics/index.html)
+  [Time Series Analytics Microservice](https://docs.openedgeplatform.intel.com/2025.1/edge-ai-libraries/time-series-analytics/index.html)
   which from the sample app context takes in the configuration related to wind
   turbine sample app and the User Defined Function(UDF) deployment package and
   provides below capabilities:


### PR DESCRIPTION
### Description

Updates references to the release 2026.1 branch for "Education" and "Health and Life Sciences" AI Suites:

- OEP website links changed from `/dev/` to `/2026.1/`
- GH links for targets in Libraries and Suites repos changed to `release-2026.1.0`
- changed the `git clone` commands to `release-2026.1.0`
---
- adjusted some older references to previous releases

### How Has This Been Tested?

Links checked, git clone commands tested.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.