### PR TITLE
Add nicu helm chart

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/configs/model-config.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/configs/model-config.yaml
@@ -13,48 +13,19 @@ preparation:
   pipeline_template: ./pipelines/nicu_shared_pipeline.template.json
   resolved_pipeline: ./pipelines/nicu_shared_pipeline.resolved.json
 
-# --- Model download sections (used by scripts/download_models.py) ---
-detection-models:
-  description: "Custom detection models (person, patient, latch) — pre-converted OpenVINO IR"
-  target_dir: /models
-  models:
-    - name: person-detect-fp32
-      xml_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/person-detect-fp32.xml
-      bin_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/person-detect-fp32.bin
-
-    - name: patient-detect-fp32
-      xml_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/patient-detect-fp32.xml
-      bin_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/patient-detect-fp32.bin
-
-    - name: latch-detect-fp32
-      xml_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/latch-detect-fp32.xml
-      bin_url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/latch-detect-fp32.bin
-
-action-recognition:
-  description: "Open Model Zoo action recognition (encoder + decoder) — FP32 IR"
-  target_dir: /models/action/FP32
-  models:
-    - name: action-recognition-0001-encoder
-      xml_url: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/3/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.xml
-      bin_url: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/3/action-recognition-0001-encoder/FP32/action-recognition-0001-encoder.bin
-
-    - name: action-recognition-0001-decoder
-      xml_url: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/3/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.xml
-      bin_url: https://storage.openvinotoolkit.org/repositories/open_model_zoo/2022.1/models_bin/3/action-recognition-0001-decoder/FP32/action-recognition-0001-decoder.bin
-
-rppg:
-  description: "MTTS-CAN rPPG model — download HDF5 and convert to OpenVINO IR"
-  target_dir: /models/rppg
-  models:
-    - name: mtts_can
-      hdf5_url: https://github.com/xliucs/MTTS-CAN/raw/main/mtts_can.hdf5
-
-video:
-  description: "Default test video for NICU Warmer pipeline"
-  target_dir: /data
-  models:
-    - name: Warmer_Testbed_YTHD
-      url: https://github.com/sakshijha11/edge-ai-suites/releases/download/nicu-models-v1/Warmer_Testbed_YTHD.mp4
+# --- Offline asset manifest ---
+# All models and videos are delivered as offline assets (zip).
+# No external download URLs are required at runtime.
+# See README.md for offline asset setup instructions.
+#
+# Asset inventory (provided in the offline package):
+#   /models/person-detect-fp32.{xml,bin}       — person detection (custom, FP32)
+#   /models/patient-detect-fp32.{xml,bin}       — patient detection (custom, FP32)
+#   /models/latch-detect-fp32.{xml,bin}         — latch detection (custom, FP32)
+#   /models/action/FP32/action-recognition-0001-encoder.{xml,bin}  — action recognition encoder (OMZ)
+#   /models/action/FP32/action-recognition-0001-decoder.{xml,bin}  — action recognition decoder (OMZ)
+#   /models/rppg/mtts_can.{xml,bin}             — rPPG MTTS-CAN (converted from HDF5)
+#   /data/Warmer_Testbed_YTHD.mp4               — test video
 
 metrics_collector:
   base_url: http://nicu-metrics-collector:9000   # docker-compose service DNS

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/Chart.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: nicu-warmer
+description: Health AI Suite - NICU Warmer Patient Monitoring
+type: application
+version: 0.1.0
+appVersion: "2026.1.0-rc1"

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/README.md
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/README.md
@@ -1,0 +1,286 @@
+# NICU Warmer – Helm Deployment
+
+This Helm chart deploys the **NICU Warmer Patient Monitoring** application on Kubernetes.
+
+
+## Prerequisites
+
+- Kubernetes cluster (K3s / Minikube / Kind / Bare-metal)
+- `kubectl`
+- `helm` (v3+)
+- A working PersistentVolume provisioner (required for PVC binding)
+- **NGINX Ingress Controller** (required when `ingress.enabled: true`, which is the default)
+- Intel GPU + NPU hardware (Meteor Lake / Arrow Lake) for accelerated inference
+
+### Ingress Controller prerequisite (required for default configuration)
+
+This chart creates Ingress resources that use `ingressClassName: nginx`. You must have the
+NGINX Ingress Controller running in your cluster before installing the chart with ingress enabled.
+
+```bash
+# Install NGINX Ingress Controller via Helm
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace
+
+# Wait for the controller to be ready
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=120s
+```
+
+If you do not have an ingress controller and do not wish to install one, set
+`ingress.enabled: false` in `values.yaml` and use port-forwarding to access the
+application (see [Access without Ingress](#access-without-ingress-controller) below).
+
+### Storage prerequisite (required)
+
+This chart creates PVCs (`nicu-models-pvc`, `nicu-uploads-pvc`) and expects your
+cluster to provide PersistentVolumes through a StorageClass.
+
+If your cluster has no dynamic provisioner, PVCs will remain `Pending` and workloads will not
+schedule.
+
+```bash
+# Check for existing storage classes
+kubectl get storageclass
+
+# If no default storage class exists, install local-path-provisioner
+kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+
+# Set it as default storage class
+kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+```
+
+## Prepare Offline Assets
+
+The NICU Warmer requires model files, video, and Python extensions to be available on the
+Kubernetes node. Extract the offline assets zip to the host path:
+
+```bash
+sudo mkdir -p /opt/nicu-warmer-assets
+sudo unzip nicu-warmer-assets.zip -d /opt/nicu-warmer-assets/
+```
+
+Expected directory structure:
+```
+/opt/nicu-warmer-assets/
+├── models/
+│   ├── person-detect-fp32.xml
+│   ├── person-detect-fp32.bin
+│   ├── patient-detect-fp32.xml
+│   ├── patient-detect-fp32.bin
+│   ├── latch-detect-fp32.xml
+│   ├── latch-detect-fp32.bin
+│   ├── rppg/
+│   │   ├── mtts_can.xml
+│   │   └── mtts_can.bin
+│   └── action/
+│       ├── FP32/
+│       │   ├── action-recognition-0001-encoder.xml
+│       │   ├── action-recognition-0001-encoder.bin
+│       │   ├── action-recognition-0001-decoder.xml
+│       │   └── action-recognition-0001-decoder.bin
+│       └── kinetics.txt
+├── videos/
+│   └── Warmer_Testbed_YTHD.mp4
+└── extensions/
+    ├── rppg_gva.py
+    ├── action_gva.py
+    └── publisher_utils_patched.py
+```
+
+To customize the host path:
+```bash
+--set assets.loadJob.hostPath=/your/custom/path
+```
+
+## Optional: Proxy Configuration
+
+If deploying behind a proxy, update the proxy settings:
+
+```bash
+helm install nicu-warmer . \
+  --set http_proxy="http://your-proxy:port" \
+  --set https_proxy="http://your-proxy:port" \
+  --set no_proxy="localhost,127.0.0.1,.svc,.cluster.local"
+```
+
+## Install
+
+```bash
+cd health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer
+
+# Default install (mixed-optimized: GPU detection, CPU rPPG, NPU action)
+helm install nicu-warmer . \
+  --namespace nicu \
+  --create-namespace
+```
+
+### Device Profile Override
+
+The chart defaults to the **mixed-optimized** profile (GPU for detection, CPU for rPPG,
+NPU for action recognition) which gives ~15 FPS on Meteor Lake.
+
+Override device selection at install time:
+
+```bash
+# All-CPU (no accelerator required, ~6 FPS)
+helm install nicu-warmer . -n nicu --create-namespace \
+  --set devices.DETECTION_DEVICE=CPU \
+  --set devices.ACTION_DEVICE=CPU
+
+# All-GPU
+helm install nicu-warmer . -n nicu --create-namespace \
+  --set devices.DETECTION_DEVICE=GPU \
+  --set devices.ACTION_DEVICE=GPU \
+  --set devices.RPPG_DEVICE=GPU
+
+# All-NPU
+helm install nicu-warmer . -n nicu --create-namespace \
+  --set devices.DETECTION_DEVICE=NPU \
+  --set devices.ACTION_DEVICE=NPU \
+  --set devices.RPPG_DEVICE=NPU
+```
+
+| Profile | DETECTION_DEVICE | RPPG_DEVICE | ACTION_DEVICE | Expected FPS |
+|---------|-----------------|-------------|---------------|-------------|
+| mixed-optimized (default) | GPU | CPU | NPU | ~15 |
+| all-gpu | GPU | GPU | GPU | ~15 |
+| all-cpu | CPU | CPU | CPU | ~6 |
+| all-npu | NPU | NPU | NPU | ~10 |
+
+> **Limitation:** NPU-optimized (FP16/INT8) models are not yet available; all profiles currently use FP32 models.
+
+## Upgrade (after changes)
+
+```bash
+helm upgrade nicu-warmer . -n nicu
+```
+
+## Verify Deployment
+
+### Pods
+```bash
+kubectl get pods -n nicu
+```
+
+All pods should show:
+```
+STATUS: Running
+READY: 1/1
+```
+
+Expected pods:
+- `nicu-backend` — Flask API for inference orchestration
+- `nicu-dlsps` — DL Streamer Pipeline Server (video inference)
+- `nicu-ui` — React frontend served by nginx
+- `nicu-metrics-collector` — System metrics (CPU/GPU/NPU/Memory)
+- `nicu-mqtt` — MQTT broker for pipeline events
+
+### Services
+```bash
+kubectl get svc -n nicu
+```
+
+### Check Logs
+```bash
+kubectl logs -n nicu deploy/nicu-backend
+kubectl logs -n nicu deploy/nicu-dlsps
+kubectl logs -n nicu deploy/nicu-metrics-collector
+kubectl logs -n nicu deploy/nicu-ui
+```
+
+### Start the Pipeline
+```bash
+# Port-forward to backend
+kubectl port-forward -n nicu svc/nicu-backend 5001:5001
+
+# Start inference
+curl -X POST http://localhost:5001/start
+
+# Check status
+curl http://localhost:5001/metrics
+```
+
+Expected output when running:
+```json
+{
+  "fps": 15.0,
+  "frame_count": 1500,
+  "lifecycle": "running",
+  "runtime_status": "running"
+}
+```
+
+## Access the Frontend UI
+
+### With Ingress (default)
+
+```bash
+kubectl get ingress -n nicu
+```
+
+Add the hostname mapping:
+```bash
+echo "<INGRESS-IP> nicu-warmer.local" | sudo tee -a /etc/hosts
+```
+
+Open: http://nicu-warmer.local/
+
+### Access without Ingress Controller
+
+If deployed with `ingress.enabled: false` or no ingress controller available:
+
+```bash
+# Forward UI service
+kubectl port-forward -n nicu svc/nicu-ui 3000:80 --address 0.0.0.0
+```
+
+Open: http://localhost:3000
+
+From the UI you can:
+- View live video feed with person/patient/latch detection bounding boxes
+- Monitor rPPG (remote photoplethysmography) vitals
+- See action recognition (caretaker activity)
+- View real-time system metrics (CPU/GPU/NPU utilization, memory, power)
+- Start/Stop the inference pipeline
+
+## Architecture
+
+| Service | Description | Port |
+|---------|-------------|------|
+| nicu-backend | Flask API — pipeline orchestration, MQTT consumer | 5001 |
+| nicu-ui | React dashboard served by nginx | 3000 |
+| nicu-metrics-collector | Hardware metrics (GPU/NPU/CPU/Memory) | 9000 |
+| nicu-dlsps | DL Streamer Pipeline Server — GStreamer inference | 8080 |
+| nicu-mqtt | Eclipse Mosquitto MQTT broker | 1883 |
+
+## Configuration
+
+See [values.yaml](values.yaml) for all configurable parameters.
+
+### Key Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `devices.DETECTION_DEVICE` | Device for detection models | `GPU` |
+| `devices.RPPG_DEVICE` | Device for rPPG model | `CPU` |
+| `devices.ACTION_DEVICE` | Device for action recognition | `NPU` |
+| `devices.TARGET_FPS` | Target frame rate | `30` |
+| `backend.image.tag` | Backend image tag | `2026.1.0-rc1` |
+| `ui.image.tag` | UI image tag | `2026.1.0-rc1` |
+| `dlsps.image.tag` | DLSPS image tag | `2026.1.0-ubuntu24-rc1` |
+| `metrics.image.tag` | Metrics collector tag | `2026.0-rc1` |
+| `ingress.enabled` | Enable ingress routing | `true` |
+| `assets.loadJob.hostPath` | Host path for offline assets | `/opt/nicu-warmer-assets` |
+| `persistence.size` | PVC storage size | `20Gi` |
+
+## Uninstall
+
+```bash
+helm uninstall nicu-warmer -n nicu
+kubectl delete namespace nicu
+```

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/_helpers.tpl
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "nicu-warmer.name" -}}
+nicu-warmer
+{{- end }}
+
+{{- define "nicu-warmer.namespace" -}}
+{{ .Values.namespace }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nicu-warmer.labels" -}}
+app.kubernetes.io/name: {{ include "nicu-warmer.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/assets-job.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/assets-job.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.assets.loadJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nicu-load-assets
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app: nicu-load-assets
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: load-assets
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "=== Loading NICU Warmer assets from offline bundle ==="
+
+              # Models
+              echo "Copying detection models..."
+              cp /assets/models/person-detect-fp32.* /models/
+              cp /assets/models/patient-detect-fp32.* /models/
+              cp /assets/models/latch-detect-fp32.* /models/
+
+              echo "Copying rPPG models..."
+              mkdir -p /models/rppg
+              cp /assets/models/rppg/mtts_can.* /models/rppg/
+
+              echo "Copying action recognition models..."
+              mkdir -p /models/action/FP32
+              cp /assets/models/action/FP32/action-recognition-0001-encoder.* /models/action/FP32/
+              cp /assets/models/action/FP32/action-recognition-0001-decoder.* /models/action/FP32/
+              cp /assets/models/action/kinetics.txt /models/action/
+
+              # Video
+              echo "Copying video assets..."
+              cp /assets/videos/*.mp4 /uploads/
+
+              echo "=== All assets loaded successfully ==="
+              ls -lhR /models/
+              ls -lh /uploads/
+          volumeMounts:
+            - name: assets-source
+              mountPath: /assets
+              readOnly: true
+            - name: models
+              mountPath: /models
+            - name: uploads
+              mountPath: /uploads
+      volumes:
+        - name: assets-source
+          hostPath:
+            path: {{ .Values.assets.loadJob.hostPath }}
+            type: Directory
+        - name: models
+          persistentVolumeClaim:
+            claimName: {{ .Values.models.claimName }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ .Values.uploads.claimName }}
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/backend-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/backend-deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nicu-backend
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: nicu-backend
+  template:
+    metadata:
+      labels:
+        app: nicu-backend
+    spec:
+      securityContext:
+        supplementalGroups: [44, 992]
+      containers:
+        - name: nicu-backend
+          image: "{{ .Values.backend.image.repository }}/{{ .Values.backend.image.name }}:{{ .Values.backend.image.tag }}"
+          imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+          ports:
+            - containerPort: 5001
+              protocol: TCP
+          env:
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: METRICS_SERVICE_URL
+              value: {{ .Values.backendConfig.metrics_collector_base_url }}
+            - name: NO_PROXY
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,nicu-mqtt,localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16"
+            - name: no_proxy
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,nicu-mqtt,localhost,127.0.0.1,10.0.0.0/8,192.168.0.0/16"
+            {{- if .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.http_proxy | quote }}
+            - name: http_proxy
+              value: {{ .Values.http_proxy | quote }}
+            {{- end }}
+            {{- if .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.https_proxy | quote }}
+            - name: https_proxy
+              value: {{ .Values.https_proxy | quote }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: nicu-device-config
+          volumeMounts:
+            - name: backend-config
+              mountPath: /app/configs/mvp-backend.yaml
+              subPath: mvp-backend.yaml
+              readOnly: true
+            {{- if .Values.models.enabled }}
+            - name: models
+              mountPath: {{ .Values.models.mountPath }}
+            {{- end }}
+            {{- if .Values.uploads.enabled }}
+            - name: uploads
+              mountPath: {{ .Values.uploads.mountPath }}
+            {{- end }}
+            - name: dri
+              mountPath: /dev/dri
+            - name: accel
+              mountPath: /dev/accel
+            {{- if .Values.dlsps.enabled }}
+            - name: dlsps-shared
+              mountPath: /shared
+            {{- end }}
+          {{- if .Values.backend.resources.limits }}
+          resources:
+            limits:
+              {{- toYaml .Values.backend.resources.limits | nindent 14 }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5001
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5001
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+      volumes:
+        - name: backend-config
+          configMap:
+            name: nicu-backend-config
+        {{- if .Values.models.enabled }}
+        - name: models
+          persistentVolumeClaim:
+            claimName: {{ .Values.models.claimName }}
+        {{- end }}
+        {{- if .Values.uploads.enabled }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ .Values.uploads.claimName }}
+        {{- end }}
+        - name: dri
+          hostPath:
+            path: /dev/dri
+        - name: accel
+          hostPath:
+            path: /dev/accel
+        {{- if .Values.dlsps.enabled }}
+        - name: dlsps-shared
+          emptyDir: {}
+        {{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/configmaps.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/configmaps.yaml
@@ -1,0 +1,138 @@
+# Backend application configuration (mvp-backend.yaml)
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nicu-backend-config
+data:
+  mvp-backend.yaml: |
+    preparation:
+      model_paths:
+        - /models/person-detect-fp32.xml
+        - /models/patient-detect-fp32.xml
+        - /models/latch-detect-fp32.xml
+      rppg_model_path: /models/rppg/mtts_can.xml
+      rppg:
+        enabled: false
+        hdf5_path: /models/mtts_can.hdf5
+        hdf5_url: ""
+        converter_command:
+          - /bin/sh
+          - -c
+          - "echo conversion-not-configured"
+      video_path: /data/uploads/Warmer_Testbed_YTHD.mp4
+      pipeline_template: ./pipelines/nicu_shared_pipeline.template.json
+      resolved_pipeline: ./pipelines/nicu_shared_pipeline.resolved.json
+
+    metrics_collector:
+      base_url: {{ .Values.backendConfig.metrics_collector_base_url }}
+
+    dlsps:
+      base_url: {{ .Values.backendConfig.dlsps_base_url }}
+      timeout_seconds: 2.0
+      assume_reachable: true
+      inference_mode: {{ .Values.backendConfig.inference_mode }}
+      pipeline_name: user_defined_pipelines
+      pipeline_version: nicu_tee
+      status_endpoint: /pipelines/status
+      status_poll_interval_seconds: 1.0
+      device: CPU
+      detections_path: /shared/detections.jsonl
+      mqtt_broker: {{ .Values.backendConfig.mqtt_broker | quote }}
+      mqtt_topic: nicu/detections
+      mqtt_client_id: nicu-backend
+      loop:
+        enabled: true
+        max_loops: -1
+      thresholds:
+        patient_presence: 0.30
+        caretaker_presence: 0.30
+        latch_detection: 0.40
+
+---
+# Device environment configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nicu-device-config
+data:
+  # Individual keys (used by envFrom in backend/dlsps pods)
+  DETECTION_DEVICE: {{ .Values.devices.DETECTION_DEVICE | quote }}
+  RPPG_DEVICE: {{ .Values.devices.RPPG_DEVICE | quote }}
+  ACTION_DEVICE: {{ .Values.devices.ACTION_DEVICE | quote }}
+  TARGET_FPS: {{ .Values.devices.TARGET_FPS | quote }}
+  {{- range $key, $value := .Values.modelPaths }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+  # device.env file (read by metrics-collector via DEVICE_ENV_PATH)
+  device.env: |-
+    DETECTION_DEVICE={{ .Values.devices.DETECTION_DEVICE }}
+    RPPG_DEVICE={{ .Values.devices.RPPG_DEVICE }}
+    ACTION_DEVICE={{ .Values.devices.ACTION_DEVICE }}
+    TARGET_FPS={{ .Values.devices.TARGET_FPS }}
+
+---
+{{- if .Values.mqtt.enabled }}
+# Mosquitto configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nicu-mosquitto-config
+data:
+  mosquitto.conf: |
+    listener 1883
+    allow_anonymous true
+{{- end }}
+
+---
+{{- if .Values.dlsps.enabled }}
+# DLSPS pipeline configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nicu-dlsps-config
+data:
+  config.json: |
+    {
+      "config": {
+        "pipelines": [
+          {
+            "name": "nicu_tee",
+            "source": "gstreamer",
+            "queue_maxsize": 50,
+            "pipeline": "{auto_source} ! decodebin3 ! videoconvert ! video/x-raw,format=BGRx ! gvadetect name=person_detect model-instance-id=person ! queue ! gvadetect name=patient_detect model-instance-id=patient ! queue ! gvadetect name=latch_detect model-instance-id=latch ! queue ! videoconvert ! video/x-raw,format=BGR ! gvapython class=RppgCallback function=process module=/extensions/rppg_gva.py name=rppg_callback ! gvapython class=ActionCallback function=process module=/extensions/action_gva.py name=action_callback ! gvametaconvert add-empty-results=true name=metaconvert ! gvapython class=MQTTPublisher function=process module=/home/pipeline-server/gvapython/mqtt_publisher/mqtt_publisher.py name=mqtt_publisher ! gvafpscounter ! appsink name=appsink",
+            "parameters": {
+              "type": "object",
+              "properties": {
+                "person-detect-properties": { "element": { "name": "person_detect", "format": "element-properties" } },
+                "patient-detect-properties": { "element": { "name": "patient_detect", "format": "element-properties" } },
+                "latch-detect-properties": { "element": { "name": "latch_detect", "format": "element-properties" } },
+                "mqtt_publisher": { "element": { "name": "mqtt_publisher", "property": "kwarg", "format": "json" }, "type": "object" },
+                "rppg_callback": { "element": { "name": "rppg_callback", "property": "kwarg", "format": "json" }, "type": "object" },
+                "action_callback": { "element": { "name": "action_callback", "property": "kwarg", "format": "json" }, "type": "object" }
+              }
+            },
+            "auto_start": false
+          }
+        ]
+      }
+    }
+  pipeline.json: |
+    {
+      "type": "GStreamer",
+      "template": [
+        "{auto_source} ! decodebin3 ! videoconvert ! video/x-raw,format=BGRx ! gvadetect name=person_detect model-instance-id=person ! queue ! gvadetect name=patient_detect model-instance-id=patient ! queue ! gvadetect name=latch_detect model-instance-id=latch ! queue ! videoconvert ! video/x-raw,format=BGR ! gvapython class=RppgCallback function=process module=/extensions/rppg_gva.py name=rppg_callback ! gvapython class=ActionCallback function=process module=/extensions/action_gva.py name=action_callback ! gvametaconvert add-empty-results=true name=metaconvert ! gvapython class=MQTTPublisher function=process module=/home/pipeline-server/gvapython/mqtt_publisher/mqtt_publisher.py name=mqtt_publisher ! gvafpscounter ! appsink name=appsink"
+      ],
+      "description": "DL Streamer Pipeline Server pipeline",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "person-detect-properties": { "element": { "name": "person_detect", "format": "element-properties" } },
+          "patient-detect-properties": { "element": { "name": "patient_detect", "format": "element-properties" } },
+          "latch-detect-properties": { "element": { "name": "latch_detect", "format": "element-properties" } },
+          "mqtt_publisher": { "element": { "name": "mqtt_publisher", "property": "kwarg", "format": "json" }, "type": "object" },
+          "rppg_callback": { "element": { "name": "rppg_callback", "property": "kwarg", "format": "json" }, "type": "object" },
+          "action_callback": { "element": { "name": "action_callback", "property": "kwarg", "format": "json" }, "type": "object" }
+        }
+      }
+    }
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/dlsps-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/dlsps-deployment.yaml
@@ -1,0 +1,133 @@
+{{- if .Values.dlsps.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nicu-dlsps
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: nicu-dlsps
+  template:
+    metadata:
+      labels:
+        app: nicu-dlsps
+    spec:
+      hostPID: true
+      securityContext:
+        supplementalGroups: [44, 992]
+      initContainers:
+        - name: setup-pipeline-dir
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              mkdir -p /var/cache/pipeline_root/user_defined_pipelines/nicu_tee
+              cp /pipeline-src/pipeline.json /var/cache/pipeline_root/user_defined_pipelines/nicu_tee/pipeline.json
+              chmod -R 777 /var/cache/pipeline_root
+          volumeMounts:
+            - name: pipeline-root
+              mountPath: /var/cache/pipeline_root
+            - name: dlsps-pipeline
+              mountPath: /pipeline-src
+              readOnly: true
+      containers:
+        - name: nicu-dlsps
+          image: "{{ .Values.dlsps.image.repository }}/{{ .Values.dlsps.image.name }}:{{ .Values.dlsps.image.tag }}"
+          imagePullPolicy: {{ .Values.dlsps.image.pullPolicy }}
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: REST_SERVER_PORT
+              value: "8080"
+            - name: MQTT_HOST
+              value: "nicu-mqtt"
+            - name: MQTT_PORT
+              value: "1883"
+            - name: NO_PROXY
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,nicu-mqtt,localhost,127.0.0.1"
+            - name: no_proxy
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,nicu-mqtt,localhost,127.0.0.1"
+            {{- if .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.http_proxy | quote }}
+            - name: http_proxy
+              value: {{ .Values.http_proxy | quote }}
+            {{- end }}
+            {{- if .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.https_proxy | quote }}
+            - name: https_proxy
+              value: {{ .Values.https_proxy | quote }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: nicu-device-config
+          volumeMounts:
+            - name: models
+              mountPath: /models
+            - name: dlsps-shared
+              mountPath: /shared
+            - name: dri
+              mountPath: /dev/dri
+            - name: sys-drm
+              mountPath: /sys/class/drm
+              readOnly: true
+            - name: dlsps-config
+              mountPath: /home/pipeline-server/config.json
+              subPath: config.json
+              readOnly: true
+            - name: pipeline-root
+              mountPath: /var/cache/pipeline_root
+            - name: extensions
+              mountPath: /extensions
+              readOnly: true
+            - name: uploads
+              mountPath: /data/uploads
+              readOnly: true
+          {{- if .Values.dlsps.resources.limits }}
+          resources:
+            limits:
+              {{- toYaml .Values.dlsps.resources.limits | nindent 14 }}
+          {{- end }}
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: {{ .Values.models.claimName }}
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ .Values.uploads.claimName }}
+        - name: dlsps-shared
+          emptyDir: {}
+        - name: pipeline-root
+          emptyDir: {}
+        - name: dri
+          hostPath:
+            path: /dev/dri
+        - name: sys-drm
+          hostPath:
+            path: /sys/class/drm
+        - name: dlsps-config
+          configMap:
+            name: nicu-dlsps-config
+            items:
+              - key: config.json
+                path: config.json
+        - name: dlsps-pipeline
+          configMap:
+            name: nicu-dlsps-config
+            items:
+              - key: pipeline.json
+                path: pipeline.json
+        - name: extensions
+          hostPath:
+            path: {{ .Values.assets.loadJob.hostPath }}/extensions
+            type: DirectoryOrCreate
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/ingress.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nicu-warmer-ingress
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ .service }}
+                port:
+                  number: {{ .port }}
+        {{- end }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/metrics-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/metrics-deployment.yaml
@@ -1,0 +1,113 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nicu-metrics-collector
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: nicu-metrics-collector
+  template:
+    metadata:
+      labels:
+        app: nicu-metrics-collector
+    spec:
+      hostPID: true
+      containers:
+        - name: nicu-metrics-collector
+          image: "{{ .Values.metrics.image.repository }}/{{ .Values.metrics.image.name }}:{{ .Values.metrics.image.tag }}"
+          imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 9000
+              protocol: TCP
+          env:
+            - name: METRICS_DIR
+              value: "/tmp/results"
+            - name: NPU_LOG
+              value: "/tmp/results/npu_usage.csv"
+            - name: METRICS_HTTP_PORT
+              value: "9000"
+            - name: DEVICE_ENV_PATH
+              value: /configs/device.env
+            {{- if .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.http_proxy | quote }}
+            {{- end }}
+            {{- if .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.https_proxy | quote }}
+            {{- end }}
+            - name: NO_PROXY
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,localhost,127.0.0.1"
+          volumeMounts:
+            - name: results
+              mountPath: /tmp/results
+            - name: device-config
+              mountPath: /configs
+              readOnly: true
+            - name: dri
+              mountPath: /dev/dri
+            - name: dev
+              mountPath: /dev
+            - name: sys
+              mountPath: /sys
+            - name: sys-devices
+              mountPath: /sys/devices
+            - name: sys-drm
+              mountPath: /sys/class/drm
+            - name: sys-debug
+              mountPath: /sys/kernel/debug
+            - name: run
+              mountPath: /run
+            - name: proc
+              mountPath: /proc
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+      volumes:
+        - name: results
+          emptyDir: {}
+        - name: device-config
+          configMap:
+            name: nicu-device-config
+            items:
+              - key: device.env
+                path: device.env
+        - name: dri
+          hostPath:
+            path: /dev/dri
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: sys-devices
+          hostPath:
+            path: /sys/devices
+        - name: sys-drm
+          hostPath:
+            path: /sys/class/drm
+        - name: sys-debug
+          hostPath:
+            path: /sys/kernel/debug
+        - name: run
+          hostPath:
+            path: /run
+        - name: proc
+          hostPath:
+            path: /proc

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/mqtt-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/mqtt-deployment.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.mqtt.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nicu-mqtt
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nicu-mqtt
+  template:
+    metadata:
+      labels:
+        app: nicu-mqtt
+    spec:
+      containers:
+        - name: nicu-mqtt
+          image: "{{ .Values.mqtt.image.repository }}:{{ .Values.mqtt.image.tag }}"
+          imagePullPolicy: {{ .Values.mqtt.image.pullPolicy }}
+          command: ["mosquitto", "-p", "1883", "-c", "/mosquitto-no-auth.conf"]
+          ports:
+            - containerPort: 1883
+              protocol: TCP
+          volumeMounts:
+            - name: mosquitto-config
+              mountPath: /mosquitto-no-auth.conf
+              subPath: mosquitto.conf
+              readOnly: true
+          livenessProbe:
+            tcpSocket:
+              port: 1883
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 1883
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: mosquitto-config
+          configMap:
+            name: nicu-mosquitto-config
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/pvc.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/pvc.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.models.claimName }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.uploads.claimName }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: 5Gi

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/services.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/services.yaml
@@ -1,0 +1,83 @@
+{{- $serviceType := .Values.service.type | default "ClusterIP" }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nicu-backend
+spec:
+  type: {{ $serviceType }}
+  selector:
+    app: nicu-backend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 5001
+      protocol: TCP
+    - name: http-direct
+      port: 5001
+      targetPort: 5001
+      protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nicu-ui
+spec:
+  type: {{ $serviceType }}
+  selector:
+    app: nicu-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000
+      protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nicu-metrics-collector
+spec:
+  type: {{ $serviceType }}
+  selector:
+    app: nicu-metrics-collector
+  ports:
+    - name: http
+      port: 9000
+      targetPort: 9000
+      protocol: TCP
+
+---
+{{- if .Values.dlsps.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: nicu-dlsps
+spec:
+  type: {{ $serviceType }}
+  selector:
+    app: nicu-dlsps
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+---
+{{- end }}
+
+{{- if .Values.mqtt.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: nicu-mqtt
+spec:
+  type: {{ $serviceType }}
+  selector:
+    app: nicu-mqtt
+  ports:
+    - name: mqtt
+      port: 1883
+      targetPort: 1883
+      protocol: TCP
+{{- end }}

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/ui-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/templates/ui-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nicu-ui
+  labels:
+    {{- include "nicu-warmer.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: nicu-ui
+  template:
+    metadata:
+      labels:
+        app: nicu-ui
+    spec:
+      containers:
+        - name: nicu-ui
+          image: "{{ .Values.ui.image.repository }}/{{ .Values.ui.image.name }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+          env:
+            {{- if .Values.ingress.enabled }}
+            - name: VITE_API_BASE_URL
+              value: "/api"
+            {{- else }}
+            - name: VITE_API_BASE_URL
+              value: "http://localhost:5001"
+            {{- end }}
+            {{- if .Values.http_proxy }}
+            - name: HTTP_PROXY
+              value: {{ .Values.http_proxy | quote }}
+            {{- end }}
+            {{- if .Values.https_proxy }}
+            - name: HTTPS_PROXY
+              value: {{ .Values.https_proxy | quote }}
+            {{- end }}
+            - name: NO_PROXY
+              value: "nicu-backend,nicu-ui,nicu-metrics-collector,nicu-dlsps,localhost,127.0.0.1"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/values.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/helm/nicu-warmer/values.yaml
@@ -1,0 +1,142 @@
+namespace: ""
+replicaCount: 1
+
+http_proxy: ""
+https_proxy: ""
+no_proxy: "localhost,127.0.0.1,.svc,.cluster.local"
+
+persistence:
+  size: 20Gi
+  accessMode: ReadWriteOnce
+  storageClassName: ""
+
+# Shared PVC for model artifacts and uploads
+models:
+  enabled: true
+  mountPath: /models
+  claimName: nicu-models-pvc
+
+uploads:
+  enabled: true
+  mountPath: /data/uploads
+  claimName: nicu-uploads-pvc
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/chunked-transfer-encoding: "on"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  hosts:
+    - host: nicu-warmer.local
+      paths:
+        # Backend API
+        - path: /api(/|$)(.*)
+          pathType: ImplementationSpecific
+          service: nicu-backend
+          port: 80
+        # Frontend UI (catch-all)
+        - path: /()(.*)
+          pathType: ImplementationSpecific
+          service: nicu-ui
+          port: 80
+  tls: []
+
+# Images
+backend:
+  image:
+    repository: intel
+    name: hl-ai-nicu-backend
+    tag: "2026.1.0-rc1"
+    pullPolicy: IfNotPresent
+  resources: {}
+
+ui:
+  image:
+    repository: intel
+    name: hl-ai-nicu-ui
+    tag: "2026.1.0-rc1"
+    pullPolicy: IfNotPresent
+
+metrics:
+  image:
+    repository: intel
+    name: hl-ai-metrics-collector
+    tag: "2026.0-rc1"
+    pullPolicy: IfNotPresent
+
+# DLSPS + MQTT (required for inference pipeline)
+dlsps:
+  enabled: true
+  image:
+    repository: intel
+    name: dlstreamer-pipeline-server
+    tag: "2026.1.0-ubuntu24-rc1"
+    pullPolicy: IfNotPresent
+  resources: {}
+
+mqtt:
+  enabled: true
+  image:
+    repository: eclipse-mosquitto
+    name: ""
+    tag: "2"
+    pullPolicy: IfNotPresent
+
+# Backend configuration (inline mvp-backend.yaml)
+backendConfig:
+  inference_mode: dlsps
+  metrics_collector_base_url: http://nicu-metrics-collector:9000
+  dlsps_base_url: http://nicu-dlsps:8080
+  mqtt_broker: "nicu-mqtt:1883"
+
+# Offline assets loading
+assets:
+  loadJob:
+    enabled: true
+    # Path on the host where user extracts the offline assets zip
+    # Expected structure:
+    #   <hostPath>/models/person-detect-fp32.{xml,bin}
+    #   <hostPath>/models/patient-detect-fp32.{xml,bin}
+    #   <hostPath>/models/latch-detect-fp32.{xml,bin}
+    #   <hostPath>/models/rppg/mtts_can.{xml,bin}
+    #   <hostPath>/models/action/FP32/action-recognition-0001-{encoder,decoder}.{xml,bin}
+    #   <hostPath>/models/action/kinetics.txt
+    #   <hostPath>/videos/Warmer_Testbed_YTHD.mp4
+    #   <hostPath>/extensions/rppg_gva.py
+    #   <hostPath>/extensions/action_gva.py
+    #   <hostPath>/extensions/publisher_utils_patched.py
+    hostPath: /opt/nicu-warmer-assets
+
+# Device configuration — controls which Intel accelerator each workload uses.
+# Valid values: CPU | GPU | NPU
+# Override at install time: --set devices.DETECTION_DEVICE=CPU
+#
+# Profiles (set all at once with -f):
+#   mixed-optimized (default): GPU detection, CPU rPPG, NPU action → best throughput
+#   all-gpu:                   GPU detection, GPU rPPG, GPU action
+#   all-cpu:                   CPU detection, CPU rPPG, CPU action (no accelerator needed)
+#   all-npu:                   NPU detection, NPU rPPG, NPU action
+devices:
+  DETECTION_DEVICE: "GPU"
+  RPPG_DEVICE: "CPU"
+  ACTION_DEVICE: "NPU"
+  TARGET_FPS: "30"
+
+# Model paths — fixed regardless of device selection
+modelPaths:
+  PERSON_MODEL: "/models/person-detect-fp32.xml"
+  PATIENT_MODEL: "/models/patient-detect-fp32.xml"
+  LATCH_MODEL: "/models/latch-detect-fp32.xml"
+  RPPG_MODEL: "/models/rppg/mtts_can.xml"
+  ACTION_ENCODER: "/models/action/FP32/action-recognition-0001-encoder.xml"
+  ACTION_DECODER: "/models/action/FP32/action-recognition-0001-decoder.xml"

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/Dockerfile
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/Dockerfile
@@ -1,39 +1,41 @@
 # -----------------------------
 # Stage 1: Build the Vite App
 # -----------------------------
-FROM node:20-alpine AS build
- 
+FROM node:20-slim AS build
+
 # Optional build argument for API base URL
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
- 
+
 WORKDIR /app
- 
+
 # Install dependencies
 COPY package.json package-lock.json* ./
 RUN npm install
- 
+
 # Copy source code
 COPY . .
- 
+
 # Build the production app
 RUN npm run build
- 
- 
+
+
 # -----------------------------
 # Stage 2: Serve with Nginx
 # -----------------------------
-FROM nginx:alpine
- 
-# Remove default nginx config
-RUN rm /etc/nginx/conf.d/default.conf
- 
+FROM nginx:1.27.4-bookworm
+
+# Remove GPL-licensed packages not needed by nginx
+RUN apt-get remove --purge -y x11-common && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
 # Copy custom nginx config
 COPY nginx.conf /etc/nginx/conf.d/default.conf
- 
+
 # Copy built files from build stage
 COPY --from=build /app/dist /usr/share/nginx/html
- 
+
 EXPOSE 3000
- 
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Fixes: https://jira.devtools.intel.com/browse/ITEP-92481

Helm chart for deploying the NICU Warmer application on Kubernetes (K3s/K8s). Deploys 5 services: backend, DL Streamer pipeline server, UI, metrics-collector, and MQTT broker.

Device selection is configurable at install time via --set devices.DETECTION_DEVICE=GPU|CPU|NPU.

### Tested (E2E on K3s, Meteor Lake)

- All 5 pods Running & Ready
- GPU inference working at 15 FPS
- CPU fallback working at 6 FPS
- NPU active for action recognition (9.7% utilization)
- Metrics endpoint reporting CPU/GPU/NPU/Memory
- UI accessible via port-forward
- Device override via helm --set verified
- helm lint passes

### Limitations

- NPU-optimized models (FP16/INT8) are not yet available; all device profiles currently use FP32 models. NPU inference works but does not achieve full NPU throughput.
- GPU/NPU access requires hostPID: true and privileged: true due to Level-Zero shared memory requirements in containerd/K8s. This is a platform constraint, not a chart design choice.
- Chart tested on single-node K3s
- Ingress requires NGINX Ingress Controller pre-installed; without it, use port-forwarding.