### PR TITLE
[DOCS] Fix references in Metro SDK Manager config.js

### DIFF
--- a/metro-ai-suite/metro-sdk-manager/docs/oep-sdk-manager-files/config.js
+++ b/metro-ai-suite/metro-sdk-manager/docs/oep-sdk-manager-files/config.js
@@ -71,8 +71,8 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           components: [
-            "DLStreamer",
-            "DLStreamer Pipeline Server",
+            "DL Streamer",
+            "DL Streamer Pipeline Server",
             "OpenVINO",
             "OpenVINO Model Server",
             "SceneScape Manager",
@@ -108,7 +108,7 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           components: [
-            "DLStreamer Pipeline Server",
+            "DL Streamer Pipeline Server",
             "Node Red",
             "Grafana",
             "MediaMTX",
@@ -123,8 +123,8 @@ const CONFIG = {
             VERSION: "2026.0"
           },
           components: [
-            "DLStreamer",
-            "DLStreamer Pipeline Server",
+            "DL Streamer",
+            "DL Streamer Pipeline Server",
             "OpenVINO",
             "OpenVINO Model Server",
             "Edge AI Libraries - Repo",
@@ -156,7 +156,7 @@ const CONFIG = {
             VERSION: "2026.0"
           },
           components: [
-            "DLStreamer Pipeline Server",
+            "DL Streamer Pipeline Server",
             "Node Red",
             "Grafana",
             "MediaMTX",
@@ -171,8 +171,8 @@ const CONFIG = {
             VERSION: "latest"
           },
           components: [
-            "DLStreamer",
-            "DLStreamer Pipeline Server",
+            "DL Streamer",
+            "DL Streamer Pipeline Server",
             "OpenVINO",
             "OpenVINO Model Server",
             "SceneScape Manager",
@@ -208,7 +208,7 @@ const CONFIG = {
             VERSION: "latest"
           },
           components: [
-            "DLStreamer Pipeline Server",
+            "DL Streamer Pipeline Server",
             "Node Red",
             "Grafana",
             "MediaMTX",
@@ -316,7 +316,7 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           text: `Get Started`,
-          link: `https://docs.openedgeplatform.intel.com/2026.1/edge-ai-suites/metro-sdk-manager/oep-vision-ai-sdk/get-started.html`
+          link: `https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/oep-sdk-manager/oep-vision-ai-sdk/get-started.html`
         },
         {
           when: {
@@ -325,7 +325,7 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           text: `Get Started`,
-          link: `https://docs.openedgeplatform.intel.com/2026.1/edge-ai-suites/metro-sdk-manager/oep-gen-ai-sdk/get-started.html`
+          link: `https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/oep-sdk-manager/oep-gen-ai-sdk/get-started.html`
         },
         {
           when: {
@@ -334,7 +334,7 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           text: `Get Started`,
-          link: `https://docs.openedgeplatform.intel.com/2026.1/edge-ai-suites/metro-sdk-manager/visual-ai-demo-kit/get-started.html`
+          link: `https://docs.openedgeplatform.intel.com/2026.1/OEP-articles/oep-sdk-manager/visual-ai-demo-kit/get-started.html`
         },
         {
           when: {
@@ -404,8 +404,8 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
             { text: "OpenVINO", url: "https://docs.openvino.ai/2026/get-started.html" },
             { text: "OpenVINO Model Server", url: "https://docs.openvino.ai/2026/model-server/ovms_what_is_openvino_model_server.html" },
             { text: "Intel® SceneScape", url: "https://github.com/open-edge-platform/scenescape" },
@@ -421,10 +421,10 @@ const CONFIG = {
           },
           links: [
             { text: "Audio Analyzer", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/audio-analyzer/index.html" },
-            { text: "Document Ingestion - pgvector", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/document-ingestion/pgvector/docs/user-guide/get-started.md" },
-            { text: "Multimodal Embedding Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/multimodal-embedding-serving/docs/user-guide/index.md" },
-            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
-            { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
+            { text: "Document Ingestion - pgvector", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/pgvector/index.html" },
+            { text: "Multimodal Embedding Serving", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/multimodal-embedding-serving/index.html" },
+            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.1.0/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
+            { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.1.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
             { text: "Chat Q&A", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/chat-question-and-answer/index.html" },
             { text: "Chat Q&A Core", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/chat-question-and-answer-core/index.html" },
             { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/2026.1/ai-libraries.html"},
@@ -438,8 +438,8 @@ const CONFIG = {
             VERSION: "2026.1"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.1/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
             { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/2026.1/ai-libraries.html"},
             { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/2026.1/ai-suite-metro.html"}
           ]
@@ -451,12 +451,12 @@ const CONFIG = {
             VERSION: "2026.0"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
-            { text: "OpenVINO", url: "https://docs.openvino.ai/2025/get-started.html" },
-            { text: "OpenVINO Model Server", url: "https://docs.openvino.ai/2025/model-server/ovms_what_is_openvino_model_server.html" },
-            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
-            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "OpenVINO", url: "https://docs.openvino.ai/2026/get-started.html" },
+            { text: "OpenVINO Model Server", url: "https://docs.openvino.ai/2026/model-server/ovms_what_is_openvino_model_server.html" },
+            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-libraries.html"},
+            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-suite-metro.html"}
           ]
         },
         {
@@ -466,15 +466,15 @@ const CONFIG = {
             VERSION: "2026.0"
           },
           links: [
-            { text: "Audio Analyzer", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/audio-analyzer/index.html" },
-            { text: "Document Ingestion - pgvector", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/document-ingestion/pgvector/docs/user-guide/get-started.md" },
-            { text: "Multimodal Embedding Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/multimodal-embedding-serving/docs/user-guide/index.md" },
-            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
-            { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
-            { text: "Chat Q&A", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/chat-question-and-answer/index.html" },
-            { text: "Chat Q&A Core", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/chat-question-and-answer-core/index.html" },
-            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
-            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}
+            { text: "Audio Analyzer", url: "https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/audio-analyzer/index.html" },
+            { text: "Document Ingestion - pgvector", url: "https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/pgvector/index.html" },
+            { text: "Multimodal Embedding Serving", url: "https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/multimodal-embedding-serving/index.html" },
+            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.0.0/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
+            { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.0.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
+            { text: "Chat Q&A", url: "http://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/chat-question-and-answer/index.html" },
+            { text: "Chat Q&A Core", url: "http://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/chat-question-and-answer-core/index.html" },
+            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-libraries.html"},
+            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-suite-metro.html"}
           ]
         },
         {
@@ -484,10 +484,10 @@ const CONFIG = {
             VERSION: "2026.0"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
-            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
-            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/2026.0/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-libraries.html"},
+            { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/2026.0/ai-suite-metro.html"}
           ]
         },
         {
@@ -497,10 +497,10 @@ const CONFIG = {
             VERSION: "latest"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
-            { text: "OpenVINO", url: "https://docs.openvino.ai/2025/get-started.html" },
-            { text: "OpenVINO Model Server", url: "https://docs.openvino.ai/2025/model-server/ovms_what_is_openvino_model_server.html" },
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "OpenVINO", url: "https://docs.openvino.ai/2026/get-started.html" },
+            { text: "OpenVINO Model Server", url: "https://docs.openvino.ai/2026/model-server/ovms_what_is_openvino_model_server.html" },
             { text: "Intel® SceneScape", url: "https://github.com/open-edge-platform/scenescape" },
             { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
             { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}
@@ -514,8 +514,8 @@ const CONFIG = {
           },
           links: [
             { text: "Audio Analyzer", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/audio-analyzer/index.html" },
-            { text: "Document Ingestion - pgvector", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/document-ingestion/pgvector/docs/user-guide/get-started.md" },
-            { text: "Multimodal Embedding Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/multimodal-embedding-serving/docs/user-guide/index.md" },
+            { text: "Document Ingestion - pgvector", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/pgvector/index.html" },
+            { text: "Multimodal Embedding Serving", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/multimodal-embedding-serving/index.html" },
             { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
             { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
             { text: "Chat Q&A", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/chat-question-and-answer/index.html" },
@@ -531,8 +531,8 @@ const CONFIG = {
             VERSION: "latest"
           },
           links: [
-            { text: "DLStreamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
-            { text: "DLStreamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
+            { text: "DL Streamer", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dl-streamer/index.html" },
+            { text: "DL Streamer Pipeline Server", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer-pipeline-server/index.html" },
             { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
             { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}
           ]


### PR DESCRIPTION
### Description

Fixes references and updates links for components which are published, from GH links to the OEP site ones.

Additionally, aligns naming for DL Streamer and DL Streamer Pipeline Server.

Changes based on changes to `config.js` in #2946.

### How Has This Been Tested?

Links checked

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.