### PR TITLE
fix(nicu-ui): eliminate GPL/Alpine license dependencies from UI container

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/Dockerfile
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/Dockerfile
@@ -1,39 +1,41 @@
 # -----------------------------
 # Stage 1: Build the Vite App
 # -----------------------------
-FROM node:20-alpine AS build
- 
+FROM node:20-slim AS build
+
 # Optional build argument for API base URL
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
- 
+
 WORKDIR /app
- 
+
 # Install dependencies
 COPY package.json package-lock.json* ./
 RUN npm install
- 
+
 # Copy source code
 COPY . .
- 
+
 # Build the production app
 RUN npm run build
- 
- 
+
+
 # -----------------------------
 # Stage 2: Serve with Nginx
 # -----------------------------
-FROM nginx:alpine
- 
-# Remove default nginx config
-RUN rm /etc/nginx/conf.d/default.conf
- 
+FROM nginx:1.27.4-bookworm
+
+# Remove GPL-licensed packages not needed by nginx
+RUN apt-get remove --purge -y x11-common && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
- 
+
 # Copy built files from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
- 
+
 EXPOSE 3000
- 
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION

- Switch build stage from node:20-alpine to node:20-slim (Debian 12)
- Switch runtime stage from nginx:alpine to nginx:1.27.4-bookworm (Debian 12)
- Remove x11-common (GPL) via apt-get purge in Dockerfile

Resolves OSPDT findings: no Alpine source code distribution required, no GPL-licensed packages in shipped container image.

