### PR TITLE
[Federal Aerospace] Remove unusable ViPPET pipelines from UI due to missing models

### DIFF
--- a/federal-aerospace/apps/handheld-multi-modal/Makefile
+++ b/federal-aerospace/apps/handheld-multi-modal/Makefile
@@ -105,10 +105,16 @@ vippet-configure: vippet-get ## Copy telegraf config and inject env vars into vi
 	@echo "Configuring vippet metrics-manager..."; \
 	cp $(SELF_DIR)/collector/telegraf.conf $(VIPPET_CWD)/vippet-telegraf.conf; \
 	python3 $(SELF_DIR)/scripts/filter_models.py \
-		"$(VIPPET_CWD)/shared/models/supported_models.yaml"; \
+		"$(VIPPET_CWD)/shared/models/supported_models.yaml" \
+		"$(VIPPET_CWD)/vippet/pipelines"; \
 	if ! grep -q 'METRICS_MANAGER_HOSTNAME' $(VIPPET_CWD)/compose.yml; then \
 		sed -i 's|METRICS_RETENTION_SECONDS:.*|&\n      METRICS_MANAGER_HOSTNAME: $${METRICS_MANAGER_HOSTNAME:-ptl}|' $(VIPPET_CWD)/compose.yml; \
 		echo "✓ compose.yml patched (METRICS_MANAGER_HOSTNAME added)"; \
+	fi; \
+	if ! grep -q 'vippet/pipelines' $(VIPPET_CWD)/compose.yml; then \
+		sed -i '/    - \.\/shared\/metadata\/:\/metadata/a\    - .\/vippet\/pipelines:\/home\/dlstreamer\/vippet\/pipelines:ro' \
+			$(VIPPET_CWD)/compose.yml; \
+		echo "✓ compose.yml patched (pipelines volume added)"; \
 	fi; \
 	echo "✓ vippet configured (telegraf.conf copied)"
 

--- a/federal-aerospace/apps/handheld-multi-modal/scripts/filter_models.py
+++ b/federal-aerospace/apps/handheld-multi-modal/scripts/filter_models.py
@@ -2,16 +2,20 @@
 # SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 """
-Filter vippet's supported_models.yaml before model installation.
+Filter vippet's supported_models.yaml and pipelines before deployment.
 
-Removes:
+Removes from supported_models.yaml:
   - huggingface models (large, require auth, not needed here)
   - models with broken download scripts (see BROKEN set below)
 
+Removes from the pipelines directory (see REMOVE_PIPELINES below):
+  - pipelines that depend on removed models (defect-detection, video-summarization-vlm)
+
 Usage:
-  python3 filter_models.py <path-to-supported_models.yaml>
+  python3 filter_models.py <path-to-supported_models.yaml> [<pipelines-dir>]
 """
 
+import os
 import sys
 import yaml
 
@@ -19,6 +23,24 @@ import yaml
 # needs a newer version of DLSPS - which means a newer version of ViPPET, with newer model-downloader service
 # TODO: remove this exclusion once ViPPET is released and updated in this stack.
 BROKEN = {"pallet_defect_detection"}
+
+# Pipelines that depend on models removed above (huggingface / broken).
+# defect-detection depends on pallet_defect_detection; video-summarization-vlm
+# depends on the gemma3 huggingface model.
+REMOVE_PIPELINES = {"defect-detection.yaml", "video-summarization-vlm.yaml"}
+
+
+def filter_pipelines(pipelines_dir: str) -> None:
+    removed = []
+    for name in REMOVE_PIPELINES:
+        path = os.path.join(pipelines_dir, name)
+        if os.path.exists(path):
+            os.remove(path)
+            removed.append(name)
+    print(
+        f"✓ pipelines filtered "
+        f"({len(removed)} removed: {', '.join(sorted(removed)) or 'none already absent'})"
+    )
 
 
 def main(src: str) -> None:
@@ -37,7 +59,9 @@ def main(src: str) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <supported_models.yaml>", file=sys.stderr)
+    if len(sys.argv) not in (2, 3):
+        print(f"Usage: {sys.argv[0]} <supported_models.yaml> [<pipelines-dir>]", file=sys.stderr)
         sys.exit(1)
     main(sys.argv[1])
+    if len(sys.argv) == 3:
+        filter_pipelines(sys.argv[2])


### PR DESCRIPTION
### Description

Removes Visual Summarization pipeline and Pallet Defect Detection Pipeline from the ViPPET UI due to missing models.
PDD model is broken and Gemma3 is unsupported in this release of ViPPET.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

