### PR TITLE
Smart Classroom: fix UI transcription section crash with long audio with rich content

### DIFF
--- a/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
@@ -234,7 +234,7 @@ const TranscriptsTab: React.FC = () => {
           });
         }
 
-        if (mountedRef.current) {
+        if (!controller.signal.aborted && mountedRef.current) {
           dispatch(completeSegmentTyping(idx));
         }
       } catch {
@@ -250,6 +250,13 @@ const TranscriptsTab: React.FC = () => {
     };
 
     run();
+
+    // Abort this segment's typewriter when the cursor moves on (or on unmount)
+    // so a stale run can't dispatch completeSegmentTyping for an old index.
+    return () => {
+      controller.abort();
+      typewriterControllers.current.delete(idx);
+    };
   }, [currentTypingIndex]);
 
   useEffect(() => {

--- a/education-ai-suite/smart-classroom/ui/src/redux/slices/transcriptSlice.ts
+++ b/education-ai-suite/smart-classroom/ui/src/redux/slices/transcriptSlice.ts
@@ -190,11 +190,25 @@ export const transcriptSlice = createSlice({
 
     completeSegmentTyping: (state, action: PayloadAction<number>) => {
       const idx = action.payload;
-      if (idx >= 0 && idx < state.segments.length) {
-        state.segments[idx].isComplete = true;
-        const next = idx + 1;
-        state.currentTypingIndex = next < state.segments.length ? next : -1;
+      if (idx < 0 || idx >= state.segments.length) return;
+
+      state.segments[idx].isComplete = true;
+
+      // Only advance the cursor when the segment that just finished is the one
+      // we're actually typing. On long transcriptions chunks can arrive faster
+      // than the typewriter animates, so a stale run may complete an older index
+      // after the cursor has moved on. Honoring it would move the cursor
+      // backward into already-completed segments and trigger a synchronous
+      // completion cascade ("Maximum update depth exceeded").
+      if (idx !== state.currentTypingIndex) return;
+
+      // Skip over segments that are already complete so we never re-type (or
+      // cascade through) finished content.
+      let next = idx + 1;
+      while (next < state.segments.length && state.segments[next].isComplete) {
+        next++;
       }
+      state.currentTypingIndex = next < state.segments.length ? next : -1;
     },
 
     setTotalDuration: (state, action: PayloadAction<number>) => {


### PR DESCRIPTION
### Description

When running a long audio transcription, the webpage could become blank with below error found on web inspect.
```
Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
    at getRootForUpdatedFiber (react-dom-client.development.js:4624:11)
    at enqueueConcurrentHookUpdate (react-dom-client.development.js:4584:14)
    at dispatchSetStateInternal (react-dom-client.development.js:9167:18)
    at dispatchSetState (react-dom-client.development.js:9127:7)
    at TranscriptsTab.tsx:144:5
```
The issue happens when the backend streams transcript chunks faster than the UI's typewriter animation (150 ms/word) can keep up. 

The fix includes:

1. transcriptSlice.ts: completeSegmentTyping now ignores completions for any index that isn't the current cursor, and skips already-complete segments when advancing, so the cursor can never move backward or cascade.
2.  TranscriptsTab.tsx: the typewriter effect now returns a cleanup that aborts the controller and removes it from the map, so a stale run can't dispatch for an old index. I also guarded the final completeSegmentTyping dispatch with !controller.signal.aborted to match the abort-aware pattern used elsewhere in the effect.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

