### PR TITLE
robotics: Add Extra Exercises section to turtlesim tutorial

### DIFF
--- a/robotics-ai-suite/docs/robotics/dev_guide/tutorials_amr/simulation/turtlesim-ros2-sample-application.md
+++ b/robotics-ai-suite/docs/robotics/dev_guide/tutorials_amr/simulation/turtlesim-ros2-sample-application.md
@@ -87,3 +87,186 @@ Complete the [get started guide](../../../gsg_robot/index.md) before continuing.
 6. To close this tutorial, do the following:
 
    Type ``Ctrl-c`` in the terminal where you executed the command for the tutorial.
+
+## Extra Exercises (Optional)
+
+While the tutorial is still running (before step 6 above), open a **new** terminal and try
+the following exercises to learn how to drive the turtle, draw shapes, and inspect the
+topics and services published by `turtlesim`. Each exercise begins by clearing the canvas
+and re-centering `turtle1` at the spawn point `(5.544445, 5.544445)` so you start from a
+known state.
+
+### Set up the new terminal
+
+Each new terminal needs the ROS 2 environment to be sourced before any `ros2` command will
+work:
+
+```bash
+source /opt/ros/jazzy/setup.bash
+export ROS_DOMAIN_ID=42
+```
+
+### Reset helper
+
+The following two commands clear all drawn lines and move `turtle1` back to the center of
+the canvas. Run them at the start of any exercise (or whenever you want a clean slate):
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+```
+
+### 1. Draw a square with `/turtle1/teleport_absolute`
+
+The pen is down by default, so each teleport draws a straight line from the current pose
+to the target. Five points (corner → corner → … → starting corner) close the square:
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+
+for xy in "2 2 0" "9 2 0" "9 9 0" "2 9 0" "2 2 0"; do
+  read x y th <<<"$xy"
+  ros2 service call /turtle1/teleport_absolute \
+    turtlesim/srv/TeleportAbsolute "{x: $x, y: $y, theta: $th}"
+  sleep 0.3
+done
+```
+
+### 2. Draw a colored square (cycle pen color per side)
+
+The `off` field of `turtlesim/srv/SetPen` must be quoted in YAML 1.1 because `off` is
+parsed as the boolean `false` otherwise. Inside a Bash double-quoted string, escape the
+inner quotes as shown below:
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+
+colors=("255 80 80" "80 255 80" "80 160 255" "255 200 60")
+points=("2 2 0" "9 2 0" "9 9 0" "2 9 0" "2 2 0")
+
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 2, y: 2, theta: 0}"
+
+for i in 0 1 2 3; do
+  read r g b <<<"${colors[$i]}"
+  ros2 service call /turtle1/set_pen \
+    turtlesim/srv/SetPen "{r: $r, g: $g, b: $b, width: 4, \"off\": 0}"
+  read x y th <<<"${points[$((i+1))]}"
+  ros2 service call /turtle1/teleport_absolute \
+    turtlesim/srv/TeleportAbsolute "{x: $x, y: $y, theta: $th}"
+  sleep 0.3
+done
+
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+```
+
+Tip: setting `"off": 1` lifts the pen — useful for jumping to a new position without
+drawing.
+
+### 3. Drive with `/turtle1/cmd_vel`
+
+Continuously publish a `geometry_msgs/Twist` to control the turtle. Press ``Ctrl-c`` to
+stop each command.
+
+Drive in a circle (linear forward + angular turn):
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+ros2 topic pub /turtle1/cmd_vel geometry_msgs/msg/Twist \
+  "{linear: {x: 2.0}, angular: {z: 1.8}}"
+```
+
+Spin in place:
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+ros2 topic pub /turtle1/cmd_vel geometry_msgs/msg/Twist \
+  "{linear: {x: 0.0}, angular: {z: 3.0}}"
+```
+
+### 4. Drive with the keyboard
+
+Run from a real terminal window (it needs raw key input):
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+ros2 run turtlesim turtle_teleop_key
+```
+
+### 5. Watch `/turtle1/pose` stream live
+
+Live pose values (x, y, theta, linear/angular velocity):
+
+```bash
+ros2 topic echo /turtle1/pose
+```
+
+Just the publish rate:
+
+```bash
+ros2 topic hz /turtle1/pose
+```
+
+### 6. Read the color sensor under the turtle
+
+Drive the turtle over its own trail (for example after running exercise 1 or 2) and watch
+the RGB values change:
+
+```bash
+ros2 topic echo /turtle1/color_sensor
+```
+
+### 7. View `/tf` in rviz
+
+Inside the rviz window:
+
+1. Set **Fixed Frame** (under "Global Options") to `world`.
+2. Click **Add** > **By topic**, select `/tf` > **TF**, click **OK**.
+3. Publish a `cmd_vel` from exercise 3 in another terminal — the turtle's frame moves in rviz.
+
+### 8. Click in rviz, see topics fire
+
+In rviz, use the toolbar buttons **2D Goal Pose**, **2D Pose Estimate**, and **Publish
+Point** while echoing the matching topic in another terminal:
+
+```bash
+ros2 topic echo /goal_pose       # 2D Goal Pose toolbar button
+ros2 topic echo /initialpose     # 2D Pose Estimate toolbar button
+ros2 topic echo /clicked_point   # Publish Point toolbar button
+```
+
+### 9. Spawn a second turtle and drive both
+
+```bash
+ros2 service call /clear std_srvs/srv/Empty
+ros2 service call /turtle1/teleport_absolute \
+  turtlesim/srv/TeleportAbsolute "{x: 5.544445, y: 5.544445, theta: 0}"
+
+ros2 service call /spawn turtlesim/srv/Spawn \
+  "{x: 3.0, y: 3.0, theta: 0, name: 'turtle2'}"
+
+ros2 topic pub /turtle2/cmd_vel geometry_msgs/msg/Twist \
+  "{linear: {x: 1.5}, angular: {z: -1.0}}"
+```
+
+### 10. Discoverability cheats
+
+```bash
+ros2 topic list -t          # topics + their types
+ros2 service list -t        # services + their types
+ros2 interface show turtlesim/srv/TeleportAbsolute
+ros2 interface show geometry_msgs/msg/Twist
+ros2 node info /turtlesim   # everything turtlesim publishes/subscribes/serves
+```
+
+When you are done with the exercises, follow step 6 above to close the tutorial.


### PR DESCRIPTION
Add an optional "Extra Exercises" section to the Turtlesim ROS 2 sample application tutorial. The new section walks the reader through driving the turtle with /turtle1/cmd_vel, drawing single-color and multi-color squares via /turtle1/teleport_absolute and /turtle1/set_pen, inspecting /turtle1/pose and /turtle1/color_sensor, viewing /tf in rviz, exercising the rviz toolbar topics (/goal_pose, /initialpose, /clicked_point), spawning a second turtle, and discovering ROS 2 interfaces with the ros2 CLI.

Each exercise begins by clearing the canvas with /clear and re-centering turtle1 at the spawn point so the reader always starts from a known state.

Also documents the YAML 1.1 quoting requirement for the SetPen.off field (off is parsed as the boolean false otherwise).


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

