### PR TITLE
[Win-Vision-AI] Fixed WebRTC/RTSP continues streaming even when the WebRTC/RTSP frame output is disabled

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
@@ -12,7 +12,7 @@ Install **Python 3.12 or higher** from [the official Python website](https://www
 Install **Git for Windows** from [the official Git website](https://git-scm.com/install/windows).
 
 ### Set Proxies (Optional)
-Open PowerShell and run all the terminal commands below
+Go to the target directory of your choice, open PowerShell and run all the terminal commands below
 
 ```powershell
 $env:http_proxy  = # example: http://proxy.example.com:891
@@ -32,7 +32,6 @@ Download the latest `dlstreamer-<version>-win64.exe` from the [Intel DL Streamer
 
 ### Clone the Suite
 
-Go to the target directory of your choice.
 If you want to clone a specific release branch, replace `main` with the desired tag.
 To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
@@ -12,6 +12,7 @@ Install **Python 3.12 or higher** from [the official Python website](https://www
 Install **Git for Windows** from [the official Git website](https://git-scm.com/install/windows).
 
 ### Set Proxies (Optional)
+Open PowerShell and run all the terminal commands below
 
 ```powershell
 $env:http_proxy  = # example: http://proxy.example.com:891
@@ -31,7 +32,7 @@ Download the latest `dlstreamer-<version>-win64.exe` from the [Intel DL Streamer
 
 ### Clone the Suite
 
-Go to the target directory of your choice, open PowerShell and run all the terminal commands below.
+Go to the target directory of your choice.
 If you want to clone a specific release branch, replace `main` with the desired tag.
 To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
@@ -126,7 +127,10 @@ gst-inspect-1.0 gencamsrc
 
 Required when any pipeline uses RTSP or WebRTC frame output.
 
+Create a new directory where MediaMTX will be downloaded, then run the setup script pointing to that directory:
+
 ```powershell
+New-Item -ItemType Directory -Path "<mediamtx_dir>"
 python src/setup_mediamtx.py --dir <mediamtx_dir> --version v1.18.1
 $env:MEDIAMTX_PATH = "<mediamtx_dir>\mediamtx.exe"
 ```
@@ -152,6 +156,8 @@ Use the exported `.xml` path in `config.yaml`.
 ---
 
 ### Configure `config.yaml`
+
+> **Note:** The `config.yaml` file is located in the `win-vision-ai` directory of your clone (i.e., `edge-ai-suites/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/config.yaml`).
 
 > **Note:** Use forward slashes in all YAML paths to avoid escape issues.
 
@@ -255,15 +261,15 @@ input:
 
 Requires the camera environment variables from [Set Environment Variables](#set-environment-variables).
 
-`serial` is the only required field. Any additional properties are passed verbatim to the `gencamsrc` GStreamer element — add as many as your camera/driver/gencamsrc support.
+`serial`, `pixel-format`, `width`, and `height` are all required fields. Any additional properties are passed verbatim to the `gencamsrc` GStreamer element — add as many as your camera/driver/gencamsrc support.
 
 ```yaml
 input:
   type: camera
   serial: <camera_serial_number> # required — camera serial number
-  pixel-format: mono8 # optional — e.g. mono8
-  width: 1280 # optional — frame width in pixels
-  height: 720 # optional — frame height in pixels
+  pixel-format: mono8 # required — e.g. mono8
+  width: 1280 # required — frame width in pixels
+  height: 720 # required — frame height in pixels
 ```
 
 <!--hide_directive:::
@@ -280,8 +286,8 @@ Streams to `http://localhost:8889/front`. Open in a browser.
 ```yaml
 output:
   frame:
-    type: webrtc
-    peer_id: front
+    - type: webrtc
+      peer_id: front
 ```
 
 <!--hide_directive:::
@@ -293,8 +299,8 @@ Streams to `rtsp://localhost:8554/front`. Open in VLC.
 ```yaml
 output:
   frame:
-    type: rtsp
-    path: /front
+    - type: rtsp
+      path: /front
 ```
 
 <!--hide_directive:::
@@ -306,10 +312,10 @@ Streams to both `http://localhost:8889/front` and `rtsp://localhost:8554/front` 
 ```yaml
 output:
   frame:
-    type: webrtc
-    peer_id: front
-    type: rtsp
-    path: /front
+    - type: webrtc
+      peer_id: front
+    - type: rtsp
+      path: /front
 ```
 
 <!--hide_directive:::
@@ -389,8 +395,8 @@ pipelines:
       model_id: inst0
     output:
       frame:
-        type: rtsp
-        path: /front
+        - type: rtsp
+          path: /front
       metadata:
         - type: mqtt
           topic: inference/front
@@ -403,8 +409,8 @@ pipelines:
       model_id: inst0
     output:
       frame:
-        type: webrtc
-        peer_id: back
+        - type: webrtc
+          peer_id: back
       metadata:
         - type: file
           path: "output/back-inference.jsonl"

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/app.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/app.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import os
 from pathlib import Path
@@ -66,20 +67,18 @@ class App(AppRunner):
         logger.info("App stopped")
 
     def _start_mediamtx(self) -> None:
-        """Start dedicated MediaMTX instance(s) — one per protocol actually used.
-
-        Each instance is configured with ONLY its own protocol enabled (rtmp/hls/srt
-        disabled) so streams cannot be read via any unintended protocol.
-        """
+        """Start MediaMTX — one combined instance, or one per protocol when different pipelines use different protocols."""
         if self._config.raw_pipeline_mode:
             raw_vals = [val for val in self._config.raw_pipelines.values() if val.strip()]
             rtsp_needed = any("rtspclientsink" in val for val in raw_vals)
             webrtc_needed = any("whipclientsink" in val for val in raw_vals)
+            both_in_same = any("rtspclientsink" in val and "whipclientsink" in val for val in raw_vals)
         else:
             frames = [entry.output.frame for entry in self._config.pipelines.values()
                       if entry.output.frame is not None]
             rtsp_needed = any(frame.has_active_rtsp() for frame in frames)
             webrtc_needed = any(frame.has_active_webrtc() for frame in frames)
+            both_in_same = any(frame.has_active_rtsp() and frame.has_active_webrtc() for frame in frames)
 
         if not rtsp_needed and not webrtc_needed:
             return
@@ -93,17 +92,19 @@ class App(AppRunner):
             return
 
         cfg = self._config.mediamtx
-        if rtsp_needed:
-            svc = MediaService(mediamtx_exe=mediamtx_exe, port=cfg.port, instance_id="rtsp")
-            if not svc.launch_server(rtsp_enabled=True, webrtc_enabled=False):
-                logger.warning("MediaMTX RTSP instance did not start — RTSP output may fail")
+        if rtsp_needed and webrtc_needed and not both_in_same:
+            for instance_id, rtsp_on, webrtc_on in [("rtsp", True, False), ("webrtc", False, True)]:
+                svc = MediaService(mediamtx_exe=mediamtx_exe, port=cfg.port, instance_id=instance_id)
+                if not svc.launch_server(rtsp_enabled=rtsp_on, webrtc_enabled=webrtc_on):
+                    logger.warning("MediaMTX (%s) did not start — stream output may fail", instance_id)
+                self._media_list.append(svc)
+        else:
+            svc = MediaService(mediamtx_exe=mediamtx_exe, port=cfg.port,
+                               instance_id="rtsp" if not webrtc_needed else ("webrtc" if not rtsp_needed else "combined"))
+            if not svc.launch_server(rtsp_enabled=rtsp_needed, webrtc_enabled=webrtc_needed):
+                logger.warning("MediaMTX did not start — stream output may fail")
             self._media_list.append(svc)
 
-        if webrtc_needed:
-            svc = MediaService(mediamtx_exe=mediamtx_exe, port=cfg.port, instance_id="webrtc")
-            if not svc.launch_server(rtsp_enabled=False, webrtc_enabled=True):
-                logger.warning("MediaMTX WebRTC instance did not start — WebRTC output may fail")
-            self._media_list.append(svc)
 
     def _start_metrics(self) -> None:
         """Create and start the MetricsCollector with a Prometheus or log exporter."""
@@ -117,8 +118,8 @@ class App(AppRunner):
         """Launch all configured pipelines.
 
         In raw pipeline mode, submits each non-empty string directly to the pipeline
-        manager with no source/sink tracking. In structured mode, builds a GStreamer
-        launch string from config and logs the RTSP/WebRTC viewer URLs.
+        manager. In structured mode, builds a GStreamer launch string from config and
+        logs the RTSP/WebRTC viewer URLs.
         """
         if self._config.raw_pipeline_mode:
             active = {name: s.strip() for name, s in self._config.raw_pipelines.items() if s.strip()}
@@ -132,6 +133,12 @@ class App(AppRunner):
                     on_completed=self._on_completed, on_error=self._on_error,
                 )
                 logger.info("Launched raw pipeline '%s'", pid)
+                rtsp_match = re.search(r"rtspclientsink\s+location=(rtsp://\S+)", launch_string)
+                whip_match = re.search(r"whipclientsink\s+signaller::whip-endpoint=(http://\S+)/whip", launch_string)
+                if rtsp_match:
+                    logger.info("[%s] RTSP stream:   %s", name, rtsp_match.group(1))
+                if whip_match:
+                    logger.info("[%s] WebRTC stream: %s", name, whip_match.group(1))
             return
 
         mtx = self._config.mediamtx
@@ -153,6 +160,7 @@ class App(AppRunner):
                     logger.info("[%s] RTSP stream: rtsp://%s:%d%s", name, mtx.host_ip, mtx.port, frame.path)
                 if frame.has_active_webrtc():
                     logger.info("[%s] WebRTC stream: http://%s:%d/%s", name, mtx.host_ip, mtx.webrtc_port, frame.peer_id)
+
 
     def _ensure_output_dirs(self) -> None:
         """Create parent directories for any file-based metadata outputs."""
@@ -195,11 +203,16 @@ class App(AppRunner):
 
         parts = [_get_source_elements(entry.input, device), inference, f"{metadata_chain}queue ! gvawatermark ! {tail}"]
         if frame is not None:
-            encode = "identity name=sink ! mfh264enc bitrate=2000 gop-size=15 ! h264parse"
-            if frame.has_active_rtsp():
-                parts.append(f"{encode} ! rtspclientsink location=rtsp://{host_ip}:{rtsp_port}{frame.path}")
-            elif frame.has_active_webrtc():
-                parts.append(f"{encode} ! whipclientsink signaller::whip-endpoint=http://{host_ip}:{webrtc_port}/{frame.peer_id}/whip")
+            enc = "mfh264enc bitrate=2000 gop-size=15 ! h264parse"
+            rtsp_sink = f"rtspclientsink location=rtsp://{host_ip}:{rtsp_port}{frame.path}"
+            webrtc_sink = f"whipclientsink signaller::whip-endpoint=http://{host_ip}:{webrtc_port}/{frame.peer_id}/whip"
+            has_rtsp, has_webrtc = frame.has_active_rtsp(), frame.has_active_webrtc()
+            if has_rtsp and has_webrtc:
+                parts.append(f"identity name=sink ! tee name=t t. ! queue ! {enc} ! {rtsp_sink} t. ! queue ! {enc} ! {webrtc_sink}")
+            elif has_rtsp:
+                parts.append(f"identity name=sink ! {enc} ! {rtsp_sink}")
+            else:
+                parts.append(f"identity name=sink ! {enc} ! {webrtc_sink}")
         else:
             logger.warning("[%s] No frame output configured — using d3d11videosink", pipeline_name)
             parts.append("d3d11videosink name=sink")

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/config.yaml
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/config.yaml
@@ -58,10 +58,10 @@ pipelines:
       model_id: inst0
     output:
       frame:                          
-        type: webrtc                   # webrtc 
-        peer_id: front                 # http://localhost:8889/front 
-        # type: rtsp                   # rtsp
-        # path: /front                 # http://localhost:8554/front 
+        - type: webrtc                   # webrtc 
+          peer_id: front                 # http://localhost:8889/front 
+        #- type: rtsp                    # rtsp
+        #  path: /front                  # rtsp://localhost:8554/front 
       metadata:
         #- type: mqtt
         #  topic: inference/front
@@ -76,10 +76,10 @@ pipelines:
       model_id: inst0
     output:
       frame: 
-        type: webrtc                   # webrtc 
-        peer_id: back                  # http://localhost:8889/back      
-        # type: rtsp                   # rtsp
-        # path: /back                  # http://localhost:8554/back
+        - type: webrtc                   # webrtc 
+          peer_id: back                  # http://localhost:8889/back 
+        #- type: rtsp                    # rtsp
+        #  path: /back                   # rtsp://localhost:8554/back 
       metadata:
         #- type: mqtt
         #  topic: inference/back

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/src/config_loader.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/src/config_loader.py
@@ -70,10 +70,10 @@ class FrameOutputConfig:
     path: str = ""        # used when type == "rtsp"
 
     def has_active_rtsp(self) -> bool:
-        return self.type == "rtsp"
+        return bool(self.path)
 
     def has_active_webrtc(self) -> bool:
-        return self.type == "webrtc"
+        return bool(self.peer_id)
 
 
 @dataclass
@@ -240,7 +240,7 @@ def _parse_pipeline_entry(name: str, raw: dict, models: Dict[str, ModelConfig], 
     else:
         frame = default_output.frame
         if frame is not None:
-            if frame.type == "rtsp":
+            if frame.has_active_rtsp():
                 frame = FrameOutputConfig(type="rtsp", path=f"/{name}")
             else:
                 frame = FrameOutputConfig(type="webrtc", peer_id=name)
@@ -269,6 +269,12 @@ def _parse_input(pipeline_name: str, raw: dict) -> InputConfig:
     if input_type == "camera":
         if "serial" not in raw:
             raise ConfigError(f"Pipeline '{pipeline_name}': camera input missing required field 'serial'")
+        if not raw.get("pixel-format"):
+            raise ConfigError(f"Pipeline '{pipeline_name}': camera input missing required field 'pixel-format' — enter a valid value (e.g. mono8, bgr8)")
+        if not raw.get("width"):
+            raise ConfigError(f"Pipeline '{pipeline_name}': camera input missing required field 'width' — enter a valid integer value")
+        if not raw.get("height"):
+            raise ConfigError(f"Pipeline '{pipeline_name}': camera input missing required field 'height' — enter a valid integer value")
         # Collect any extra keys as passthrough properties for gencamsrc
         reserved = {"type", "serial"}
         extra_props = {k: v for k, v in raw.items() if k not in reserved}
@@ -300,9 +306,20 @@ def _parse_inference(pipeline_name: str, raw: dict, models: Dict[str, ModelConfi
 
 
 def _parse_output(pipeline_name: str, raw: dict, require_path: bool = True) -> OutputConfig:
-    """Parse an 'output' section into an OutputConfig with optional frame and metadata sinks."""
+    """Parse an 'output' section into an OutputConfig with optional frame and metadata sinks.
+
+    'frame' accepts a list of one or two entries (type: rtsp / type: webrtc).
+    When two entries are present both protocols run simultaneously.
+    'metadata' is a list of zero or more sink entries (mqtt, file, etc.).
+    """
     frame_raw = raw.get("frame")
-    frame = _parse_frame_output(pipeline_name, frame_raw, require_path) if frame_raw else None
+    frame_items = frame_raw if isinstance(frame_raw, list) else ([frame_raw] if frame_raw else [])
+    parsed = [_parse_frame_output(pipeline_name, entry, require_path) for entry in frame_items]
+    if len(parsed) == 2:
+        frame = FrameOutputConfig(type="", path=parsed[0].path or parsed[1].path,
+                                  peer_id=parsed[0].peer_id or parsed[1].peer_id)
+    else:
+        frame = parsed[0] if parsed else None
     metadata = [_parse_metadata_output(pipeline_name, idx, m) for idx, m in enumerate(raw.get("metadata") or [])]
     return OutputConfig(frame=frame, metadata=metadata)
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/src/media_service.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/src/media_service.py
@@ -63,7 +63,7 @@ class MediaService:
     def _build_runtime_config(self, rtsp_enabled: bool, webrtc_enabled: bool) -> Path:
         """Write a per-instance runtime config with only the required protocol enabled.
 
-        Disables rtmp, hls, and srt in every instance to prevent port conflicts
+        Disables rtmp, hls, srt, and api in every instance to prevent port conflicts
         when multiple MediaMTX instances run side-by-side.
         """
         text = (self.mediamtx_dir / "mediamtx.yml").read_text(encoding="utf-8")
@@ -73,9 +73,10 @@ class MediaService:
             ("rtmp",   False),
             ("hls",    False),
             ("srt",    False),
+            ("api",    False),
         ]:
             text = re.sub(
-                rf"^{proto}:\s*(yes|no)\s*$",
+                rf"^{proto}:\s*(yes|no|true|false)\s*$",
                 f"{proto}: {'yes' if enabled else 'no'}",
                 text, flags=re.MULTILINE,
             )


### PR DESCRIPTION
### Description
Fixed the following bugs related to windows
1. Incorrect webrtc_enabled status in logs when both RTSP and WebRTC are enabled in the config
2. In the raw pipelines, when rtspclientsink is included, WebRTC streaming is also active
3. WebRTC/RTSP continues streaming even when the WebRTC/RTSP frame output is commented out/Disabled
4. streaming error when width and height field is empty but log keep printing

Fixes # (issue)
1. https://jira.devtools.intel.com/browse/ITEP-92314
2. https://jira.devtools.intel.com/browse/ITEP-92340
3. https://jira.devtools.intel.com/browse/ITEP-92311
4. https://jira.devtools.intel.com/browse/ITEP-92321

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

