### PR TITLE
[Federal Aerospace] Increase client request size for Chat application to allow sending larger files

### DIFF
--- a/federal-aerospace/apps/handheld-multi-modal/apps/nginx/nginx-standalone.conf
+++ b/federal-aerospace/apps/handheld-multi-modal/apps/nginx/nginx-standalone.conf
@@ -12,6 +12,9 @@ http {
     ssl_protocols       TLSv1.3;
     ssl_conf_command    Ciphersuites TLS_AES_256_GCM_SHA384;
 
+    client_max_body_size 200M;
+    proxy_read_timeout   300s;
+
     # Required for Open WebUI websockets
     location / {
       proxy_pass         http://open-webui:8080;

--- a/federal-aerospace/apps/handheld-multi-modal/apps/nginx/nginx.conf
+++ b/federal-aerospace/apps/handheld-multi-modal/apps/nginx/nginx.conf
@@ -33,6 +33,9 @@ http {
     ssl_protocols       TLSv1.3;
     ssl_conf_command    Ciphersuites TLS_AES_256_GCM_SHA384;
 
+    client_max_body_size 200M;
+    proxy_read_timeout   300s;
+
     # Required for Open WebUI websockets
     location / {
       proxy_pass         http://open-webui:8080;


### PR DESCRIPTION
### Description

Increases client request size in nginx for Chat app to allow sending larger files (e.g. PDFs). Default limit is 1MB.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

