### PR TITLE
Smart Classroom: Fix the TTFT/TPS/Time taken metrics to standard formula

### DIFF
--- a/education-ai-suite/.gitignore
+++ b/education-ai-suite/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # Ignore virtual environments
 *venv*
+smartclassroom/
 
 # Ignore storage directory
 storage/

--- a/education-ai-suite/smart-classroom/components/llm/ipex/summarizer.py
+++ b/education-ai-suite/smart-classroom/components/llm/ipex/summarizer.py
@@ -1,6 +1,7 @@
 from components.llm.base_summarizer import BaseSummarizer
 import torch
 import threading
+import time
 from utils.locks import audio_pipeline_lock
 from utils.config_loader import config
 from utils import ensure_model
@@ -112,6 +113,7 @@ class Summarizer(BaseSummarizer):
                     def __init__(self, tokenizer, skip_special_tokens=True, skip_prompt=True):
                         super().__init__(tokenizer, skip_special_tokens=skip_special_tokens, skip_prompt=skip_prompt)
                         self.total_tokens = 0
+                        self.generation_start_time = None
 
                     def put(self, value):
                         self.total_tokens += 1
@@ -131,7 +133,7 @@ class Summarizer(BaseSummarizer):
 
                         torch.xpu.empty_cache()
                         torch.xpu.synchronize()
-
+                        streamer.generation_start_time = time.perf_counter()
                         self.model.generate(**gen_kwargs)
                     finally:
                         audio_pipeline_lock.release()

--- a/education-ai-suite/smart-classroom/components/llm/openvino/summarizer.py
+++ b/education-ai-suite/smart-classroom/components/llm/openvino/summarizer.py
@@ -1,5 +1,5 @@
 from components.llm.base_summarizer import BaseSummarizer
-import logging, threading, gc
+import logging, threading, gc, time
 from transformers import AutoTokenizer, TextIteratorStreamer
 from optimum.intel.openvino import OVModelForCausalLM
 from utils import ensure_model
@@ -60,6 +60,7 @@ class Summarizer(BaseSummarizer):
                         skip_prompt=skip_prompt,
                     )
                     self.total_tokens = 0
+                    self.generation_start_time = None
 
                 def put(self, value):
                     if value is not None:
@@ -77,6 +78,7 @@ class Summarizer(BaseSummarizer):
                 try:
                     with audio_pipeline_lock:
                         model = self._load_model()
