### PR TITLE
timeseries: Fix the common_utils.py

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/common_utils.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-time-series/tests/utils/common_utils.py
@@ -545,7 +545,7 @@ def check_logs_by_level(resource_name, log_level, resource_type="container", nam
             # Get logs without shell=True
             logs_result = subprocess.run(
                 ["docker", "logs", resource_name],
-                capture_output=True,
+                stdout=subprocess.PIPE,
                 text=True,
                 stderr=subprocess.STDOUT
             )


### PR DESCRIPTION
### Description

Changes:

1.In function check_logs_by_level : Removed capture_output argument and added stdout argument because that subprocess call was invalid in python.

Fixes # (issue)

### Any Newly Introduced Dependencies

NO

### How Has This Been Tested?
Workflow was trigger and it passed the tests

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

