### PR TITLE
fix fastdds by pointing to correct .so

### DIFF
--- a/robotics-ai-suite/components/object-detection/object_detection_tutorial/jazzy/debian/changelog
+++ b/robotics-ai-suite/components/object-detection/object_detection_tutorial/jazzy/debian/changelog
@@ -1,3 +1,9 @@
+ros-jazzy-object-detection-tutorial (2.3-2) UNRELEASED; urgency=low
+
+  * Update Environments for fastdds
+
+ -- ECI Maintainer <eci.maintainer@intel.com>  Wed, 09 Jul 2026 12:00:00 +0200
+
 ros-jazzy-object-detection-tutorial (2.3-1) UNRELEASED; urgency=low
 
   * Initial release

--- a/robotics-ai-suite/components/object-detection/object_detection_tutorial/launch/openvino_object_detection.launch.py
+++ b/robotics-ai-suite/components/object-detection/object_detection_tutorial/launch/openvino_object_detection.launch.py
@@ -10,13 +10,20 @@ from tempfile import NamedTemporaryFile
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, LogInfo, OpaqueFunction, Shutdown
+from launch.actions import (
+    DeclareLaunchArgument,
+    LogInfo,
+    OpaqueFunction,
+    SetEnvironmentVariable,
+    Shutdown,
+)
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 import yaml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+ROS_DISTRO_VERSION = os.environ.get('ROS_DISTRO', 'humble')  # Default to 'humble' if not set
 
 
 def create_modified_yaml(device):
@@ -55,6 +62,16 @@ def create_modified_yaml(device):
 def generate_launch_description(*args, **kwargs):
     device = LaunchConfiguration('device')
     supported_devices = ['NPU', 'GPU', 'CPU']
+
+    ld_preload_action = None
+    if ROS_DISTRO_VERSION == 'jazzy':
+        ld_preload_action = SetEnvironmentVariable(
+            name='LD_PRELOAD',
+            value=(
+                f'/opt/ros/{ROS_DISTRO_VERSION}/lib/libfastcdr.so:'
+                f'/opt/ros/{ROS_DISTRO_VERSION}/lib/libfastrtps.so'
+            ),
+        )
 
     def launch_nodes(context, *args, **kwargs):
         selected_device = context.launch_configurations['device']
@@ -105,6 +122,7 @@ def generate_launch_description(*args, **kwargs):
                 default_value='GPU',
                 description='Inference device to use (e.g., NPU, GPU, CPU)',
             ),
+            *([ld_preload_action] if ld_preload_action else []),
             OpaqueFunction(function=launch_nodes),
             LogInfo(msg=[LaunchConfiguration('device'), ' device selected for inference']),
         ]

--- a/robotics-ai-suite/components/object-detection/segmentation_realsense_tutorial/jazzy/debian/changelog
+++ b/robotics-ai-suite/components/object-detection/segmentation_realsense_tutorial/jazzy/debian/changelog
@@ -1,3 +1,9 @@
+ros-jazzy-segmentation-realsense-tutorial (2.3-2) UNRELEASED; urgency=low
+
+  * Update Environment for fastdds
+
+ -- ECI Maintainer <eci.maintainer@intel.com>  Wed, 09 Jul 2026 12:00:00 +0200
+
 ros-jazzy-segmentation-realsense-tutorial (2.3-1) UNRELEASED; urgency=low
 
   * Initial release

--- a/robotics-ai-suite/components/object-detection/segmentation_realsense_tutorial/launch/openvino_segmentation.launch.py
+++ b/robotics-ai-suite/components/object-detection/segmentation_realsense_tutorial/launch/openvino_segmentation.launch.py
@@ -16,6 +16,7 @@ from launch.actions import (
     IncludeLaunchDescription,
     LogInfo,
     OpaqueFunction,
+    SetEnvironmentVariable,
     Shutdown,
 )
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -25,6 +26,7 @@ import yaml
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+ROS_DISTRO_VERSION = os.environ.get('ROS_DISTRO', 'humble')  # Default to 'humble' if not set
 
 
 def create_modified_yaml(device):
@@ -61,6 +63,16 @@ def create_modified_yaml(device):
 def generate_launch_description(*args, **kwargs):
     device = LaunchConfiguration('device')
     supported_devices = ['GPU', 'CPU']
+
+    ld_preload_action = None
+    if ROS_DISTRO_VERSION == 'jazzy':
+        ld_preload_action = SetEnvironmentVariable(
+            name='LD_PRELOAD',
+            value=(
+                f'/opt/ros/{ROS_DISTRO_VERSION}/lib/libfastcdr.so:'
+                f'/opt/ros/{ROS_DISTRO_VERSION}/lib/libfastrtps.so'
+            ),
+        )
 
     def launch_nodes(context, *args, **kwargs):
         selected_device = context.launch_configurations['device']
@@ -127,6 +139,7 @@ def generate_launch_description(*args, **kwargs):
             DeclareLaunchArgument(
                 device, default_value='GPU', description='Inference device to use (e.g., GPU, CPU)'
             ),
+            *([ld_preload_action] if ld_preload_action else []),
             OpaqueFunction(function=launch_nodes),
             LogInfo(msg=[LaunchConfiguration('device'), ' device selected for inference']),
         ]


### PR DESCRIPTION
### Description

This commit fixes bug where fastdds was not able to get images from realsense because of two similar libraries conflicting from librealsense2 and ros-jazzy-librealsense2
Fixes # (issue)



### How Has This Been Tested?

Manually tested by installing packages on a fresh system and testing the tutorials 

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

