### PR TITLE
[Smart Intersection] [main] RTSP Setup Docs || MQTT Port Exposure Docs || Updated GIDs

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
@@ -170,9 +170,14 @@ services:
       - "c 209:* rmw"
       - "a 189:* rwm"
     group_add:
+      - "44"
       - "109"
       - "110"
+      - "990"
       - "992"
+      - "993"
+      - "994"
+      - "996"
     depends_on:
       - broker
       - ntpserver

--- a/metro-ai-suite/metro-vision-ai-app-recipe/compose-without-scenescape.yml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/compose-without-scenescape.yml
@@ -45,9 +45,14 @@ services:
       - "/dev:/dev"
       - "/tmp:/tmp"
     group_add:
+      - "44"
       - "109"
       - "110"
+      - "990"
       - "992"
+      - "993"
+      - "994"
+      - "996"
     device_cgroup_rules:
       - "c 189:* rmw"
       - "c 209:* rmw"

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/chart/templates/dlstreamer-pipeline-server/deployment.yaml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/chart/templates/dlstreamer-pipeline-server/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       runtimeClassName: kata-qemu
       {{- end }}
       securityContext:
-        supplementalGroups: [109,110,992]
+        supplementalGroups: [44,109,110,990,992,993,994,996]
       volumes:
       - name: dev-shm
         hostPath:

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/how-to-setup-rtsp.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/how-to-setup-rtsp.md
@@ -1,0 +1,121 @@
+# RTSP Stream Setup for Smart Intersection
+
+Steps to serve the intersection `.ts` video files over RTSP using mediamtx and ffmpeg.
+
+## Prerequisites
+
+- `<rtsp-server-IP>`: Machine IP that runs mediamtx (Check with`hostname -I`)
+- Port `8554` must not be blocked by firewall
+
+## 1. Download mediamtx
+
+```bash
+wget https://github.com/bluenviron/mediamtx/releases/download/v1.9.0/mediamtx_v1.9.0_linux_amd64.tar.gz
+tar xzf mediamtx_v1.9.0_linux_amd64.tar.gz
+```
+
+This extracts `mediamtx` binary and `mediamtx.yml` config.
+
+## 2. Start mediamtx RTSP server
+
+```bash
+nohup ./mediamtx &
+```
+
+By default it listens on `:8554` (all interfaces).
+
+## 3. Install ffmpeg
+
+```bash
+sudo apt-get install -y ffmpeg
+```
+
+## 4. Download the video file
+
+```bash
+curl -k -L -o 1122north_h264.ts \
+  "https://github.com/open-edge-platform/edge-ai-resources/raw/refs/heads/main/videos/1122north_h264.ts"
+```
+
+Other available videos:
+- `1122east_h264.ts`
+- `1122west_h264.ts`
+- `1122south_h264.ts`
+
+## 5. Publish the stream
+
+```bash
+ffmpeg -stream_loop -1 -re -i 1122north_h264.ts -c copy -f rtsp rtsp://localhost:8554/north
+```
+
+To run in background:
+```bash
+nohup ffmpeg -stream_loop -1 -re -i 1122north_h264.ts -c copy -f rtsp rtsp://localhost:8554/north > /tmp/ffmpeg_rtsp.log 2>&1 &
+```
+
+## 6. Verify the stream
+
+```bash
+ffprobe rtsp://localhost:8554/north
+```
+
+Expected output: H.264 High profile, 1280x720, 30fps.
+
+## Access
+
+- Local: `rtsp://localhost:8554/north`
+- Remote: `rtsp://<rtsp-server-IP>:8554/north`
+
+## Multiple streams
+
+To serve all four cameras:
+```bash
+ffmpeg -stream_loop -1 -re -i 1122north_h264.ts -c copy -f rtsp rtsp://localhost:8554/north &
+ffmpeg -stream_loop -1 -re -i 1122south_h264.ts -c copy -f rtsp rtsp://localhost:8554/south &
+ffmpeg -stream_loop -1 -re -i 1122east_h264.ts  -c copy -f rtsp rtsp://localhost:8554/east &
+ffmpeg -stream_loop -1 -re -i 1122west_h264.ts  -c copy -f rtsp rtsp://localhost:8554/west &
+```
+
+## 7. Configure the DL Streamer pipeline
+
+Edit `smart-intersection/src/dlstreamer-pipeline-server/config.json` to switch a camera from the local video file to the RTSP source.
+
+Replace the `multifilesrc` source element in the pipeline string:
+
+**Before (local file):**
+```
+multifilesrc loop=true location=/home/pipeline-server/videos/1122north_h264.ts
+```
+
+**After (RTSP source):**
+```
+urisourcebin uri=rtsp://<rtsp-server-IP>:8554/north
+```
+
+Replace `<rtsp-server-IP>` with the IP of the machine running mediamtx.
+
+To use all four RTSP streams, update each camera pipeline accordingly:
+
+| Pipeline | RTSP URI |
+|----------|----------|
+| `intersection-cam1` | `rtsp://<mediamtx-ip>:8554/north` |
+| `intersection-cam2` | `rtsp://<mediamtx-ip>:8554/east` |
+| `intersection-cam3` | `rtsp://<mediamtx-ip>:8554/south` |
+| `intersection-cam4` | `rtsp://<mediamtx-ip>:8554/west` |
+
+## 8. Restart the pipeline server
+
+After editing `config.json`, recreate the container to pick up the changes:
+
+```bash
+cd smart-intersection/src
+docker compose up -d --force-recreate dlstreamer-pipeline-server
+```
+
+Verify the RTSP source is active in the logs:
+
+```bash
+docker logs metro-vision-ai-app-recipe-dlstreamer-pipeline-server-1 2>&1 | grep "element"
+```
+
+You should see `'element': 'urisourcebin'` for the cameras configured with RTSP, confirming the stream is being consumed from the remote source.

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/troubleshooting.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/troubleshooting.md
@@ -120,6 +120,26 @@ to file new tickets there (after learning about the guidelines for [Contributing
     ```
 
 
+### 9. Accessing the MQTT Broker Externally
+   - **Issue**: You want to connect an external MQTT client to the broker for debugging or monitoring topics.
+   - **Solution**: Expose port 1883 on the broker service by adding a `ports` section in `docker-compose.yml`:
+     ```yaml
+     broker:
+       ports:
+         - "1883:1883"
+     ```
+   - Then restart the broker:
+     ```bash
+     docker compose up -d --force-recreate broker
+     ```
+   - Connect using an MQTT client with TLS and the CA certificate:
+     ```bash
+     mosquitto_sub -h <HOST_IP> -p 1883 \
+       --cafile ./smart-intersection/src/secrets/certs/scenescape-ca.pem \
+       -t '#' -v
+     ```
+   - **Note**: The broker uses TLS (TLSv1.3) but allows anonymous connections — no username/password is required. You must use an MQTT client (not a web browser) since MQTT is a TCP protocol, not HTTP.
+
 ## Troubleshooting Helm Deployments
 
 ### 1. Helm Chart Not Found:
@@ -179,3 +199,18 @@ to file new tickets there (after learning about the guidelines for [Contributing
    - **Solution**: Ensure the [Intel Device Plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes) (NFD + GPU plugin + NPU plugin) are installed on your cluster and that the target node has the required hardware. See the [Prerequisites](./get-started/deploy-with-helm.md#prerequisites) section for installation steps.
 
      > **Note:** If your node uses Intel Xe discrete GPUs (Arc), set `gpu.type` to `gpu.intel.com/xe` in `values.yaml`.
+
+### 5. Accessing the MQTT Broker Externally
+
+   - **Issue**: You want to connect an external MQTT client to the broker for debugging or monitoring topics in a Helm deployment.
+   - **Solution**: Use `kubectl port-forward` to expose the broker service locally:
+     ```bash
+     kubectl port-forward svc/smart-intersection-broker -n smart-intersection 1883:1883
+     ```
+   - Then connect using an MQTT client with TLS:
+     ```bash
+     mosquitto_sub -h localhost -p 1883 \
+       --cafile <path-to-scenescape-ca.pem> \
+       -t '#' -v
+     ```
+   - **Note**: The broker uses TLS (TLSv1.3) but allows anonymous connections — no username/password is required. You must use an MQTT client (not a web browser) since MQTT is a TCP protocol, not HTTP.


### PR DESCRIPTION

### Description
- Add supplemental group IDs (44,109,110,990,992,993,994,996) for GPU/device access in compose files and Helm chart.
- Add how-to-setup-rtsp.md guide.
- Add MQTT broker external access troubleshooting for Docker and Helm.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

