### PR TITLE
[DOCS] Separate release notes 2025

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/release-notes.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/release-notes.md
@@ -62,7 +62,6 @@ This release introduces **S3-based frame storage**, **deployment hardening**, an
 - Documentation has been extended and improved for ease of navigation, covering updates to
   setup guides, Helm deployment, and more.
 
-
 For information on older versions, check [release notes 2025](./release-notes/release-notes-2025.md)
 
 <!--hide_directive
@@ -70,6 +69,7 @@ For information on older versions, check [release notes 2025](./release-notes/re
 :maxdepth: 5
 :hidden:
 
-release-notes/release-notes-2025.md
+Release Notes 2025 <./release-notes/release-notes-2025.md>
+
 ```
 hide_directive-->

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/release-notes/release-notes-2025.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/release-notes/release-notes-2025.md
@@ -1,6 +1,8 @@
-# December 2025
+# Release Notes: Industrial Edge Insights Multimodal 2025
 
-## version 1.0.0
+## Version 1.0.0
+
+**December 2025**
 
 This is the first version of the Multimodal Weld Defect Detection sample app,
 showcasing the Vision and Time Series defect detection use case by detecting anomalous welding.

--- a/metro-ai-suite/image-based-video-search/docs/user-guide/index.md
+++ b/metro-ai-suite/image-based-video-search/docs/user-guide/index.md
@@ -90,7 +90,7 @@ how-it-works
 how-to-use-gpu-for-inference
 how-to-use-npu-for-inference
 troubleshooting
-release-notes
+Release Notes <./release-notes.md>
 
 :::
 hide_directive-->

--- a/metro-ai-suite/image-based-video-search/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/image-based-video-search/docs/user-guide/release-notes.md
@@ -1,6 +1,6 @@
-# Release Notes
+# Release Notes: Image-Based Video Search
 
-- [Version 1.3.4](#version-130)
+- [Version 1.3.0](#version-130)
 - [Version 1.2.0](#version-120)
 - [Version 1.1.0](#version-110)
 - [Version 1.0.1](#version-101)

--- a/metro-ai-suite/sensor-fusion-for-traffic-management/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/sensor-fusion-for-traffic-management/docs/user-guide/release-notes.md
@@ -1,34 +1,34 @@
-# Intel® OEP Sensor Fusion For Traffic Management - Release Notes
+# Release Notes: Sensor Fusion For Traffic Management
 
 ## Version 2026.1.0
 
 **June 17, 2026**
 
 This release delivers **BEVFusion 3D object detection** enablement and
-optimization on Intel GPUs. It provides a complete end-to-end pipeline — from
+optimization on Intel® GPUs. It provides a complete end-to-end pipeline — from
 training and model export to optimized deployment inference — targeting
 autonomous driving and roadside perception (V2X) scenarios with multi-sensor
 (Camera + LiDAR) fusion.
 
 Supported Platforms:
 
-| Platform | GPU |
-|---|---|
-| Intel Panther Lake (PTL) | Integrated GPU |
-| Intel Arc B580 (Battlemage) | Discrete GPU |
+| Platform                     | GPU            |
+| ---------------------------- | -------------- |
+| Intel® Panther Lake (PTL)    | Integrated GPU |
+| Intel® Arc B580 (Battlemage) | Discrete GPU   |
 
 **New**
 
-- **Sparse Convolution OpenVINO GPU Plugin Implementation**
+- **Sparse Convolution OpenVINO™ GPU Plugin Implementation**
 
-  Native 3D Sparse Convolution support in the OpenVINO GPU plugin, enabling the
+  Native 3D Sparse Convolution support in the OpenVINO™ GPU plugin, enabling the
   Second-based BEVFusion unified pipeline to run entirely within a single
-  OpenVINO inference call on Intel GPU. The `SparseConvolution` operator
+  OpenVINO™ inference call on Intel® GPU. The `SparseConvolution` operator
   (registered under domain `org.openvinotoolkit`) covers both SparseConv3d and
   SubMConv3d variants with fused BatchNorm + optional ReLU, totaling ~21 layers
-  in the lidar sparse encoder. A custom OpenVINO build patch
+  in the lidar sparse encoder. A custom OpenVINO™ build patch
   (`custom_openvino_2026.1.0_sparse_ops.patch`, ~12K lines) integrates all GPU
-  kernel implementations into the OpenVINO 2026.1.0 GPU plugin.
+  kernel implementations into the OpenVINO™ 2026.1.0 GPU plugin.
 
 - **BEVFusion-specific custom operators in GPU plugin**
 
@@ -37,12 +37,11 @@ Supported Platforms:
   also implemented to support the full unified pipeline.
 
 - **Two deployment pipelines**
-
   - Split (PointPillars): `./bevfusion` — 4 independent ONNX sub-graphs (camera
     backbone, lidar PFE, fuser, detection head) + external SYCL kernels,
-    using standard ONNX / OpenVINO IR.
+    using standard ONNX / OpenVINO™ IR.
   - Unified (Second): `./bevfusion_unified` — single unified ONNX with custom
-    sparse ops executed inside the OpenVINO GPU plugin.
+    sparse ops executed inside the OpenVINO™ GPU plugin.
 
 - **Multi-dataset support**
 
@@ -54,7 +53,7 @@ Supported Platforms:
   Complete training-to-deploy workflow including dense mode training, BEVPool
   V1/V2 support, automated ONNX export, static-V PFE export, INT8 PTQ
   quantization (NNCF-based), and NVIDIA checkpoint compatibility (direct
-  conversion from CUDA-V2XFusion `.pth` to Intel GPU deploy without retraining).
+  conversion from CUDA-V2XFusion `.pth` to Intel® GPU deploy without retraining).
 
 **Improved**
 
@@ -88,12 +87,11 @@ Supported Platforms:
 - Bundled release model assets use dummy weights for runtime interface
   validation; real trained weights are required for meaningful detection results.
 
-
-
 <!--hide_directive
 :::{toctree}
 :hidden:
 
 Release Notes 2025 <release-notes/release-notes-2025.md>
+
 :::
 hide_directive-->

--- a/metro-ai-suite/sensor-fusion-for-traffic-management/docs/user-guide/release-notes/release-notes-2025.md
+++ b/metro-ai-suite/sensor-fusion-for-traffic-management/docs/user-guide/release-notes/release-notes-2025.md
@@ -1,21 +1,20 @@
-# Release Notes
+# Release Notes: Sensor Fusion For Traffic Management 2025
 
-## Current Release
+## Previous Releases
 
-**Version**: 3.0.0 
-**Release Date**: 21 Nov 2025  
+**Version**: 3.0.0\
+**Release Date**: 21 Nov 2025
 
 **Features**:
 
 - Camera Lidar Fusion:
-
-    - Support 2C+1L/4C+2L pipeline
-    - Support 8C+4L/12C+2L/12C4L pipeline
-    - Support Pointpillar model
-    - Updated OpenVINO to 2025.3
-    - Updated oneAPI to 2025.3.0
+  - Support 2C+1L/4C+2L pipeline
+  - Support 8C+4L/12C+2L/12C4L pipeline
+  - Support Pointpillar model
+  - Updated OpenVINO to 2025.3
+  - Updated oneAPI to 2025.3.0
 
 **HW used for validation**:
 
--    Intel® Core™ processors (13th Gen, i7 recommended) + Intel® Arc™ B-Series Graphics (Intel® Arc™ B580 recommended) 
--    Intel® Core™ Ultra 7 Processor 265H
+- Intel® Core™ processors (13th Gen, i7 recommended) + Intel® Arc™ B-Series Graphics (Intel® Arc™ B580 recommended)
+- Intel® Core™ Ultra 7 Processor 265H

--- a/metro-ai-suite/smart-nvr/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/smart-nvr/docs/user-guide/release-notes.md
@@ -2,11 +2,6 @@
 
 - [Version 2026.1.0](#version-202610)
 - [Version 1.2.4](#version-124)
-- [Version 1.2.3](#version-123)
-- [Version 1.2.2](#version-122)
-- [Version 1.2.1](#version-121)
-- [Version 1.2.0](#version-120)
-- [Version RC1](#version-rc1)
 
 ## Current Release
 
@@ -43,64 +38,12 @@
 - Documentation updates for clarity and accuracy.
 - Minor bug fixes.
 
-### Version 1.2.3
+<!--hide_directive
+:::{toctree}
+:hidden:
 
-**Release Date**: 24 November 2025
+Release Notes 2025 <./release-notes/release-notes-2025.md>
 
-**New Features**:
+:::
+hide_directive-->
 
-- Minor Fixes
-
-### Version 1.2.2
-
-**Release Date**: 14 November 2025
-
-**New Features**:
-
-- Bug Fixes
-
-### Version 1.2.1
-
-**Release Date**: 30 October 2025
-
-**New Features**:
-
-- Continuous Video Streaming: Introduced support for uninterrupted video streaming based on user-selected cameras.
-- Helm Chart Support: Deployment via Helm charts is now supported, simplifying installation and configuration.
-- Rules Engine Integration: Enabled communication between the rules engine and Intel® SceneScape, demonstrated using the Smart Intersection RI integration.
-- Unit Testing: Added comprehensive unit test cases to improve reliability and maintainability.
-
-### Version 1.2.0
-
-**Release Date**: 04 August 2025
-
-**Features**:
-
-- This is an incremental release on top of RC1 providing fixes for issues found on RC1. The notes provided under RC1 apply for this incremental release too.
-- Issues fixed are listed below:
-  - Updated docker images to public registry.
-  - Updated README to pull the image from remote registry.
-
-### Version RC1
-
-**Release Date**: 14 July 2025
-
-**Features**:
-
-- Smart NVR backend and frontend based on the single docker image
-- Gradio based UI for selecting the use case
-- Docker compose based deployment for the E2E application
-- Auto Routing of the NVR events
-- Routing of the events based on the timestamp
-- Experimental Showcasing Using NVR's Event routing capabilities to OEP VLM microservice.
-
-**HW used for validation**:
-
-- Intel® Xeon® 5 + Intel® Arc&trade; B580 GPU
-
-**Known Issues/Limitations**:
-
-- Edge Manageability Framework and Edge Microvisor Toolkit are not supported yet.
-- Users are required to build the images and use the sample application. Docker images are not available yet on public registries (pending approvals).
-- Helm charts for the application are not supported in this release.
-- The **AI-Powered Event Viewer** feature relies on Frigate GenAI features, which may exhibit instability or bugs, impacting event data processing reliability.

--- a/metro-ai-suite/smart-nvr/docs/user-guide/release-notes/release-notes-2025.md
+++ b/metro-ai-suite/smart-nvr/docs/user-guide/release-notes/release-notes-2025.md
@@ -1,0 +1,71 @@
+# Release Notes: Smart NVR 2025
+
+- [Version 1.2.3](#version-123)
+- [Version 1.2.2](#version-122)
+- [Version 1.2.1](#version-121)
+- [Version 1.2.0](#version-120)
+- [Version RC1](#version-rc1)
+
+## Previous Releases
+
+### Version 1.2.3
+
+**Release Date**: 24 November 2025
+
+**New Features**:
+
+- Minor Fixes
+
+### Version 1.2.2
+
+**Release Date**: 14 November 2025
+
+**New Features**:
+
+- Bug Fixes
+
+### Version 1.2.1
+
+**Release Date**: 30 October 2025
+
+**New Features**:
+
+- Continuous Video Streaming: Introduced support for uninterrupted video streaming based on user-selected cameras.
+- Helm Chart Support: Deployment via Helm charts is now supported, simplifying installation and configuration.
+- Rules Engine Integration: Enabled communication between the rules engine and Scenescape, demonstrated using the Smart Intersection RI integration.
+- Unit Testing: Added comprehensive unit test cases to improve reliability and maintainability.
+
+### Version 1.2.0
+
+**Release Date**: 04 August 2025
+
+**Features**:
+
+- This is an incremental release on top of RC1 providing fixes for issues found on RC1. The notes provided under RC1 apply for this incremental release too.
+- Issues fixed are listed below:
+  - Updated docker images to public registry.
+  - Updated README to pull the image from remote registry.
+
+### Version RC1
+
+**Release Date**: 14 July 2025
+
+**Features**:
+
+- Smart NVR backend and frontend based on the single docker image
+- Gradio based UI for selecting the use case
+- Docker compose based deployment for the E2E application
+- Auto Routing of the NVR events
+- Routing of the events based on the timestamp
+- Experimental Showcasing Using NVR's Event routing capabilities to OEP VLM microservice.
+
+**HW used for validation**:
+
+- Intel® Xeon® 5 + Intel® Arc&trade; B580 GPU
+
+**Known Issues/Limitations**:
+
+- Edge Manageability Framework and Edge Microvisor Toolkit are not supported yet.
+- Users are required to build the images and use the sample application. Docker images are not available yet on public registries (pending approvals).
+- Helm charts for the application are not supported in this release.
+- The **AI-Powered Event Viewer** feature relies on Frigate GenAI features, which may exhibit instability or bugs, impacting event data processing reliability.


### PR DESCRIPTION
### Description

- fix some concatenation issues for release notes articles
- separate 2025 release notes into their own articles

Partial port from #3445.

### How Has This Been Tested?

Docs built locally.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.