### PR TITLE
fix(mmpm): route UI <-> aggregator through nginx, restore VITE_API_BASE_URL override

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docker-compose.yaml
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docker-compose.yaml
@@ -207,13 +207,16 @@ services:
       context: ./services/ui
       dockerfile: Dockerfile
       args:
-        VITE_API_BASE_URL: http://${HOST_IP:-localhost}:8001
-        VITE_POSE_STREAM_URL: http://${HOST_IP:-localhost}:8085/video_feed
         HTTP_PROXY: ${HTTP_PROXY}
         HTTPS_PROXY: ${HTTPS_PROXY}
         NO_PROXY: ${NO_PROXY}
     image: intel/hl-ai-ui:${TAG:-1.0.1}
-    container_name: ui  
+    container_name: ui
+    # nginx in this image reverse-proxies /api/ and /pose-stream/ to the
+    # aggregator (host port 8001) and 3D-pose service (host port 8085).
+    # host-gateway lets the bridge-network UI reach those host-mode services.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "3000:3000"
     depends_on:

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/Dockerfile
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/Dockerfile
@@ -3,10 +3,14 @@
 # -----------------------------
 FROM node:20-alpine AS build
  
-# Optional build argument for API base URL
+# Optional build arguments to override the runtime URLs. When unset the
+# UI uses relative paths (`/api`, `/pose-stream/video_feed`) served by
+# the in-image nginx reverse proxy.
 ARG VITE_API_BASE_URL
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
- 
+ARG VITE_POSE_STREAM_URL
+ENV VITE_POSE_STREAM_URL=$VITE_POSE_STREAM_URL
+
 WORKDIR /app
  
 # Install dependencies

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/nginx.conf
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/nginx.conf
@@ -1,14 +1,41 @@
 server {
     listen 3000;
- 
+
     server_name _;
- 
+
     root /usr/share/nginx/html;
     index index.html;
- 
+
+    # Reverse proxy: aggregator HTTP/SSE API. Keeps the browser on a single
+    # origin (port 3000) so the UI works behind SSH tunnels, ingress, and
+    # corporate proxies without exposing port 8001 externally.
+    location /api/ {
+        proxy_pass         http://host.docker.internal:8001/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_set_header   Connection "";
+        # SSE (/api/events) and other long-lived streams require buffering off
+        proxy_buffering    off;
+        proxy_cache        off;
+        proxy_read_timeout 1h;
+        proxy_send_timeout 1h;
+    }
+
+    # Reverse proxy: 3D pose MJPEG stream (multipart/x-mixed-replace)
+    location /pose-stream/ {
+        proxy_pass         http://host.docker.internal:8085/;
+        proxy_http_version 1.1;
+        proxy_set_header   Host $host;
+        proxy_set_header   Connection "";
+        proxy_buffering    off;
+        proxy_read_timeout 1h;
+    }
+
     location / {
         try_files $uri /index.html;
     }
- 
+
     error_page 500 502 503 504 /50x.html;
 }

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/components/LeftPanel/WorkloadCard.tsx
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/components/LeftPanel/WorkloadCard.tsx
@@ -48,10 +48,12 @@ const WorkloadCard: React.FC<WorkloadCardProps> = ({
   frameData,
   people,
 }) => {
-  // Pose MJPEG stream URL: overridable via env for Helm, defaults to 8085 for docker-compose
-  const hostIp = (import.meta as any).env?.VITE_HOST_IP || (typeof window !== 'undefined' ? window.location.hostname : 'localhost');
-  const poseStreamUrl = (import.meta as any).env?.VITE_POSE_STREAM_URL
-    || `${typeof window !== 'undefined' ? window.location.protocol : 'http:'}//${hostIp}:8085/video_feed`;
+  // Pose MJPEG stream URL: defaults to the nginx reverse-proxy path so the
+  // browser stays on port 3000. Override with VITE_POSE_STREAM_URL (absolute)
+  // for deployments that need to hit the 3D-pose service directly.
+  const poseStreamUrl =
+    ((import.meta as any).env?.VITE_POSE_STREAM_URL as string | undefined)
+    || '/pose-stream/video_feed';
 
   const statusColors = {
     idle: '#6c757d',

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/constants.ts
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/constants.ts
@@ -6,10 +6,10 @@ export const constants = {
   VERSION: 'v1.0.0',
 };
 
-const API_HOST = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
-export const API_BASE_URL = typeof window !== 'undefined'
-  ? `${window.location.protocol}//${API_HOST}:8001`
-  : `http://${API_HOST}:8001`;
+// Default: call the aggregator through the UI nginx reverse proxy.
+// Override with VITE_API_BASE_URL at build time to point at an absolute URL.
+export const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api';
 
 export const WORKLOADS = [
   {

--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/services/api.ts
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/services/ui/src/services/api.ts
@@ -8,13 +8,15 @@ export type StartResponse = {
 };
 export type StopResponse = { status: string; message: string };
 
-// Derive the backend origin from the browser host so prebuilt UI images
-// still call the machine that actually served the page.
-const API_HOST = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
-const API_PORT = (import.meta as any).env?.VITE_API_PORT || '8001';
-const BASE_URL = typeof window !== 'undefined'
-  ? `${window.location.protocol}//${API_HOST}:${API_PORT}`
-  : `http://${API_HOST}:${API_PORT}`;
+// Default: call the aggregator through the UI nginx reverse proxy
+// (`/api/...`). Keeps the browser on a single origin so the UI works
+// behind SSH tunnels, ingress, and reverse proxies without exposing
+// port 8001 externally.
+//
+// Override with VITE_API_BASE_URL at build time for deployments that
+// need to talk to the aggregator directly (e.g. an absolute URL like
+// `http://10.0.0.5:8001`).
+const BASE_URL = ((import.meta as any).env?.VITE_API_BASE_URL as string | undefined) || '/api';
 const AGGREGATOR_URL = BASE_URL;
 // const METRICS_URL = import.meta.env.VITE_METRICS_BASE_URL || `http://${API_HOST}:${METRICS_PORT}`;
 
@@ -187,8 +189,9 @@ export async function getWorkloadDevices(): Promise<{
 export function getEventsUrl(workloads: WorkloadType[]): string {
   const params = workloads.map(w => `workload=${w}`).join('&');
   return `${BASE_URL}/events?${params}`;
-  
-  // Example: http://<HOST_IP>:8001/events?workload=rppg&workload=ai-ecg&workload=mdpnp&workload=3d-pose
+
+  // Default resolves to `/api/events?...` (proxied by nginx to the aggregator).
+  // Override with VITE_API_BASE_URL to call the aggregator directly.
 }
 
 export const api = {


### PR DESCRIPTION
## Problem
The MMPM UI was hard-coded to call the aggregator on `http://localhost:8001` and
the 3D-pose MJPEG stream on `http://localhost:8085`. In any deployment where the
browser is not on the same host as the backend (LAN access, port-forward, Docker
on a remote VM, k8s NodePort, etc.) every `/api/*` call and the pose stream
fail with `ERR_CONNECTION_REFUSED`.

## Fix
Route all browser traffic through the UI's nginx container on port 3000:

- `services/ui/nginx.conf` — add `location /api/` → `host.docker.internal:8001`
  and `location /pose-stream/` → `host.docker.internal:8085` (SSE + MJPEG safe:
  `proxy_buffering off`, `proxy_read_timeout 1h`, `Connection ""`).
- `services/ui/src/services/api.ts`, `src/constants.ts`,
  `src/components/LeftPanel/WorkloadCard.tsx` — default `BASE_URL` /
  `API_BASE_URL` / `poseStreamUrl` to relative `/api` and
  `/pose-stream/video_feed`; honor `VITE_API_BASE_URL` /
  `VITE_POSE_STREAM_URL` build-time overrides when set.
- `services/ui/Dockerfile` — add the matching `ARG`/`ENV` plumbing for
  `VITE_POSE_STREAM_URL`.
- `docker-compose.yaml` — drop the stale localhost build args from the `ui`
  service and add `extra_hosts: host.docker.internal:host-gateway` so the nginx
  proxy can reach the host-network aggregator/pose services.

## Validation
Full fresh `docker compose up -d --build` against the rebuilt 1.0.1 images
No behavior change when `VITE_API_BASE_URL` is set explicitly.