### PR TITLE
[Content Search] Lack of handling the corrupted file

### DIFF
--- a/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
@@ -107,9 +107,46 @@ class AssetService:
     @staticmethod
     async def _prepare_and_upload_asset(db: Session, file: UploadFile, **kwargs) -> dict:
         max_size_bytes = _max_bytes_for(file)
+
         payload = await storage_service.upload_and_prepare_payload(
             file, max_size_bytes=max_size_bytes
         )
+
+        if "validation_error" in payload:
+            from utils.crud_task import task_crud
+            from utils.schemas_task import TaskStatus
+
+            error_code = 40002 if payload.get("error_type") == "invalid_file" else 41301
+
+            failed_task = task_crud.create_task(
+                db,
+                task_type="file_search",
+                payload={
+                    "file_name": file.filename,
+                    "content_type": file.content_type,
+                    "validation_error": payload["validation_error"],
+                    "error_type": payload["error_type"],
+                    **kwargs
+                },
+                status=TaskStatus.FAILED
+            )
+            failed_task.result = {
+                "error": payload["validation_error"],
+                "error_type": payload["error_type"]
+            }
+            db.commit()
+
+            return {
+                "is_biz_error": True,
+                "code": error_code,
+                "message": f"Upload validation failed: {payload['validation_error']}",
+                "data": {
+                    "task_id": str(failed_task.id),
+                    "file_name": file.filename,
+                    "reason": payload["validation_error"]
+                }
+            }
+
         file_hash = payload["file_hash"]
 
         existing_asset = AssetService._find_existing_asset(db, file_hash)

--- a/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/asset_service.py
@@ -147,6 +147,55 @@ class AssetService:
                 }
             }
 
+        file_key = payload.get("file_key")
+        file_name_lower = (file.filename or "").lower()
+
+        if any(file_name_lower.endswith(ext) for ext in ['.pdf', '.mp4', '.avi', '.mov', '.mkv']):
+            from utils.crud_task import task_crud
+            from utils.schemas_task import TaskStatus
+            from utils.file_validator import file_validator
+
+            file_path = storage_service.get_file_disk_path(file_key)
+            is_valid, error_msg = file_validator.validate_file_integrity(str(file_path))
+
+            if not is_valid:
+                print(f"[ASSET] File integrity check failed: {file.filename}, Error: {error_msg}", flush=True)
+
+                try:
+                    storage_service.delete_file(file_key, missing_ok=True)
+                except Exception:
+                    pass
+
+                failed_task = task_crud.create_task(
+                    db,
+                    task_type="file_search",
+                    payload={
+                        "file_name": file.filename,
+                        "content_type": file.content_type,
+                        "file_key": file_key,
+                        "validation_error": error_msg,
+                        "error_type": "corrupted_file",
+                        **kwargs
+                    },
+                    status=TaskStatus.FAILED
+                )
+                failed_task.result = {
+                    "error": error_msg,
+                    "error_type": "corrupted_file"
+                }
+                db.commit()
+
+                return {
+                    "is_biz_error": True,
+                    "code": 40002,
+                    "message": f"File integrity validation failed: {error_msg}",
+                    "data": {
+                        "task_id": str(failed_task.id),
+                        "file_name": file.filename,
+                        "reason": error_msg
+                    }
+                }
+
         file_hash = payload["file_hash"]
 
         existing_asset = AssetService._find_existing_asset(db, file_hash)

