### PR TITLE
[Metro] Metro Vision AI App Recipe Tutorials - Smart Intersection fix link to SceneScape docs

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/test_admin.py
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/test_admin.py
@@ -35,7 +35,7 @@ def web_options_availability_check(waiter, scenescape_url):
     scenescape_url + "/cam/list/",  # Cameras
     scenescape_url + "/singleton_sensor/list/",  # Sensors
     scenescape_url + "/asset/list/",  # Object Library
-    "https://docs.openedgeplatform.intel.com/scenescape/main/toc.html",  # Documentation
+    "https://docs.openedgeplatform.intel.com/scenescape/dev/index.html",  # Documentation
     scenescape_url + "/admin"  # Admin
   ]
 


### PR DESCRIPTION
### Description

- Fixes a link in Metro Vision AI App Recipe tutorials in Smart Intersection tests leading to SceneScape documentation.

### How Has This Been Tested?

Link checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.