### PR TITLE
[Federal Aerospace] Do not autogenerate release notes in the workflow

### DIFF
--- a/.github/workflows/fedaero.yaml
+++ b/.github/workflows/fedaero.yaml
@@ -288,7 +288,7 @@ jobs:
             Rolling dev build from `main` @ ${{ github.sha }}.
             For the stable pinned release see the "Latest release" badge.
           # Auto-generate notes from PRs / commits since the previous run.
-          generate_release_notes: true
+          generate_release_notes: false
           # Marked as prerelease so it doesn't compete with versioned releases
           # for customer attention.
           prerelease: true
@@ -372,6 +372,6 @@ jobs:
             - `handheld-multi-modal.zip` — handheld multi-modal app
             - `deterministic-threat-detection.zip` — deterministic threat detection app
           # Auto-generate changelog from PRs / commits since the previous tag.
-          generate_release_notes: true
+          generate_release_notes: false
           prerelease: false
           files: assets/*.zip


### PR DESCRIPTION
### Description
Disables autogeneration of release notes in the workflow on the first release creation, because the request body will be too large - all commits will be included.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