--- a/education-ai-suite/smart-classroom/content_search/utils/file_validator.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/file_validator.py
@@ -1,0 +1,147 @@
+#
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import os
+import logging
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class FileValidator:
+    """Centralized file validation for uploads"""
+
+    # File size limits (in MB)
+    DOCUMENT_MAX_MB = int(os.environ.get("DOCUMENT_MAX_MB", "100"))
+    VIDEO_MAX_MB = int(os.environ.get("VIDEO_MAX_MB", "1024"))
+
+    # Video content type prefix and extensions
+    VIDEO_CONTENT_PREFIX = "video/"
+    VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv"}
+
+    # Expected content types for common extensions
+    EXTENSION_TO_CONTENT_TYPE = {
+        ".pdf": "application/pdf",
+        ".txt": "text/plain",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".doc": "application/msword",
+        ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ".ppt": "application/vnd.ms-powerpoint",
+        ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        ".xls": "application/vnd.ms-excel",
+        ".mp4": "video/mp4",
+        ".avi": "video/x-msvideo",
+        ".mov": "video/quicktime",
+        ".mkv": "video/x-matroska",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+    }
+
+    # Magic numbers (file signatures) for validation
+    MAGIC_NUMBERS = {
+        ".pdf": [b"%PDF"],
+        ".png": [b"\x89PNG\r\n\x1a\n"],
+        ".jpg": [b"\xff\xd8\xff"],
+        ".jpeg": [b"\xff\xd8\xff"],
+        ".docx": [b"PK\x03\x04"],
+        ".pptx": [b"PK\x03\x04"],
+        ".xlsx": [b"PK\x03\x04"],
+        ".zip": [b"PK\x03\x04"],
+        ".mp4": [b"\x00\x00\x00\x18ftypmp4", b"\x00\x00\x00\x1cftypmp42", b"\x00\x00\x00\x20ftypisom"],
+        ".avi": [b"RIFF"],
+        ".mov": [b"\x00\x00\x00\x14ftyp", b"\x00\x00\x00\x18ftyp", b"\x00\x00\x00\x1cftyp", b"\x00\x00\x00\x20ftyp"],
+        ".mkv": [b"\x1a\x45\xdf\xa3"],
+    }
+
+    @staticmethod
+    def get_max_size_bytes(content_type: Optional[str], filename: Optional[str]) -> int:
+        """Get maximum allowed file size based on content type and filename"""
+        ctype = (content_type or "").lower()
+        if ctype.startswith(FileValidator.VIDEO_CONTENT_PREFIX):
+            return FileValidator.VIDEO_MAX_MB * 1024 * 1024
+
+        name = (filename or "").lower()
+        if any(name.endswith(ext) for ext in FileValidator.VIDEO_EXTENSIONS):
+            return FileValidator.VIDEO_MAX_MB * 1024 * 1024
+
+        return FileValidator.DOCUMENT_MAX_MB * 1024 * 1024
+
+    @staticmethod
+    def validate_basic_file(
+        filename: Optional[str],
+        content_type: Optional[str],
+        file_size: Optional[int]
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Validate basic file properties before upload
+        Returns: (is_valid, error_message)
+        """
+        if not filename:
+            return False, "Filename is required"
+
+        if file_size is not None and file_size == 0:
+            return False, "File is empty (0 bytes)"
+
+        name_lower = filename.lower()
+        ext = None
+        for possible_ext in FileValidator.EXTENSION_TO_CONTENT_TYPE.keys():
+            if name_lower.endswith(possible_ext):
+                ext = possible_ext
+                break
+
+        if not ext:
+            logger.warning(f"Unknown file extension for: {filename}")
+            return True, None
+
+        if not content_type:
+            return True, None
+
+        expected_type = FileValidator.EXTENSION_TO_CONTENT_TYPE.get(ext)
+        actual_type = content_type.lower()
+
+        if expected_type and not actual_type.startswith(expected_type.split('/')[0]):
+            error_msg = f"File extension mismatch: {filename} has extension {ext} but content-type is {content_type}"
+            logger.warning(error_msg)
+            return False, error_msg
+
+        return True, None
+
+    @staticmethod
+    def validate_file_content(
+        first_chunk: bytes,
+        filename: str
+    ) -> Tuple[bool, Optional[str]]:
+        """
+        Validate file content by checking magic number (file signature)
+        Returns: (is_valid, error_message)
+        """
+        if not filename or not first_chunk:
+            return True, None
+
+        name_lower = filename.lower()
+        ext = None
+        for possible_ext in FileValidator.MAGIC_NUMBERS.keys():
+            if name_lower.endswith(possible_ext):
+                ext = possible_ext
+                break
+
+        if not ext:
+            return True, None
+
+        expected_signatures = FileValidator.MAGIC_NUMBERS.get(ext, [])
+        if not expected_signatures:
+            return True, None
+
+        for signature in expected_signatures:
+            if first_chunk.startswith(signature):
+                return True, None
+
+        error_msg = f"File content mismatch: {filename} has extension {ext} but content does not match expected file signature"
+        logger.warning(error_msg)
+        return False, error_msg
+
+
+file_validator = FileValidator()

--- a/education-ai-suite/smart-classroom/content_search/utils/file_validator.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/file_validator.py
@@ -11,17 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 class FileValidator:
-    """Centralized file validation for uploads"""
-
-    # File size limits (in MB)
     DOCUMENT_MAX_MB = int(os.environ.get("DOCUMENT_MAX_MB", "100"))
     VIDEO_MAX_MB = int(os.environ.get("VIDEO_MAX_MB", "1024"))
 
-    # Video content type prefix and extensions
     VIDEO_CONTENT_PREFIX = "video/"
     VIDEO_EXTENSIONS = {".mp4", ".avi", ".mov", ".mkv"}
 
-    # Expected content types for common extensions
     EXTENSION_TO_CONTENT_TYPE = {
         ".pdf": "application/pdf",
         ".txt": "text/plain",
@@ -40,7 +35,6 @@ class FileValidator:
         ".png": "image/png",
     }
 
-    # Magic numbers (file signatures) for validation
     MAGIC_NUMBERS = {
         ".pdf": [b"%PDF"],
         ".png": [b"\x89PNG\r\n\x1a\n"],
@@ -75,10 +69,6 @@ class FileValidator:
         content_type: Optional[str],
         file_size: Optional[int]
     ) -> Tuple[bool, Optional[str]]:
-        """
-        Validate basic file properties before upload
-        Returns: (is_valid, error_message)
-        """
         if not filename:
             return False, "Filename is required"
 
@@ -114,10 +104,6 @@ class FileValidator:
         first_chunk: bytes,
         filename: str
     ) -> Tuple[bool, Optional[str]]:
-        """
-        Validate file content by checking magic number (file signature)
-        Returns: (is_valid, error_message)
-        """
         if not filename or not first_chunk:
             return True, None
 
@@ -142,6 +128,66 @@ class FileValidator:
         error_msg = f"File content mismatch: {filename} has extension {ext} but content does not match expected file signature"
         logger.warning(error_msg)
         return False, error_msg
+
+    @staticmethod
+    def validate_file_integrity(file_path: str) -> Tuple[bool, Optional[str]]:
+        if not os.path.exists(file_path):
+            return False, "File does not exist"
+
+        ext = os.path.splitext(file_path)[1].lower()
+
+        try:
+            if ext == '.pdf':
+                try:
+                    import pypdf
+                except ImportError:
+                    logger.warning("pypdf not installed, skipping PDF integrity check")
+                    return True, None
+
+                try:
+                    with open(file_path, 'rb') as f:
+                        reader = pypdf.PdfReader(f)
+                        page_count = len(reader.pages)
+                        if page_count == 0:
+                            return False, "PDF has no readable pages"
+                    logger.info(f"PDF validation passed: {page_count} pages")
+                    return True, None
+                except Exception as e:
+                    error_msg = f"PDF file is corrupted or unreadable: {str(e)}"
+                    logger.error(error_msg)
+                    return False, error_msg
+
+            elif ext in ['.mp4', '.avi', '.mov', '.mkv']:
+                try:
+                    import cv2
+                except ImportError:
+                    logger.warning("cv2 not installed, skipping video integrity check")
+                    return True, None
+
+                try:
+                    cap = cv2.VideoCapture(file_path)
+                    if not cap.isOpened():
+                        return False, "Video file is corrupted or unreadable"
+
+                    frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+                    if frame_count <= 0:
+                        cap.release()
+                        return False, "Video file has no readable frames"
+
+                    cap.release()
+                    logger.info(f"Video validation passed: {frame_count} frames")
+                    return True, None
+                except Exception as e:
+                    error_msg = f"Video validation failed: {str(e)}"
+                    logger.error(error_msg)
+                    return False, error_msg
+
+        except Exception as e:
+            error_msg = f"File integrity validation error: {str(e)}"
+            logger.error(error_msg)
+            return False, error_msg
+
+        return True, None
 
 
 file_validator = FileValidator()

--- a/education-ai-suite/smart-classroom/content_search/utils/storage_service.py
+++ b/education-ai-suite/smart-classroom/content_search/utils/storage_service.py
@@ -9,6 +9,8 @@ import logging
 from fastapi import HTTPException, UploadFile
 from typing import Optional
 
+from utils.file_validator import file_validator
+
 # Stream in 1 MiB chunks so memory stays bounded even for multi-GB uploads.
 _STREAM_CHUNK_SIZE = 1024 * 1024
 
@@ -46,9 +48,18 @@ class StorageService:
         if not self.is_available:
             raise RuntimeError(f"Storage Service is unavailable: {self._error_msg}")
 
+        is_valid, error_msg = file_validator.validate_basic_file(
+            filename=file.filename,
+            content_type=file.content_type,
+            file_size=file.size
+        )
+        if not is_valid:
+            logger.warning(f"Upload rejected: {error_msg}")
+            return {"validation_error": error_msg, "error_type": "invalid_file"}
+
         if max_size_bytes is not None and file.size and file.size > max_size_bytes:
             logger.warning(f"Upload rejected: file '{file.filename}' size {file.size} bytes exceeds maximum allowed {max_size_bytes} bytes")
-            raise HTTPException(status_code=413, detail="File size exceeds maximum allowed limit")
+            return {"validation_error": "File size exceeds maximum allowed limit", "error_type": "file_too_large"}
 
         run_id = str(uuid.uuid4())
         main_type = file.content_type.split('/')[0]
@@ -66,25 +77,34 @@ class StorageService:
 
         hasher = hashlib.sha256()
         total_bytes = 0
-        try:
-            with open(dst_path, "wb") as out:
-                while True:
-                    chunk = await file.read(_STREAM_CHUNK_SIZE)
-                    if not chunk:
-                        break
-                    total_bytes += len(chunk)
-                    if max_size_bytes is not None and total_bytes > max_size_bytes:
-                        logger.warning(f"Upload rejected during streaming: file '{file.filename}' reached {total_bytes} bytes, exceeds maximum allowed {max_size_bytes} bytes")
-                        raise HTTPException(status_code=413, detail="File size exceeds maximum allowed limit")
-                    hasher.update(chunk)
-                    out.write(chunk)
-        except HTTPException:
-            # Remove the partial file so we don't leave junk on disk.
-            try:
-                dst_path.unlink(missing_ok=True)
-            except Exception:
-                pass
-            raise
+        is_first_chunk = True
+        with open(dst_path, "wb") as out:
+            while True:
+                chunk = await file.read(_STREAM_CHUNK_SIZE)
+                if not chunk:
+                    break
+
+                if is_first_chunk:
+                    is_valid, error_msg = file_validator.validate_file_content(chunk, file.filename)
+                    if not is_valid:
+                        logger.warning(f"Upload rejected: {error_msg}")
+                        try:
+                            dst_path.unlink(missing_ok=True)
+                        except Exception:
+                            pass
+                        return {"validation_error": error_msg, "error_type": "invalid_file"}
+                    is_first_chunk = False
+
+                total_bytes += len(chunk)
+                if max_size_bytes is not None and total_bytes > max_size_bytes:
+                    logger.warning(f"Upload rejected during streaming: file '{file.filename}' reached {total_bytes} bytes, exceeds maximum allowed {max_size_bytes} bytes")
+                    try:
+                        dst_path.unlink(missing_ok=True)
+                    except Exception:
+                        pass
+                    return {"validation_error": "File size exceeds maximum allowed limit", "error_type": "file_too_large"}
+                hasher.update(chunk)
+                out.write(chunk)
 
         return {
             "source": "local",

--- a/education-ai-suite/smart-classroom/docs/dev-guide/content-search/Content_search_API.md
+++ b/education-ai-suite/smart-classroom/docs/dev-guide/content-search/Content_search_API.md
@@ -49,6 +49,7 @@ Content-Type: application/json
 | 20000 | SUCCESS | Task submitted, query successful, or cleanup completed. |
 | 40000 | BAD_REQUEST | General logic error (e.g., trying to delete a processing task). |
 | 40001 | AUTH_FAILED | Invalid username or password. |
+| 40002 | INVALID_FILE | File validation failed (empty file, content mismatch, or corrupted). |
 | 40901 | FILE_ALREADY_EXISTS | File already existed (Hash exist). |
 | 50001 | FILE_TYPE_ERROR | Unsupported file format (Allowed: mp4, mov, jpg, png, pdf). |
 | 50002 | TASK_NOT_FOUND | Task ID does not exist or has expired. |


### PR DESCRIPTION
### Description

Add a new BUSSINESS CODE 40002 for INVALID_FILE, before upload file, if file is corrupted, will return 40002

```
{
    "code": 40002,
    "data": {
        "task_id": "4dc81b3e-dc10-4bcd-a352-bb9c55e24d83",
        "file_name": "corrupted.pdf",
        "reason": "PDF file is corrupted or unreadable: Stream has ended unexpectedly"
    },
    "message": "File integrity validation failed: PDF file is corrupted or unreadable: Stream has ended unexpectedly",
    "timestamp": 1779265222
}
```
Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

