### PR TITLE
feat(nicu-ui): show WAITING state on ActionCard before pipeline starts

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/ActionCard.tsx
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/ActionCard.tsx
@@ -3,6 +3,8 @@ import type { ActionData } from '../../types/nicu';
 
 interface ActionCardProps {
   action: ActionData;
+  systemStatus?: string;
+  patientDetected?: boolean;
 }
 
 const MOTION_COLORS: Record<string, string> = {
@@ -16,9 +18,11 @@ const MOTION_COLORS: Record<string, string> = {
 // Hold movement state for this many ms so the user can read it
 const STICKY_HOLD_MS = 2000;
 
-const ActionCard: React.FC<ActionCardProps> = ({ action }) => {
+const ActionCard: React.FC<ActionCardProps> = ({ action, systemStatus, patientDetected }) => {
+  const pipelineRunning = systemStatus === 'running' || systemStatus === 'starting';
   const isValid = action.status === 'valid';
   const isError = action.status === 'error';
+  const isWarmingUp = action.status === 'warming_up' && !pipelineRunning;
   const motionLevel = action.motion_level || 'unknown';
   const topActivity = action.top_activity || 'Unknown';
   const isModelStill = topActivity === 'Resting / Still';
@@ -57,6 +61,20 @@ const ActionCard: React.FC<ActionCardProps> = ({ action }) => {
     pillMod = 'nicu-det-pill--off';
     pillText = '✗ ERR';
     subText = 'Error';
+    confColor = '#999';
+    confValue = 0;
+  } else if (isWarmingUp) {
+    cardMod = 'nicu-det-card--off';
+    pillMod = 'nicu-det-pill--off';
+    pillText = '⏳ WAITING';
+    subText = 'Waiting for pipeline';
+    confColor = '#999';
+    confValue = 0;
+  } else if (!isValid && pipelineRunning && !patientDetected) {
+    cardMod = 'nicu-det-card--off';
+    pillMod = 'nicu-det-pill--off';
+    pillText = 'IDLE';
+    subText = 'No patient detected';
     confColor = '#999';
     confValue = 0;
   } else if (!isValid || isStill) {

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/NicuPanel.tsx
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/ui/src/components/NicuPanel/NicuPanel.tsx
@@ -85,7 +85,7 @@ const NicuPanel: React.FC<NicuPanelProps> = ({ expanded = false }) => {
                 detail={caretakerDetail}
               />
               <LatchStatusCard latch={nicu.latch} />
-              <ActionCard action={nicu.action} />
+              <ActionCard action={nicu.action} systemStatus={nicu.systemStatus} patientDetected={nicu.patient.detected} />
             </div>
 
             {/* rPPG — always below, never expandable */}
@@ -122,7 +122,7 @@ const NicuPanel: React.FC<NicuPanelProps> = ({ expanded = false }) => {
                 detail={caretakerDetail}
               />
               <LatchStatusCard latch={nicu.latch} />
-              <ActionCard action={nicu.action} />
+              <ActionCard action={nicu.action} systemStatus={nicu.systemStatus} patientDetected={nicu.patient.detected} />
             </div>
 
             <span className="nicu-section-label">Vital Signs</span>


### PR DESCRIPTION
ActionCard now accepts systemStatus prop and displays '⏳ WAITING / Waiting for pipeline' when the system is not yet running (status is warming_up and pipeline has not started). Once the pipeline transitions to running/starting, the card falls through to the normal STILL or MOVEMENT display logic.


