### PR TITLE
fix(multimodal): K3S NPU utilization, DDS multicast, and GPU metrics collection

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/ai-ecg-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/ai-ecg-deployment.yaml
@@ -32,6 +32,11 @@ spec:
           imagePullPolicy: {{ .Values.aiEcg.image.pullPolicy }}
           securityContext:
             privileged: true
+          env:
+            {{- if eq .Values.devices.ECG_DEVICE "NPU" }}
+            - name: ZE_ENABLE_ALT_DRIVERS
+              value: "libze_intel_npu.so"
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: device-config

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/dds-bridge-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/dds-bridge-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: dds-bridge
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: dds-bridge
           image: "{{ .Values.ddsBridge.image.repository }}/{{ .Values.ddsBridge.image.name }}:{{ .Values.ddsBridge.image.tag }}"

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/mdpnp-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/mdpnp-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: mdpnp
     spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: mdpnp
           image: "{{ .Values.mdpnp.image.repository }}/{{ .Values.mdpnp.image.name }}:{{ .Values.mdpnp.image.tag }}"

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/pose-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/pose-deployment.yaml
@@ -74,6 +74,10 @@ spec:
               value: "aggregator,localhost,127.0.0.1"
             - name: no_proxy
               value: "aggregator,localhost,127.0.0.1"
+            {{- if eq .Values.devices.POSE_3D_DEVICE "NPU" }}
+            - name: ZE_ENABLE_ALT_DRIVERS
+              value: "libze_intel_npu.so"
+            {{- end }}
           volumeMounts:
             - name: models
               mountPath: /models

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/rppg-deployment.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/helm/multi_modal_patient_monitoring/templates/rppg-deployment.yaml
@@ -59,6 +59,10 @@ spec:
               value: "aggregator,localhost,127.0.0.1"
             - name: no_proxy
               value: "aggregator,localhost,127.0.0.1"
+            {{- if eq .Values.devices.RPPG_DEVICE "NPU" }}
+            - name: ZE_ENABLE_ALT_DRIVERS
+              value: "libze_intel_npu.so"
+            {{- end }}
           volumeMounts:
             - name: models
               mountPath: /models

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/metrics-collector/app.py
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/metrics-collector/app.py
@@ -68,8 +68,8 @@ def parse_npu_usage() -> Optional[Dict[str, Any]]:
 
 
 def parse_gpu_metrics() -> Optional[Dict[str, Any]]:
-    # Files like qmassa1-*-tool-generated.json created by qmassa
-    pattern = str(METRICS_DIR / "qmassa1-*-tool-generated.json")
+    # Files like qmassa<N>-*-tool-generated.json created by qmassa
+    pattern = str(METRICS_DIR / "qmassa*-*-tool-generated.json")
     candidates = glob.glob(pattern)
     if not candidates:
         return None
@@ -261,7 +261,7 @@ def build_memory_series() -> List[List[float]]:
 def build_gpu_series() -> List[List[float]]:
     """Build a time series for GPU utilization.
     Data source: qmassa JSON files named
-    "qmassa1-*-tool-generated.json" under METRICS_DIR. Each file has
+    "qmassa<N>-*-tool-generated.json" under METRICS_DIR. Each file has
     a top-level structure like:
 
         {
@@ -293,7 +293,7 @@ def build_gpu_series() -> List[List[float]]:
     how CPU and memory series are built.
     """
 
-    pattern = str(METRICS_DIR / "qmassa1-*-tool-generated.json")
+    pattern = str(METRICS_DIR / "qmassa*-*-tool-generated.json")
     candidates = glob.glob(pattern)
     if not candidates:
         return []


### PR DESCRIPTION
## Summary

Fixes three issues in Multi-Modal Patient Monitoring when deployed on EMT-S with K3S and Docker:

1. **NPU shows 0% utilization in K3S** — AI inference pods (3D Pose, AI-ECG, rPPG) lacked the `ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so` environment variable required for the NPU runtime on PTL/WCL platforms.

2. **MD PnP panel shows no data** — DDS multicast discovery between mdpnp and dds-bridge pods was blocked by EMT's default iptables DROP policy on pod virtual interfaces. Enabling `hostNetwork: true` allows DDS participants to discover each other on the host network.

3. **GPU Utilization chart missing on BTL/PTL** — The metrics collector used a hardcoded glob `qmassa1-*-tool-generated.json` which only matched card 1. Single-GPU systems (PTL, BTL) produce `qmassa0-*` files. Changed to `qmassa*-*-tool-generated.json`.

## Changes

- `helm/.../templates/pose-deployment.yaml` — Add `ZE_ENABLE_ALT_DRIVERS` env when `POSE_3D_DEVICE=NPU`
- `helm/.../templates/ai-ecg-deployment.yaml` — Add `ZE_ENABLE_ALT_DRIVERS` env when `ECG_DEVICE=NPU`
- `helm/.../templates/rppg-deployment.yaml` — Add `ZE_ENABLE_ALT_DRIVERS` env when `RPPG_DEVICE=NPU`
- `helm/.../templates/dds-bridge-deployment.yaml` — Add `hostNetwork: true`, `dnsPolicy: ClusterFirstWithHostNet`
- `helm/.../templates/mdpnp-deployment.yaml` — Add `hostNetwork: true`, `dnsPolicy: ClusterFirstWithHostNet`
- `services/metrics-collector/app.py` — Fix glob pattern to match any GPU card number

## Testing

Verified on PTL (EMT-S 3.1.35) with both Docker and K3S deployments:
- NPU utilization shows ~10% during 3D Pose inference
- MD PnP panel displays ECG HR, CO2 RR, IBP values
- GPU metrics glob matches `qmassa0-*` files (platform-independent fix, applies to BTL equally)

## Related

- Depends on: #2939  (NPU Docker support — `run_compose.sh` + driver install)