### PR TITLE
[smart-classroom] - [Bug-fix] Modified single script for service down and release ports on stopping

### DIFF
--- a/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
@@ -31,7 +31,7 @@ The setup script will:
    - FFmpeg (auto-install if missing)
    - DL Streamer (auto-download and extract `dlstreamer_dlls_2026.0.0.zip` to `C:\dlls_windows`)
 
-3. **[3] Configure Settings**v
+3. **[3] Configure Settings**
    - [3.1] Language & ASR Configuration (provider, model, device)
    - [3.2] Upload Size Limits
    - [3.3] OCR Configuration

--- a/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/get-started.md
@@ -1,11 +1,21 @@
 # Quick Start Guide
 
-## Step 1: Run Setup Script (First-Time Only)
+## Step 1: Clone Repository
+ 
+Go to the target directory of your choice and clone the suite.
+If you want to clone a specific release branch, replace `main` with the desired tag.
+To learn more on partial cloning, check the [Repository Cloning guide](https://docs.openedgeplatform.intel.com/dev/OEP-articles/contribution-guide.html#repository-cloning-partial-cloning).
 
-Open PowerShell and navigate to the smart-classroom directory:
+```bash
+  git clone --filter=blob:none --sparse --branch main https://github.com/open-edge-platform/edge-ai-suites.git
+  cd edge-ai-suites
+  git sparse-checkout set education-ai-suite
+  cd education-ai-suite
+  cd smart-classroom
+```
+## Step 2: Run Setup Script (First-Time Only)
 
 ```powershell
-cd edge-ai-suites\education-ai-suite\smart-classroom
 .\setup-smart-classroom.ps1
 ```
 
@@ -21,14 +31,14 @@ The setup script will:
    - FFmpeg (auto-install if missing)
    - DL Streamer (auto-download and extract `dlstreamer_dlls_2026.0.0.zip` to `C:\dlls_windows`)
 
-3. **[3] Configure Settings**
+3. **[3] Configure Settings**v
    - [3.1] Language & ASR Configuration (provider, model, device)
    - [3.2] Upload Size Limits
    - [3.3] OCR Configuration
 
 4. **Launch Smart Classroom** (automatically runs `start-smart-classroom.ps1`)
 
-## Step 2: Access the Application
+## Step 3: Access the Application
 
 Once all services are running, open your browser:
 

--- a/education-ai-suite/smart-classroom/start-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/start-smart-classroom.ps1
@@ -78,78 +78,76 @@ function Stop-AllServices {
     Write-Host "========================================" -ForegroundColor Yellow
     Write-Host ""
     
-    $connections = Get-NetTCPConnection -LocalPort 8000 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping Backend (port 8000)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    $ports = @(8000, 9011, 9090, 5173)
+    $portNames = @{ 8000 = "Backend"; 9011 = "Content Search"; 9090 = "ChromaDB"; 5173 = "Frontend" }
+    
+    foreach ($port in $ports) {
+        Write-Host "  Stopping $($portNames[$port]) (port $port)..." -ForegroundColor Yellow
+        
+        # Retry killing processes on this port up to 3 times
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+            try {
+                $connections = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+                if ($connections) {
+                    $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+                    foreach ($procId in $procIds) {
+                        Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+                    }
+                }
+            } catch {
+                # Continue to next method
+            }
+            
+            Start-Sleep -Milliseconds 300
         }
-        Write-Host "    Backend stopped." -ForegroundColor Gray
+        
+        # Use taskkill as additional method
+        try {
+            taskkill /F /FI "LocalPort eq $port" 2>$null
+        } catch {}
+        
+        Start-Sleep -Seconds 1
     }
     
-    $connections = Get-NetTCPConnection -LocalPort 9011 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping Content Search (port 9011)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-        }
-        Write-Host "    Content Search stopped." -ForegroundColor Gray
-    }
+    # Comprehensive process cleanup (silent)
     
-    $connections = Get-NetTCPConnection -LocalPort 9090 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping ChromaDB (port 9090)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    # Kill all Python processes (multiple attempts)
+    try {
+        Get-Process python, python.exe -ErrorAction SilentlyContinue | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
         }
-        Write-Host "    ChromaDB stopped." -ForegroundColor Gray
-    }
-
-    $connections = Get-NetTCPConnection -LocalPort 9900 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping VLM (port 9900)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    } catch {}
+    
+    # Kill all npm/node processes
+    try {
+        Get-Process node, npm -ErrorAction SilentlyContinue | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
         }
