### PR TITLE
fix(multimodal): enable NPU support on Wildcat Lake platform

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/configs/device.env
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/configs/device.env
@@ -1,5 +1,7 @@
 # Default inference devices
-# Valid values: CPU | GPU | NPU 
+# Valid values: CPU | GPU | NPU
+# NPU requires: /dev/accel device, render group access, and
+# compatible NPU drivers (linux-npu-driver >= v1.32.1 for Wildcat Lake)
 
 ECG_DEVICE=GPU
 RPPG_DEVICE=GPU

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/run_compose.sh
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/run_compose.sh
@@ -26,6 +26,8 @@ if [[ "${ECG_DEVICE:-}" == "NPU" ]]; then
     devices:
       - "/dev/dri:/dev/dri"
       - "/dev/accel/accel0:/dev/accel/accel0"
+    group_add:
+      - render
 EOF
 fi
 
@@ -38,6 +40,8 @@ if [[ "${POSE_3D_DEVICE:-}" == "NPU" ]]; then
     devices:
       - "/dev/dri:/dev/dri"
       - "/dev/accel/accel0:/dev/accel/accel0"
+    group_add:
+      - render
 EOF
 fi
 
@@ -50,6 +54,8 @@ if [[ "${RPPG_DEVICE:-}" == "NPU" ]]; then
     devices:
       - "/dev/dri:/dev/dri"
       - "/dev/accel/accel0:/dev/accel/accel0"
+    group_add:
+      - render
 EOF
 fi
 

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/3d-pose-estimation/scripts/install_ubuntu_npu_drivers.sh
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/3d-pose-estimation/scripts/install_ubuntu_npu_drivers.sh
@@ -22,8 +22,9 @@ set -o pipefail
 
 # Default URLs for linux-npu-driver and Level Zero (can be overridden
 # via environment variables or Docker build args).
-: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.23.0/linux-npu-driver-v1.23.0.20250827-17270089246-ubuntu2204.tar.gz}"
-: "${LEVEL_ZERO_URL:=https://github.com/oneapi-src/level-zero/releases/download/v1.22.4/level-zero_1.22.4+u22.04_amd64.deb}"
+# v1.32.1 supports Meteor Lake, Arrow Lake, Lunar Lake, Panther Lake, and Wildcat Lake.
+: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.32.1/linux-npu-driver-v1.32.1.20260422-24767473183-ubuntu2404.tar.gz}"
+: "${LEVEL_ZERO_URL:=https://snapshot.ppa.launchpadcontent.net/kobuk-team/intel-graphics/ubuntu/20260324T100000Z/pool/main/l/level-zero-loader/libze1_1.27.0-1~24.04~ppa2_amd64.deb}"
 
 # LEVEL_ZERO_URL can be overridden or set empty to skip Level Zero
 # installation if a compatible runtime is already present.
@@ -44,17 +45,24 @@ fi
 
 tar -xf "${TARBALL_NAME}"
 
