### PR TITLE
[Smart Intersection] [compose] pgserver healthcheck and fix web depends_on condition

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
@@ -221,6 +221,12 @@ services:
       - pgserver-db:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U scenescape -d scenescape"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   web:
     image: intel/scenescape-manager:v2026.1.0-rc1
@@ -231,7 +237,7 @@ services:
           - web.scenescape.intel.com
     depends_on:
       pgserver:
-        condition: service_started
+        condition: service_healthy
       broker:
         condition: service_started
     environment:


### PR DESCRIPTION
- Add healthcheck to pgserver service (pg_isready)
- Change web depends_on pgserver condition from service_started to service_healthy
- Fixes web container crash when postgres TCP isn't ready yet


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