-        Write-Host "    VLM stopped." -ForegroundColor Gray
-    }
-
-    $connections = Get-NetTCPConnection -LocalPort 8001 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping Preprocess (port 8001)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+    } catch {}
+    
+    # Kill uvicorn processes specifically
+    try {
+        Get-Process uvicorn -ErrorAction SilentlyContinue | ForEach-Object {
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
         }
-        Write-Host "    Preprocess stopped." -ForegroundColor Gray
-    }
-
-    $connections = Get-NetTCPConnection -LocalPort 9990 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping Ingest (port 9990)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-        }
-        Write-Host "    Ingest stopped." -ForegroundColor Gray
-    }
-
-    $connections = Get-NetTCPConnection -LocalPort 5173 -ErrorAction SilentlyContinue
-    if ($connections) {
-        Write-Host "  Stopping Frontend (port 5173)..." -ForegroundColor Yellow
-        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
-        foreach ($procId in $procIds) {
-            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
-        }
-        Write-Host "    Frontend stopped." -ForegroundColor Gray
+    } catch {}
+    
+    # Final wait for ports to be freed
+    Start-Sleep -Seconds 3
+    
+    # Verify ports are free
+    foreach ($port in $ports) {
+        try {
+            $connection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
+            if ($connection) {
+                taskkill /F /PID $connection.OwningProcess 2>$null
+                Start-Sleep -Seconds 1
+            }
+        } catch {}
     }
     
     Write-Host ""
-    Write-Host "  All services stopped." -ForegroundColor Green
+    Write-Host "Services stopped.. Wait for the processes to get terminated...before start again..." -ForegroundColor Green
 }
 
 # Register Ctrl+C handler
@@ -165,6 +163,9 @@ trap {
     Write-Host "  Script interrupted!" -ForegroundColor Red
     if ($script:servicesStarted) {
         Stop-AllServices
+    }
+    for ($i = 30; $i -gt 0; $i--) {
+        Start-Sleep -Seconds 1
     }
     exit 1
 }
@@ -303,9 +304,25 @@ Write-Host ""
 Write-Host "[PRE-CHECK] DETECTING RUNNING SERVICES" -ForegroundColor Cyan
 Write-Host "--------------------------------------" -ForegroundColor Cyan
 
-$backendRunning = Test-PortInUse -Port 8000
-$contentSearchRunning = Test-PortInUse -Port 9011
-$frontendRunning = Test-PortInUse -Port 5173
+# Wait a moment for ports to be fully released from previous session
+Write-Host "  Checking port status..." -ForegroundColor Gray
+Start-Sleep -Seconds 2
+
+# Enhanced port checking that verifies services are actually listening (not just in TIME_WAIT)
+function Test-ServiceListening {
+    param([int]$Port)
+    
+    try {
+        $connection = Get-NetTCPConnection -LocalPort $Port -State "Listen" -ErrorAction SilentlyContinue
+        return $null -ne $connection
+    } catch {
+        return $false
+    }
+}
+
+$backendRunning = Test-ServiceListening -Port 8000
+$contentSearchRunning = Test-ServiceListening -Port 9011
+$frontendRunning = Test-ServiceListening -Port 5173
 
 $anyRunning = $backendRunning -or $contentSearchRunning -or $frontendRunning
 
