### PR TITLE
Smart Classroom: Upgrade to pyannote 4.0 and PaddleOCR 2.10

### DIFF
--- a/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
@@ -1,5 +1,6 @@
 from pyannote.audio import Pipeline
 import torch
+import torchaudio
 from torch.serialization import safe_globals
 import os
 
@@ -29,14 +30,17 @@ class PyannoteDiarizer:
         ]):
             self.pipeline = Pipeline.from_pretrained(
                 pipeline_source,
-                use_auth_token=hf_token
+                token=hf_token
             )
 
         self.device = torch.device(device)
         self.pipeline.to(self.device)
 
     def diarize(self, audio_path):
-        diarization = self.pipeline(audio_path)
+        waveform, sample_rate = torchaudio.load(audio_path)
+        audio_input = {"waveform": waveform, "sample_rate": sample_rate}
+        output = self.pipeline(audio_input)
+        diarization = output.speaker_diarization
         segments = []
         for turn, _, speaker in diarization.itertracks(yield_label=True):
             segments.append({

--- a/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
@@ -40,7 +40,7 @@ class PyannoteDiarizer:
         waveform, sample_rate = torchaudio.load(audio_path)
         audio_input = {"waveform": waveform, "sample_rate": sample_rate}
         output = self.pipeline(audio_input)
-        diarization = output.speaker_diarization
+        diarization = output.exclusive_speaker_diarization
         segments = []
         for turn, _, speaker in diarization.itertracks(yield_label=True):
             segments.append({

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -28,7 +28,7 @@ models:
   
   diarization: #Only applicable when diarization is set to True for ASR
     provider: "huggingface"
-    name: "pyannote/speaker-diarization-3.1"
+    name: "pyannote/speaker-diarization-community-1"
     models_base_path: "models"
 
   summarizer:

--- a/education-ai-suite/smart-classroom/docs/user-guide/advance-setup-guide.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/advance-setup-guide.md
@@ -48,15 +48,7 @@ pip install --upgrade -r requirements.txt
 
 ### E. Enable OCR Features (Optional)
 
-If you need OCR functionality for document text extraction, install PaddleOCR separately:
-
-```bash
-pip install paddleocr==2.7.0.3 --no-deps
-```
-
-> **Note:** The `--no-deps` flag is required because PaddleOCR declares an outdated `PyMuPDF` dependency that has no pre-built wheel for Python 3.12 on Windows. 
-
-Then enable OCR in `config.yaml`:
+If you need OCR functionality for document text extraction, enable OCR in `config.yaml`:
 
 ```yaml
 ocr:

--- a/education-ai-suite/smart-classroom/main.py
+++ b/education-ai-suite/smart-classroom/main.py
@@ -1,4 +1,7 @@
 import sys
+import warnings
+warnings.filterwarnings("ignore", message=r"[\s\S]*torchcodec is not installed correctly")
+
 from utils import system_checker
 
 from utils.logger_config import setup_logger

--- a/education-ai-suite/smart-classroom/requirements.txt
+++ b/education-ai-suite/smart-classroom/requirements.txt
@@ -56,6 +56,7 @@ hf_xet==1.4.3
 ultralytics==8.4.39
 
 # OCR dependencies
+paddleocr==2.10.0
 pyclipper
 PyMuPDF==1.26.3
 paddlepaddle==3.3.1
@@ -67,7 +68,7 @@ lmdb==1.7.3
 attrdict==2.0.1
 lxml==6.0.0
 scikit-image==0.25.2
-imgaug==0.4.0
+albumentations>=1.4.0
 
 # SSL certificates
 certifi>=2025.7.14

--- a/education-ai-suite/smart-classroom/requirements.txt
+++ b/education-ai-suite/smart-classroom/requirements.txt
@@ -41,7 +41,7 @@ sentence-transformers==3.0.1
 # Whisper / audio
 openai-whisper==20250625
 speechbrain==1.0.3
-pyannote.audio==4.0.0
+pyannote.audio==4.0.4
 
 # Vector search
 faiss-cpu==1.11.0

--- a/education-ai-suite/smart-classroom/requirements.txt
+++ b/education-ai-suite/smart-classroom/requirements.txt
@@ -18,11 +18,11 @@ uvicorn==0.35.0
 WMI==1.5.1
 
 # Scientific stack (stability-critical)
-numpy==1.26.4
-pandas==2.2.2
+numpy==2.2.6
+pandas==2.2.3
 pyarrow==16.1.0
-scikit-learn==1.5.1
-scipy==1.14.1
+scikit-learn==1.6.1
+scipy==1.15.3
 
 # Torch stack
 torch==2.8.0
@@ -41,7 +41,7 @@ sentence-transformers==3.0.1
 # Whisper / audio
 openai-whisper==20250625
 speechbrain==1.0.3
-pyannote.audio==3.3.2
+pyannote.audio==4.0.0
 
 # Vector search
 faiss-cpu==1.11.0
@@ -58,7 +58,7 @@ ultralytics==8.4.39
 # OCR dependencies
 pyclipper
 PyMuPDF==1.26.3
-paddlepaddle==2.6.2
+paddlepaddle==3.3.1
 beautifulsoup4==4.13.4
 fire==0.7.1
 rapidfuzz==3.13.0

--- a/education-ai-suite/smart-classroom/start-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/start-smart-classroom.ps1
@@ -620,13 +620,11 @@ Write-Host ""
 Write-Host "[3/4] CHECKING CONFIGURATION" -ForegroundColor Green
 Write-Host "----------------------------" -ForegroundColor Green
 
-$ocrEnabled = $false
 $configPath = Join-Path $ScriptDir "config.yaml"
 if (Test-Path $configPath) {
     $configContent = Get-Content $configPath -Raw
     if ($configContent -match "ocr:\s*\n\s*enabled:\s*true") {
-        $ocrEnabled = $true
-        Write-Host "  OCR: Enabled (will install paddleocr)" -ForegroundColor Yellow
+        Write-Host "  OCR: Enabled" -ForegroundColor Yellow
     } else {
         Write-Host "  OCR: Disabled" -ForegroundColor Gray
     }
@@ -811,16 +809,6 @@ if ($IsWindowsOS) {
     } else {
         Write-Host "Launching Terminal 1: Backend..." -ForegroundColor Yellow
         
-        # Build paddleocr install command if OCR enabled
-        $paddleocrCmd = ""
-        if ($ocrEnabled) {
-            $paddleocrCmd = @"
-
-Write-Host ''
-Write-Host 'Installing PaddleOCR (OCR enabled in config)...' -ForegroundColor Yellow
-pip install paddleocr==2.7.0.3 --no-deps
-"@
-        }
         
         $backendScript = @"
 `$ErrorActionPreference = 'Continue'
@@ -871,7 +859,6 @@ Write-Host ''
 Write-Host 'Upgrading pip and installing requirements...' -ForegroundColor Yellow
 python -m pip install --upgrade pip
 pip install --upgrade -r requirements.txt
-$paddleocrCmd
 
 Write-Host ''
 Write-Host 'Starting Backend Service (port 8000)...' -ForegroundColor Green
@@ -1078,7 +1065,6 @@ npm run dev -- --host 0.0.0.0 --port 5173
         Write-Host "Skipping Backend (already running on port 8000)" -ForegroundColor Yellow
     } else {
         Write-Host "Launching Terminal 1: Backend..." -ForegroundColor Yellow
-        $paddleCmd = if ($ocrEnabled) { "pip install paddleocr==2.7.0.3 --no-deps; " } else { "" }
         $parentDir = Split-Path $ScriptDir -Parent
         $be_bash = @"
 $proxyExport
@@ -1094,7 +1080,6 @@ source smartclassroom/bin/activate
 cd smart-classroom
 pip install --upgrade pip
 pip install -r requirements.txt
-$paddleCmd
 echo 'Starting Backend (port 8000)...'
 python main.py
 exec bash

--- a/education-ai-suite/smart-classroom/ui/src/components/RightPanel/Timeline.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/RightPanel/Timeline.tsx
@@ -94,11 +94,10 @@ const Timeline: React.FC = () => {
       const match = speaker.match(/SPEAKER_(\d+)/i);
       if (match) {
         const speakerNumber = match[1];
-        const baseLabel = lang === "zh" ? "说话人" : labels.student;
-        return `${baseLabel}_${speakerNumber}`;
+        return `${labels.student}_${speakerNumber}`;
       }
-      if (lang === "zh" && speaker.toUpperCase() === "SPEAKER") {
-        return "说话人";
+      if (speaker.toUpperCase() === "SPEAKER") {
+        return labels.student;
       }
     }
     if (lang === "zh") {

--- a/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
@@ -99,12 +99,12 @@ const TranscriptsTab: React.FC = () => {
       const speakerMatch = speaker.match(/speaker_(\d+)/i);
       if (speakerMatch) {
         const speakerNumber = speakerMatch[1];
-        const baseLabel = currentLanguage === "zh" ? "说话人" : labels.student.toUpperCase();
+        const baseLabel = currentLanguage === "zh" ? labels.student : labels.student.toUpperCase();
         return `${baseLabel}_${speakerNumber}`;
       }
-    
+
       if (speaker.toLowerCase() === 'speaker') {
-        return currentLanguage === "zh" ? "说话人" : labels.student.toUpperCase();
+        return currentLanguage === "zh" ? labels.student : labels.student.toUpperCase();
       }
       return speaker;
     }

--- a/education-ai-suite/smart-classroom/utils/ensure_model.py
+++ b/education-ai-suite/smart-classroom/utils/ensure_model.py
@@ -67,13 +67,26 @@ def _cache_diarization_dependencies_locally(pipeline_dir: str, hf_token: str = N
     pipeline_params = pipeline_config.get("pipeline", {}).get("params", {})
     changed = False
 
-    for key in ("segmentation", "embedding"):
+    for key in ("segmentation", "embedding", "plda"):
         model_ref = pipeline_params.get(key)
         if not isinstance(model_ref, str):
             continue
-        if os.path.isfile(model_ref):
+        if os.path.isfile(model_ref) or os.path.isdir(model_ref):
             continue
         if "/" not in model_ref:
+            continue
+
+        # pyannote 4.0 uses "$model/<name>" to reference sub-models bundled in the snapshot
+        if model_ref.startswith("$model/"):
+            sub_name = model_ref[len("$model/"):]
+            sub_dir = os.path.join(pipeline_dir, sub_name)
+            local_checkpoint = os.path.join(sub_dir, HF_PYTORCH_WEIGHTS_NAME)
+            if os.path.exists(local_checkpoint):
+                pipeline_params[key] = local_checkpoint
+                changed = True
+            elif os.path.isdir(sub_dir):
+                pipeline_params[key] = sub_dir
+                changed = True
             continue
 
         dependency_dir = os.path.join(pipeline_dir, "dependencies", model_ref.replace("/", "_"))

--- a/education-ai-suite/smart-classroom/utils/ensure_model.py
+++ b/education-ai-suite/smart-classroom/utils/ensure_model.py
@@ -190,16 +190,30 @@ def _initialize_ocr():
             f"OCR currently only supports English (lang='en'). Got: '{lang}'. "
             f"To use other languages, set 'ocr.enabled: false' in config.yaml."
         )
-    
-    logger.info(f"Initializing OCR models: provider={config.models.ocr.provider}, lang={lang}, device={config.models.ocr.device}")
-    PaddleOCRModelManager.initialize(lang=lang, use_angle_cls=True, device=config.models.ocr.device)
-    
+
+
     if config.models.ocr.provider == "openvino":
         paddle_models_dir = Path(config.models.ocr.model_dir)
-        lang = config.app.language
+        det_model_dir = paddle_models_dir / "det" / lang / config.models.ocr.det_model
+        rec_model_dir = paddle_models_dir / "rec" / lang / config.models.ocr.rec_model
+
+        ir_already_exists = (
+            (det_model_dir / "det_model.xml").exists()
+            and (det_model_dir / "det_model.bin").exists()
+            and (rec_model_dir / "rec_model.xml").exists()
+            and (rec_model_dir / "rec_model.bin").exists()
+        )
+
+        if ir_already_exists:
+            logger.info("OpenVINO IR models already exist, skipping PaddleOCR download/conversion")
+            return
+
+        logger.info(f"Initializing OCR models: provider={config.models.ocr.provider}, lang={lang}, device={config.models.ocr.device}")
+        PaddleOCRModelManager.initialize(lang=lang, use_angle_cls=True, device=config.models.ocr.device)
+
         det_dir = paddle_models_dir / "det" / lang
         rec_dir = paddle_models_dir / "rec" / lang
-        
+
         if not det_dir.exists() or not any(det_dir.iterdir()):
             raise RuntimeError(
                 f"{paddle_models_dir}/det/{lang}/ is empty. Ensure PaddleOCR models are cached before initializing OpenVINO OCR."
@@ -208,10 +222,12 @@ def _initialize_ocr():
             raise RuntimeError(
                 f"{paddle_models_dir}/rec/{lang}/ is empty. Ensure PaddleOCR models are cached before initializing OpenVINO OCR."
             )
-        
+
         logger.info("Converting PaddleOCR models to OpenVINO IR...")
         convert_ppocr_pipeline(models_root=paddle_models_dir, output_root=paddle_models_dir, lang=lang)
         logger.info("OpenVINO IR conversion completed")
+    else:
+        PaddleOCRModelManager.initialize(lang=lang, use_angle_cls=True, device=config.models.ocr.device)
 
 
 def get_model_path() -> str:

--- a/education-ai-suite/smart-classroom/utils/ocr_utils/convert_to_openvino.py
+++ b/education-ai-suite/smart-classroom/utils/ocr_utils/convert_to_openvino.py
@@ -167,10 +167,15 @@ def convert_model(
     dynamic_width: bool = False,
 ) -> tuple:
 
+    output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     stem = model_name or pdmodel_path.stem
     xml_path = output_dir / f"{stem}.xml"
     bin_path = output_dir / f"{stem}.bin"
+
+    if xml_path.exists() and bin_path.exists():
+        log.info("Skipping conversion, IR already exists: %s", xml_path)
+        return xml_path, bin_path
 
     log.info("Reading model: %s", pdmodel_path)
     ov_model = ov.convert_model(str(pdmodel_path))


### PR DESCRIPTION
### Description

- Upgrade pyannote.audio to 4.0 with the openly-licensed speaker-diarization-community-1 model. Adapts diarizer to the new API.
- Upgrade PaddleOCR to 2.10.0 — removes the --no-deps install workaround and special-case launch script logic. Replaces deprecated imgaug with albumentations. The PaddleOCR 2.7 had outdated transitive deps that broke the upgrade of pyannote, so the upgrade is necessary.
- Bump numpy, pandas, scipy, scikit-learn to current stable releases for compatibility with the new stack.
- Fix Chinese speaker labels — use localized labels.student consistently instead of hardcoded "说话人" in Timeline and TranscriptsTab.
- Skip the PaddleOCR initialization when models are already converted to OpenVINO IR. Avoid duplicated download & convert.

Fixes #2181

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

