### PR TITLE
[smart-classroom] -[Fix] Resource utilization not shown in specific case

### DIFF
--- a/education-ai-suite/smart-classroom/ui/src/components/LeftPanel/UploadSection.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/LeftPanel/UploadSection.tsx
@@ -95,6 +95,26 @@ const UploadSection: React.FC<UploadSectionProps> = ({ disabled }) => {
 
   const [showFileManager, setShowFileManager] = useState(false);
 
+  const ensureSessionAndMonitoring = useCallback(async () => {
+    if (!sessionIdRef.current) {
+      try {
+        const res = await createSession();
+        sessionIdRef.current = res.sessionId;
+        dispatch(setSessionId(res.sessionId));
+      } catch (e) {
+        console.warn("Could not create session for metrics:", e);
+      }
+    }
+    if (sessionIdRef.current && !monitoringActiveRef.current) {
+      try {
+        await startMonitoring(sessionIdRef.current);
+        dispatch(setMonitoringActive(true));
+      } catch (e) {
+        console.warn("Could not start monitoring:", e);
+      }
+    }
+  }, [dispatch]);
+
   // Check if files exist on the server on initial mount
   useEffect(() => {
     const checkServerFiles = async () => {
@@ -108,6 +128,7 @@ const UploadSection: React.FC<UploadSectionProps> = ({ disabled }) => {
         if (hasFiles) {
           dispatch(setCsHasUploads(true));
           dispatch(setCsUploadsComplete(true));
+          await ensureSessionAndMonitoring();
         }
         if (Array.isArray(tags) && tags.length > 0) {
           serverTagsRef.current = tags;
@@ -118,7 +139,7 @@ const UploadSection: React.FC<UploadSectionProps> = ({ disabled }) => {
       }
     };
     checkServerFiles();
-  }, [dispatch]);
+  }, [dispatch, ensureSessionAndMonitoring]);
 
   const selectAllRef = useRef<HTMLInputElement>(null);
   const allSelected = entries.length > 0 && entries.every((e) => e.selected);
@@ -323,26 +344,6 @@ const UploadSection: React.FC<UploadSectionProps> = ({ disabled }) => {
       )
     );
 
-    // Ensure session + monitoring without blocking uploads
-    const ensureSessionAndMonitoring = async () => {
-      if (!sessionIdRef.current) {
-        try {
-          const res = await createSession();
-          sessionIdRef.current = res.sessionId;
-          dispatch(setSessionId(res.sessionId));
-        } catch (e) {
-          console.warn("Could not create session for metrics:", e);
-        }
-      }
-      if (sessionIdRef.current && !monitoringActiveRef.current) {
-        try {
-          await startMonitoring(sessionIdRef.current);
-          dispatch(setMonitoringActive(true));
-        } catch (e) {
-          console.warn("Could not start monitoring:", e);
-        }
-      }
-    };
     ensureSessionAndMonitoring();
 
     await Promise.all(

--- a/education-ai-suite/smart-classroom/ui/src/components/common/MetricsPoller.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/common/MetricsPoller.tsx
@@ -10,6 +10,7 @@ const MetricsPoller: React.FC = () => {
   const sessionId = useAppSelector(s => s.ui.sessionId);
   const aiProcessing = useAppSelector(s => s.ui.aiProcessing);
   const csProcessing = useAppSelector(s => s.ui.csProcessing);
+  const monitoringActive = useAppSelector(s => s.ui.monitoringActive);
   const summaryStatus = useAppSelector(s => s.summary.status);
   const monitoringPaused = useAppSelector(s => s.ui.monitoringPaused);
   const dispatch = useAppDispatch();
@@ -50,7 +51,7 @@ const MetricsPoller: React.FC = () => {
       return; 
     }
 
-    const shouldPoll = aiProcessing || csProcessing || summaryStatus === 'streaming';
+    const shouldPoll = monitoringActive || aiProcessing || csProcessing || summaryStatus === 'streaming';
     if (!shouldPoll) return;
 
     let cancelled = false;
@@ -65,7 +66,7 @@ const MetricsPoller: React.FC = () => {
       cancelled = true;
       if (timeoutRef.current) { clearTimeout(timeoutRef.current); timeoutRef.current = null; }
     };
-  }, [sessionId, aiProcessing, csProcessing, summaryStatus, monitoringPaused, dispatch]);
+  }, [sessionId, aiProcessing, csProcessing, monitoringActive, summaryStatus, monitoringPaused, dispatch]);
 
   return null;
 };


### PR DESCRIPTION
### Description
When Content Search opens with existing files and a session is created on load, the resource charts now start fetching data from the backend metrics endpoint and update correctly even when no new upload or transcription job is running.

Fix: [https://jira.devtools.intel.com/browse/ITEP-92862](https://jira.devtools.intel.com/browse/ITEP-92862)