@@ -337,13 +354,10 @@ if ($Restart) {
     # -Restart flag: stop all running services and start fresh
     Write-Host "  -Restart flag specified. Stopping all running services..." -ForegroundColor Yellow
     if ($backendRunning) { Stop-ServiceOnPort -Port 8000 -ServiceName "Backend" }
-    if ($contentSearchRunning) {
+    if ($contentSearchRunning) { 
         Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
     }
     Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
-    Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
-    Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
-    Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
     if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
     
     $deleteVenvs = Read-Host "  Delete virtual environments and create new? (Y/N)"
@@ -372,13 +386,10 @@ if ($Restart) {
             Write-Host ""
             Write-Host "  Restarting all services..." -ForegroundColor Yellow
             if ($backendRunning) { Stop-ServiceOnPort -Port 8000 -ServiceName "Backend" }
-            if ($contentSearchRunning) {
+            if ($contentSearchRunning) { 
                 Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
             }
             Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
-            Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
-            Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
-            Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
             if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
             
             $deleteVenvs = Read-Host "  Delete virtual environments and create new? (Y/N)"
@@ -404,15 +415,12 @@ if ($Restart) {
             Write-Host ""
             Write-Host "  Stopping all services..." -ForegroundColor Yellow
             if ($backendRunning) { Stop-ServiceOnPort -Port 8000 -ServiceName "Backend" }
-            if ($contentSearchRunning) {
+            if ($contentSearchRunning) { 
                 Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
             }
             Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
-            Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
-            Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
-            Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
             if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
-            Write-Host "  All services stopped. Exiting." -ForegroundColor Green
+            Write-Host "  All services stopped. Waiting for processes to terminate...Before starting new services..." -ForegroundColor Green
             exit 0
         }
         "E" {
@@ -429,12 +437,9 @@ if ($Restart) {
 } else {
     Write-Host "  No main services detected." -ForegroundColor Green
     Write-Host ""
-    Write-Host "  Stopping any orphaned processes (ChromaDB, VLM, Preprocess, Ingest, Python)..." -ForegroundColor Yellow
-
+    Write-Host "  Stopping any orphaned processes (ChromaDB, Python)..." -ForegroundColor Yellow
+    
     Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
-    Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
-    Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
-    Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
     
     Get-Process -Name "python" -ErrorAction SilentlyContinue | ForEach-Object {
         $procPath = $_.Path
@@ -977,6 +982,19 @@ if (-not `$venvValid) {
 Write-Host 'Activating virtual environment...' -ForegroundColor Gray
 & "`$venvPath\Scripts\Activate.ps1"
 
+# Run install.ps1 if tesseract not found
+`$tesseractExists = Get-Command tesseract -ErrorAction SilentlyContinue
+if (-not `$tesseractExists) {
+    Write-Host ''
+    Write-Host 'Running install.ps1 (Content Search dependencies)...' -ForegroundColor Yellow
+    Write-Host 'NOTE: This requires Administrator privileges' -ForegroundColor Yellow
+    Write-Host ''
+    if (Test-Path '.\install.ps1') {
+        & '.\install.ps1'
+    } else {
+        Write-Host 'install.ps1 not found, skipping...' -ForegroundColor Yellow
+    }
+}
 
 Write-Host ''
 Write-Host 'Upgrading pip and installing requirements...' -ForegroundColor Yellow
@@ -1229,6 +1247,9 @@ while ($true) {
     switch ($key.ToUpper()) {
         "Q" {
             Stop-AllServices
+            for ($i = 30; $i -gt 0; $i--) {
+                Start-Sleep -Seconds 1
+            }
             exit 0
         }
         "E" {

--- a/education-ai-suite/smart-classroom/start-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/start-smart-classroom.ps1
@@ -78,8 +78,8 @@ function Stop-AllServices {
     Write-Host "========================================" -ForegroundColor Yellow
     Write-Host ""
     
-    $ports = @(8000, 9011, 9090, 5173)
-    $portNames = @{ 8000 = "Backend"; 9011 = "Content Search"; 9090 = "ChromaDB"; 5173 = "Frontend" }
+    $ports = @(8000, 9011, 5173)
+    $portNames = @{ 8000 = "Backend"; 9011 = "Content Search"; 5173 = "Frontend" }
     
     foreach ($port in $ports) {
         Write-Host "  Stopping $($portNames[$port]) (port $port)..." -ForegroundColor Yellow
@@ -107,6 +107,42 @@ function Stop-AllServices {
         } catch {}
         
         Start-Sleep -Seconds 1
+    }
+
+    $connections = Get-NetTCPConnection -LocalPort 9090 -ErrorAction SilentlyContinue
+    if ($connections) {
+        Write-Host "  Stopping ChromaDB (port 9090)..." -ForegroundColor Yellow
+        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+        foreach ($procId in $procIds) {
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $connections = Get-NetTCPConnection -LocalPort 9900 -ErrorAction SilentlyContinue
+    if ($connections) {
+        Write-Host "  Stopping VLM (port 9900)..." -ForegroundColor Yellow
+        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+        foreach ($procId in $procIds) {
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $connections = Get-NetTCPConnection -LocalPort 8001 -ErrorAction SilentlyContinue
+    if ($connections) {
+        Write-Host "  Stopping Preprocess (port 8001)..." -ForegroundColor Yellow
+        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+        foreach ($procId in $procIds) {
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $connections = Get-NetTCPConnection -LocalPort 9990 -ErrorAction SilentlyContinue
+    if ($connections) {
+        Write-Host "  Stopping Ingest (port 9990)..." -ForegroundColor Yellow
+        $procIds = $connections | Select-Object -ExpandProperty OwningProcess -Unique
+        foreach ($procId in $procIds) {
+            Stop-Process -Id $procId -Force -ErrorAction SilentlyContinue
+        }
     }
     
     # Comprehensive process cleanup (silent)
@@ -136,7 +172,8 @@ function Stop-AllServices {
     Start-Sleep -Seconds 3
     
     # Verify ports are free
-    foreach ($port in $ports) {
+    $portsToVerify = @(8000, 9011, 9090, 9900, 8001, 9990, 5173)
+    foreach ($port in $portsToVerify) {
         try {
             $connection = Get-NetTCPConnection -LocalPort $port -ErrorAction SilentlyContinue
             if ($connection) {
@@ -358,6 +395,9 @@ if ($Restart) {
         Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
     }
     Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
+    Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
+    Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
+    Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
     if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
     
     $deleteVenvs = Read-Host "  Delete virtual environments and create new? (Y/N)"
@@ -390,6 +430,9 @@ if ($Restart) {
                 Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
             }
             Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
+            Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
+            Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
+            Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
             if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
             
             $deleteVenvs = Read-Host "  Delete virtual environments and create new? (Y/N)"
@@ -419,6 +462,9 @@ if ($Restart) {
                 Stop-ServiceOnPort -Port 9011 -ServiceName "Content Search"
             }
             Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
+            Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
+            Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
+            Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
             if ($frontendRunning) { Stop-ServiceOnPort -Port 5173 -ServiceName "Frontend" }
             Write-Host "  All services stopped. Waiting for processes to terminate...Before starting new services..." -ForegroundColor Green
             exit 0
@@ -437,9 +483,12 @@ if ($Restart) {
 } else {
     Write-Host "  No main services detected." -ForegroundColor Green
     Write-Host ""
-    Write-Host "  Stopping any orphaned processes (ChromaDB, Python)..." -ForegroundColor Yellow
+    Write-Host "  Stopping any orphaned processes (ChromaDB, VLM, Preprocess, Ingest, Python)..." -ForegroundColor Yellow
     
     Stop-ServiceOnPort -Port 9090 -ServiceName "ChromaDB"
+    Stop-ServiceOnPort -Port 9900 -ServiceName "VLM"
+    Stop-ServiceOnPort -Port 8001 -ServiceName "Preprocess"
+    Stop-ServiceOnPort -Port 9990 -ServiceName "Ingest"
     
     Get-Process -Name "python" -ErrorAction SilentlyContinue | ForEach-Object {
         $procPath = $_.Path

--- a/education-ai-suite/smart-classroom/start-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/start-smart-classroom.ps1
@@ -1031,19 +1031,6 @@ if (-not `$venvValid) {
 Write-Host 'Activating virtual environment...' -ForegroundColor Gray
 & "`$venvPath\Scripts\Activate.ps1"
 
-# Run install.ps1 if tesseract not found
-`$tesseractExists = Get-Command tesseract -ErrorAction SilentlyContinue
-if (-not `$tesseractExists) {
-    Write-Host ''
-    Write-Host 'Running install.ps1 (Content Search dependencies)...' -ForegroundColor Yellow
-    Write-Host 'NOTE: This requires Administrator privileges' -ForegroundColor Yellow
-    Write-Host ''
-    if (Test-Path '.\install.ps1') {
-        & '.\install.ps1'
-    } else {
-        Write-Host 'install.ps1 not found, skipping...' -ForegroundColor Yellow
-    }
-}
 
 Write-Host ''
 Write-Host 'Upgrading pip and installing requirements...' -ForegroundColor Yellow


### PR DESCRIPTION
### Description
 This PR has a fix for 

1. [ITEP-93251](https://jira.devtools.intel.com/browse/ITEP-93251) - Added the repo cloning instruction on get-started file.
2. [ITEP-93265](https://jira.devtools.intel.com/browse/ITEP-93265) - Added 30-second graceful shutdown and comprehensive service stop handling.

- **Robust Cleanup**: Enhanced Stop-AllServices function with:
  - 3x retry logic per port
  - Multiple cleanup methods (Stop-Process + taskkill)
  - Explicit uvicorn process termination
  - Final port verification with forced cleanup if needed