### PR TITLE
[smart-classroom] - fix: Added back the missing Tesseract/install step 

### DIFF
--- a/education-ai-suite/smart-classroom/start-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/start-smart-classroom.ps1
@@ -1031,6 +1031,19 @@ if (-not `$venvValid) {
 Write-Host 'Activating virtual environment...' -ForegroundColor Gray
 & "`$venvPath\Scripts\Activate.ps1"
 
+# Run install.ps1 if tesseract not found
+`$tesseractExists = Get-Command tesseract -ErrorAction SilentlyContinue
+if (-not `$tesseractExists) {
+    Write-Host ''
+    Write-Host 'Running install.ps1 (Content Search dependencies)...' -ForegroundColor Yellow
+    Write-Host 'NOTE: This requires Administrator privileges' -ForegroundColor Yellow
+    Write-Host ''
+    if (Test-Path '.\install.ps1') {
+        & '.\install.ps1'
+    } else {
+        Write-Host 'install.ps1 not found, skipping...' -ForegroundColor Yellow
+    }
+}
 
 Write-Host ''
 Write-Host 'Upgrading pip and installing requirements...' -ForegroundColor Yellow


### PR DESCRIPTION
Content Search startup flow.


### Description
 Added back the missing Tesseract/install step in the Content Search startup flow. 

This step was reverted back due to previous patch 
[https://github.com/open-edge-platform/edge-ai-suites/pull/3156](https://github.com/open-edge-platform/edge-ai-suites/pull/3156)