+                        streamer.generation_start_time = time.perf_counter()
                         model.generate(
                             input_ids=inputs.input_ids,
                             max_new_tokens=max_new_tokens,

--- a/education-ai-suite/smart-classroom/components/llm/openvino_genai/summarizer.py
+++ b/education-ai-suite/smart-classroom/components/llm/openvino_genai/summarizer.py
@@ -1,7 +1,7 @@
 from components.llm.base_summarizer import BaseSummarizer
 import openvino_genai as ov_genai
 from transformers import AutoTokenizer
-import logging, threading, gc
+import logging, threading, gc, time
 from utils import ensure_model
 from utils.config_loader import config
 from utils.ov_genai_util import YieldingTextStreamer
@@ -25,6 +25,7 @@ class Summarizer(BaseSummarizer):
                 try:
                     with audio_pipeline_lock:
                         model = self._load_model()
+                        streamer.generation_start_time = time.perf_counter()
                         model.generate(
                             prompt,
                             streamer=streamer,

--- a/education-ai-suite/smart-classroom/components/summarizer_component.py
+++ b/education-ai-suite/smart-classroom/components/summarizer_component.py
@@ -127,8 +127,16 @@ class SummarizerComponent(PipelineComponent):
             end = time.perf_counter()
             total_tokens = streamer.total_tokens if streamer else -1
             summarization_time = end - start
-            ttft = (first_token_time - start) if first_token_time else -1
-            tps = (total_tokens / summarization_time) if summarization_time > 0 else -1
+
+            ttft_baseline = (
+                streamer.generation_start_time
+                if streamer and getattr(streamer, 'generation_start_time', None)
+                else start
+            )
+            ttft = (first_token_time - ttft_baseline) if first_token_time else -1
+
+            decode_time = (summarization_time - ttft) if ttft > 0 else summarization_time
+            tps = ((total_tokens - 1) / decode_time) if decode_time > 0 and total_tokens > 1 else -1
 
             performance_data = StorageManager.read_performance_metrics(
                 project_config.get("location"),

--- a/education-ai-suite/smart-classroom/components/summarizer_component.py
+++ b/education-ai-suite/smart-classroom/components/summarizer_component.py
@@ -138,16 +138,6 @@ class SummarizerComponent(PipelineComponent):
             decode_time = (summarization_time - ttft) if ttft > 0 else summarization_time
             tps = ((total_tokens - 1) / decode_time) if decode_time > 0 and total_tokens > 1 else -1
 
-            performance_data = StorageManager.read_performance_metrics(
-                project_config.get("location"),
-                project_config.get("name"),
-                self.session_id
-            )
-
-            performance_metrics = performance_data.get("performance", {})
-            asr_time = performance_metrics.get("transcription_time", 0)
-            end_to_end_time = asr_time + summarization_time
-
             StorageManager.update_csv(
                 path=os.path.join(project_path, "performance_metrics.csv"),
                 new_data={
@@ -156,6 +146,6 @@ class SummarizerComponent(PipelineComponent):
                     "performance.ttft": f"{round(ttft, 4)}s",
                     "performance.tps": round(tps, 4),
                     "performance.total_tokens": total_tokens,
-                    "performance.end_to_end_time": f"{round(end_to_end_time, 4)}s",
+                    "performance.summarization_time": f"{round(summarization_time, 4)}s",
                 }
             )

--- a/education-ai-suite/smart-classroom/components/summarizer_component.py
+++ b/education-ai-suite/smart-classroom/components/summarizer_component.py
@@ -135,7 +135,7 @@ class SummarizerComponent(PipelineComponent):
             )
             ttft = (first_token_time - ttft_baseline) if first_token_time else -1
 
-            decode_time = (summarization_time - ttft) if ttft > 0 else summarization_time
+            decode_time = (end - first_token_time) if first_token_time else summarization_time
             tps = ((total_tokens - 1) / decode_time) if decode_time > 0 and total_tokens > 1 else -1
 
             StorageManager.update_csv(

--- a/education-ai-suite/smart-classroom/ui/src/components/RightPanel/ConfigurationMetricsAccordion.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/RightPanel/ConfigurationMetricsAccordion.tsx
@@ -100,7 +100,7 @@ const ConfigurationMetricsAccordion: React.FC<Props> = ({ activeScreen }) => {
               <p><strong>{t("accordion.ttft") || "TTFT"}:</strong> {performanceData?.ttft || "-"}</p>
               <p><strong>{t("accordion.tps") || "Tokens Per Second"}:</strong> {performanceData?.tps || "-"}</p>
               <p><strong>{t("accordion.totalTokensProcessed") || "Total tokens processed"}:</strong> {performanceData?.total_tokens || "-"}</p>
-              <p><strong>{t("accordion.totalTimeTaken") || "Total Time Taken"}:</strong> {performanceData?.end_to_end_time || "-"}</p>
+              <p><strong>{t("accordion.summarizationTime") || "Summarization Time"}:</strong> {performanceData?.summarization_time || "-"}</p>
             </>
           )}
         </div>

--- a/education-ai-suite/smart-classroom/ui/src/i18n/en.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/en.json
@@ -131,6 +131,7 @@
       "totalTokensProcessed": "Total tokens processed",
       "timeToGenerateSummary": "Time taken to generate summary",
       "totalTimeTaken":"Total Time Taken",
+      "summarizationTime":"Summarization Time",
       "loadingConfiguration": "Loading configuration data...",
       "cpuUtilization": "CPU Utilization",
       "gpuUtilization": "GPU Utilization",

--- a/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
@@ -131,6 +131,7 @@
     "totalTokensProcessed": "处理的总 Token 数",
     "timeToGenerateSummary": "生成摘要耗时",
     "totalTimeTaken":"总耗时",
+    "summarizationTime":"摘要生成耗时",
     "loadingConfiguration": "正在加载配置...",
     "cpuUtilization": "CPU 利用率",
     "gpuUtilization": "GPU 利用率",

--- a/education-ai-suite/smart-classroom/utils/ov_genai_util.py
+++ b/education-ai-suite/smart-classroom/utils/ov_genai_util.py
@@ -8,6 +8,7 @@ class YieldingTextStreamer(ov_genai.StreamerBase):
         self.skip_special_tokens = skip_special_tokens
         self._queue = queue.Queue()
         self.total_tokens = 0
+        self.generation_start_time = None
         self._token_cache = []
         self._print_len = 0
 


### PR DESCRIPTION
### Description
As YingWei requested, correct the formula of below metrics
TTFT includes Model load, prefill, buffer delay
Issue: Model load should not be included, removed

TPS Formula: total_tokens / summarization_time
Issue: summarization_time is the total time from start to end, which includes TTFT (model loading + prefill). A more standard TPS metric would exclude TTFT to measure pure decode throughput:
Standard TPS = (total_tokens - 1) / (summarization_time - ttft)

Before
<img width="1192" height="516" alt="image" src="https://github.com/user-attachments/assets/64556134-e5d2-4a6b-84f3-9d78ce790175" />
After
<img width="1215" height="489" alt="image" src="https://github.com/user-attachments/assets/dcfe491d-fb79-4b7e-b231-c623381c3a6a" />

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

