### PR TITLE
Bumped opencv-python for adbscan to close dependabot alert

### DIFF
--- a/robotics-ai-suite/components/adbscan/Follow_me_RS_2D/src/turtlebot3_simulations/followme_turtlebot3_gazebo/scripts/requirements_humble.txt
+++ b/robotics-ai-suite/components/adbscan/Follow_me_RS_2D/src/turtlebot3_simulations/followme_turtlebot3_gazebo/scripts/requirements_humble.txt
@@ -1,4 +1,4 @@
 numpy==1.24.3
 mediapipe==0.10.9
-opencv-python==4.8.0.76
+opencv-python>=4.8.1.76
 pyyaml

--- a/robotics-ai-suite/components/adbscan/Follow_me_RS_2D/src/turtlebot3_simulations/followme_turtlebot3_gazebo/scripts/requirements_jazzy.txt
+++ b/robotics-ai-suite/components/adbscan/Follow_me_RS_2D/src/turtlebot3_simulations/followme_turtlebot3_gazebo/scripts/requirements_jazzy.txt
@@ -1,4 +1,4 @@
 numpy==1.26.4
 mediapipe==0.10.31
-opencv-python==4.8.0.78
+opencv-python>=4.8.1.78
 pyyaml


### PR DESCRIPTION
### Description

Updated ADBSCAN's turtlebot tutorial's dependencies to close open CVEs

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

