### PR TITLE
 Changed version tags to 2026.1.0 release

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/Makefile
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/Makefile
@@ -3,7 +3,7 @@
 # Default device profile (mixed-optimized: detection=GPU, rPPG=CPU, action=NPU)
 DEVICE_ENV ?= configs/res/mixed-optimized.env
 REGISTRY ?= true
-TAG ?= 2026.1.0-rc2
+TAG ?= 2026.1.0
 export TAG
 
 RPPG_CONVERTER_IMAGE ?= nicu-rppg-converter:local

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/docker-compose.yaml
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/docker-compose.yaml
@@ -90,7 +90,7 @@ services:
     privileged: true
 
   nicu-dlsps:
-    image: ${NICU_DLSPS_IMAGE:-intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24-rc2}
+    image: ${NICU_DLSPS_IMAGE:-intel/dlstreamer-pipeline-server:2026.1.0-ubuntu24}
     container_name: nicu-dlsps
     user: "0:0"
     profiles: ["dlsps"]

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/sources.Dockerfile
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/sources.Dockerfile
@@ -1,5 +1,5 @@
 # -------- Stage 1: Download GPL Sources --------
-FROM intel/hl-ai-nicu-backend:2026.1.0-rc1 AS source-builder
+FROM intel/hl-ai-nicu-backend:2026.1.0 AS source-builder
 LABEL stage="source-builder"
 
 USER root


### PR DESCRIPTION
Update all NICU Warmer image tags from rc (rc1/rc2) versions to the final 2026.1.0 release:

Makefile: TAG 2026.1.0-rc2 → 2026.1.0
docker-compose.yaml: dlstreamer-pipeline-server 2026.1.0-ubuntu24-rc2 → 2026.1.0-ubuntu24
sources.Dockerfile: nicu-backend 2026.1.0-rc1 → 2026.1.0