-# Install all .deb packages from linux-npu-driver bundle
-if ! dpkg -i ./*.deb; then
-    # Attempt to fix missing dependencies
-    apt-get update && apt-get -f install -y || true
+# Install all .deb packages from linux-npu-driver bundle using apt
+# (apt handles dependencies better than dpkg)
+apt-get update
+if ! apt-get install -y --no-install-recommends --allow-downgrades ./intel-*.deb 2>/dev/null; then
+    # Fallback to dpkg for non-Ubuntu base images
+    dpkg -i ./intel-*.deb || true
+    apt-get -f install -y || true
 fi
 
-# Optionally install Level Zero runtime if URL provided
+# Install Level Zero loader if URL provided
 if [ -n "${LEVEL_ZERO_URL}" ]; then
-    curl -L -O "${LEVEL_ZERO_URL}" && \
-    dpkg -i level-zero_*.deb || true
+    curl -L -o level-zero-loader.deb "${LEVEL_ZERO_URL}" && \
+    apt-get install -y --no-install-recommends --allow-downgrades ./level-zero-loader.deb 2>/dev/null || \
+    dpkg -i ./level-zero-loader.deb || true
 fi
+
+# Ensure render group exists in container (for device access)
+groupadd -f render 2>/dev/null || true
 
 apt-get clean && rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/npu_deps

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/3d-pose-estimation/src/inference.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/3d-pose-estimation/src/inference.py
@@ -48,17 +48,15 @@ class PoseInference:
             self._configure_device_properties(device, device_properties)
     
         try:
-            # Compile model for GPU - no fallback for GPU-only operation
             self.compiled_model = self.core.compile_model(str(self.model_path), device)
             self.device = device
-            logger.info("✓ 3D pose model loaded successfully on GPU")
+            logger.info(f"✓ 3D pose model loaded successfully on {device}")
             print(f"[INFO] ✓ Successfully loaded model on {device}")
     
         except Exception as e:
             logger.error(f"Failed to load model on {device}: {e}")
             print(f"[ERROR] Failed to load on {device}: {e}")
-            # For 3D pose, we want GPU-only operation, so don't fallback
-            raise RuntimeError(f"GPU inference required but failed: {e}")
+            raise RuntimeError(f"Failed to compile model on {device}: {e}")
     
         # Get input/output info
         self.input_layer = self.compiled_model.input(0)

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/scripts/install_ubuntu_npu_drivers.sh
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ai-ecg/backend/scripts/install_ubuntu_npu_drivers.sh
@@ -22,8 +22,9 @@ set -o pipefail
 
 # Default URLs for linux-npu-driver and Level Zero (can be overridden
 # via environment variables or Docker build args).
-: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.23.0/linux-npu-driver-v1.23.0.20250827-17270089246-ubuntu2204.tar.gz}"
-: "${LEVEL_ZERO_URL:=https://github.com/oneapi-src/level-zero/releases/download/v1.22.4/level-zero_1.22.4+u22.04_amd64.deb}"
+# v1.32.1 supports Meteor Lake, Arrow Lake, Lunar Lake, Panther Lake, and Wildcat Lake.
+: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.32.1/linux-npu-driver-v1.32.1.20260422-24767473183-ubuntu2404.tar.gz}"
+: "${LEVEL_ZERO_URL:=https://snapshot.ppa.launchpadcontent.net/kobuk-team/intel-graphics/ubuntu/20260324T100000Z/pool/main/l/level-zero-loader/libze1_1.27.0-1~24.04~ppa2_amd64.deb}"
 
 # LEVEL_ZERO_URL can be overridden or set empty to skip Level Zero
 # installation if a compatible runtime is already present.
@@ -44,17 +45,24 @@ fi
 
 tar -xf "${TARBALL_NAME}"
 
-# Install all .deb packages from linux-npu-driver bundle
-if ! dpkg -i ./*.deb; then
-    # Attempt to fix missing dependencies
-    apt-get update && apt-get -f install -y || true
+# Install all .deb packages from linux-npu-driver bundle using apt
+# (apt handles dependencies better than dpkg)
+apt-get update
+if ! apt-get install -y --no-install-recommends --allow-downgrades ./intel-*.deb 2>/dev/null; then
+    # Fallback to dpkg for non-Ubuntu base images
+    dpkg -i ./intel-*.deb || true
+    apt-get -f install -y || true
 fi
 
-# Optionally install Level Zero runtime if URL provided
+# Install Level Zero loader if URL provided
 if [ -n "${LEVEL_ZERO_URL}" ]; then
-    curl -L -O "${LEVEL_ZERO_URL}" && \
-    dpkg -i level-zero_*.deb || true
+    curl -L -o level-zero-loader.deb "${LEVEL_ZERO_URL}" && \
+    apt-get install -y --no-install-recommends --allow-downgrades ./level-zero-loader.deb 2>/dev/null || \
+    dpkg -i ./level-zero-loader.deb || true
 fi
+
+# Ensure render group exists in container (for device access)
+groupadd -f render 2>/dev/null || true
 
 apt-get clean && rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/npu_deps

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/rppg/scripts/install_ubuntu_npu_drivers.sh
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/rppg/scripts/install_ubuntu_npu_drivers.sh
@@ -22,8 +22,9 @@ set -o pipefail
 
 # Default URLs for linux-npu-driver and Level Zero (can be overridden
 # via environment variables or Docker build args).
-: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.23.0/linux-npu-driver-v1.23.0.20250827-17270089246-ubuntu2204.tar.gz}"
-: "${LEVEL_ZERO_URL:=https://github.com/oneapi-src/level-zero/releases/download/v1.22.4/level-zero_1.22.4+u22.04_amd64.deb}"
+# v1.32.1 supports Meteor Lake, Arrow Lake, Lunar Lake, Panther Lake, and Wildcat Lake.
+: "${NPU_DRIVER_URL:=https://github.com/intel/linux-npu-driver/releases/download/v1.32.1/linux-npu-driver-v1.32.1.20260422-24767473183-ubuntu2404.tar.gz}"
+: "${LEVEL_ZERO_URL:=https://snapshot.ppa.launchpadcontent.net/kobuk-team/intel-graphics/ubuntu/20260324T100000Z/pool/main/l/level-zero-loader/libze1_1.27.0-1~24.04~ppa2_amd64.deb}"
 
 # LEVEL_ZERO_URL can be overridden or set empty to skip Level Zero
 # installation if a compatible runtime is already present.
@@ -44,17 +45,24 @@ fi
 
 tar -xf "${TARBALL_NAME}"
 
-# Install all .deb packages from linux-npu-driver bundle
-if ! dpkg -i ./*.deb; then
-    # Attempt to fix missing dependencies
-    apt-get update && apt-get -f install -y || true
+# Install all .deb packages from linux-npu-driver bundle using apt
+# (apt handles dependencies better than dpkg)
+apt-get update
+if ! apt-get install -y --no-install-recommends --allow-downgrades ./intel-*.deb 2>/dev/null; then
+    # Fallback to dpkg for non-Ubuntu base images
+    dpkg -i ./intel-*.deb || true
+    apt-get -f install -y || true
 fi
 
-# Optionally install Level Zero runtime if URL provided
+# Install Level Zero loader if URL provided
 if [ -n "${LEVEL_ZERO_URL}" ]; then
-    curl -L -O "${LEVEL_ZERO_URL}" && \
-    dpkg -i level-zero_*.deb || true
+    curl -L -o level-zero-loader.deb "${LEVEL_ZERO_URL}" && \
+    apt-get install -y --no-install-recommends --allow-downgrades ./level-zero-loader.deb 2>/dev/null || \
+    dpkg -i ./level-zero-loader.deb || true
 fi
+
+# Ensure render group exists in container (for device access)
+groupadd -f render 2>/dev/null || true
 
 apt-get clean && rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/npu_deps


### PR DESCRIPTION
Root cause: run_compose.sh NPU override missing render group for /dev/accel access. Additionally, NPU user-space driver v1.23.0 in containers doesn't support the WCL 50xx NPU generation (device fd3e).

Changes:
- run_compose.sh: Add group_add render to NPU device override (keeps all NPU config in the dynamic override per reviewer feedback)
- install_ubuntu_npu_drivers.sh: Upgrade NPU driver v1.23.0 -> v1.32.1 and Level Zero v1.22.4 -> v1.27.0 (adds WCL/PTL/ARL support)
- inference.py: Fix misleading 'GPU inference required' error message when NPU device is selected
- device.env: Document NPU requirements

Tested on WCL machine (BA38RNL66114, kernel 6.17.0-29-generic):
- With fix: OpenVINO detects ['CPU', 'NPU'], inference runs on NPU
- Without fix: 'No NPU devices found' / 'must be used with LEVEL0 backend'

Fixes: ITEP-90946, ITEP-90867


