### PR TITLE
Smart Classroom Content Search Enhance ResultCard to display text 

### DIFF
--- a/education-ai-suite/smart-classroom/ui/src/components/LeftPanel/ResultSection.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/LeftPanel/ResultSection.tsx
@@ -24,6 +24,7 @@ export interface CsSearchResultMeta {
   video_start_second?: number;
   video_end_second?: number;
   summary_text?: string;
+  chunk_text?: string;
   doc_page_number?: number;
   tags?: string[];
   doc_filetype?: string;
@@ -139,6 +140,7 @@ const ResultCard: React.FC<{ result: SearchResult }> = ({ result }) => {
   const tags = Array.isArray(meta.tags) ? meta.tags : [];
   const fileType = meta.type;
   const filePath = meta.file_path;
+  const isIndependentText = !meta.file_name && fileType === "document";
 
   const renderPreview = () => {
     // For image type, build the HTTP URL from the local:// path and try to display it
@@ -176,14 +178,46 @@ const ResultCard: React.FC<{ result: SearchResult }> = ({ result }) => {
       </div>
 
       <div className="cs-result-item-content">
-        <div className="cs-result-item-row">
-          <span className="cs-result-item-value" title={fileName}>{fileName}</span>
-        </div>
-
-        {fileType === "document" && (
-          <div className="cs-result-item-row">
-            <span className="cs-result-item-page-label">Page: {meta.doc_page_number ?? "NA"}</span>
+        {isIndependentText ? (
+          <div className="cs-result-item-summary">
+            <p className={`cs-result-item-summary-text${summaryExpanded ? " cs-result-item-summary-text--expanded" : ""}`}>
+              <span className="cs-result-item-summary-label">Raw Text: </span>
+              {meta.chunk_text}
+            </p>
+            <button
+              className="cs-result-item-summary-toggle"
+              onClick={() => setSummaryExpanded((prev) => !prev)}
+            >
+              {summaryExpanded ? t("resultSection.showLess") : t("resultSection.showMore")}
+            </button>
           </div>
+        ) : (
+          <>
+            <div className="cs-result-item-row">
+              <span className="cs-result-item-value" title={fileName}>{fileName}</span>
+            </div>
+
+            {fileType === "document" && (
+              <div className="cs-result-item-row">
+                <span className="cs-result-item-page-label">Page: {meta.doc_page_number ?? "NA"}</span>
+              </div>
+            )}
+
+            {fileType === "document" && meta.chunk_text && (
+              <div className="cs-result-item-summary">
+                <p className={`cs-result-item-summary-text${summaryExpanded ? " cs-result-item-summary-text--expanded" : ""}`}>
+                  <span className="cs-result-item-summary-label">Raw Text: </span>
+                  {meta.chunk_text}
+                </p>
+                <button
+                  className="cs-result-item-summary-toggle"
+                  onClick={() => setSummaryExpanded((prev) => !prev)}
+                >
+                  {summaryExpanded ? t("resultSection.showLess") : t("resultSection.showMore")}
+                </button>
+              </div>
+            )}
+          </>
         )}
 
         {fileType === "video" && (


### PR DESCRIPTION
### Description
Enhance ResultCard to display chunk text and enhance independent texs display

Fixes NEX-T23096 test case
From 
<img width="1379" height="239" alt="image" src="https://github.com/user-attachments/assets/1e9a986d-381a-4b36-8884-92e0eba2e6b7" />
<img width="1387" height="232" alt="image" src="https://github.com/user-attachments/assets/f87c05da-6863-45de-b369-de96da85d071" />
to 
<img width="1342" height="232" alt="image" src="https://github.com/user-attachments/assets/ce2e2338-f4fd-489a-b481-18b12ec2aee3" />
<img width="1363" height="303" alt="image" src="https://github.com/user-attachments/assets/49b96fca-5c72-48c3-bf80-691e1f877c35" />

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

