### PR TITLE
[smart classroom] Add Qwen3.5 9B support for VLM

### DIFF
--- a/education-ai-suite/smart-classroom/api/vlm_chat.py
+++ b/education-ai-suite/smart-classroom/api/vlm_chat.py
@@ -146,6 +146,7 @@ async def chat_completions(request: Request):
             stream=True,
             max_new_tokens=chat_req.max_completion_tokens,
             temperature=chat_req.temperature,
+            enable_thinking=chat_req.enable_thinking,
         )
         return StreamingResponse(
             _sse_stream(token_iter, model_name),
@@ -159,6 +160,7 @@ async def chat_completions(request: Request):
         stream=False,
         max_new_tokens=chat_req.max_completion_tokens,
         temperature=chat_req.temperature,
+        enable_thinking=chat_req.enable_thinking,
     )
     response = mods.ChatCompletionResponse(
         id=str(uuid.uuid4()),

--- a/education-ai-suite/smart-classroom/components/grading/config.yaml
+++ b/education-ai-suite/smart-classroom/components/grading/config.yaml
@@ -10,7 +10,7 @@ vlm:
 
 grading:
   force_regrade: true
-  debug_mode: true
+  debug_mode: false
 
 watch:
   poll_interval: 5

--- a/education-ai-suite/smart-classroom/components/grading/config.yaml
+++ b/education-ai-suite/smart-classroom/components/grading/config.yaml
@@ -10,7 +10,7 @@ vlm:
 
 grading:
   force_regrade: true
-  debug_mode: false
+  debug_mode: true
 
 watch:
   poll_interval: 5

--- a/education-ai-suite/smart-classroom/components/grading/services/vlm_client.py
+++ b/education-ai-suite/smart-classroom/components/grading/services/vlm_client.py
@@ -67,6 +67,7 @@ def build_payload(image: "Path | PIL.Image.Image", user_prompt: str,
         ],
         "max_completion_tokens": max_tokens,
         "temperature": temperature,
+        "enable_thinking": False,
     }
 
 
@@ -171,6 +172,7 @@ def extract_header_info(
         ],
         "max_completion_tokens": max_tokens,
         "temperature": temperature,
+        "enable_thinking": False,
     }
 
     start = time.perf_counter()

--- a/education-ai-suite/smart-classroom/components/vlm/text_gen_handle.py
+++ b/education-ai-suite/smart-classroom/components/vlm/text_gen_handle.py
@@ -46,6 +46,7 @@ class TextGenHandler:
         stream: bool = True,
         max_new_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
+        enable_thinking: Optional[bool] = None,
     ) -> Union[Iterator[str], str]:
         return self._get_runner().submit(
             prompt,
@@ -53,6 +54,7 @@ class TextGenHandler:
             stream=stream,
             max_new_tokens=max_new_tokens,
             temperature=temperature,
+            enable_thinking=enable_thinking,
         )
 
     def load(self) -> None:

--- a/education-ai-suite/smart-classroom/components/vlm/text_gen_vlm.py
+++ b/education-ai-suite/smart-classroom/components/vlm/text_gen_vlm.py
@@ -111,19 +111,23 @@ class VLMTextGen:
         self._pipe = ov_genai.VLMPipeline(
             str(model_dir), device=self._device, **self._ov_config()
         )
-        # The OpenVINO conversion writes ``extra_special_tokens`` as a list in
-        # tokenizer_config.json, but transformers expects a dict. Override it to
-        # avoid ``AttributeError: 'list' object has no attribute 'keys'``.
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            str(model_dir), extra_special_tokens={}
-        )
-        if "qwen3" in self._model_name.lower():
-            _think_tokens = ["<think>", "</think>"]
-            _existing = set(getattr(self.tokenizer, "additional_special_tokens", []) or [])
-            _missing = [t for t in _think_tokens if t not in _existing]
-            if _missing:
-                self.tokenizer.add_special_tokens({"additional_special_tokens": _missing})
-                logger.info("Registered think tags as special tokens: %s", _missing)
+        try:
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                str(model_dir), extra_special_tokens={}
+            )
+            if "qwen3" in self._model_name.lower():
+                _think_tokens = ["<think>", "</think>"]
+                _existing = set(getattr(self.tokenizer, "additional_special_tokens", []) or [])
+                _missing = [t for t in _think_tokens if t not in _existing]
+                if _missing:
+                    self.tokenizer.add_special_tokens({"additional_special_tokens": _missing})
+                    logger.info("Registered think tags as special tokens: %s", _missing)
+        except Exception as exc:
+            logger.warning(
+                "transformers AutoTokenizer failed (%s); falling back to the "
+                "OpenVINO pipeline tokenizer.", exc
+            )
+            self.tokenizer = self._pipe.get_tokenizer()
         logger.info("Warm VLM ready.")
 
     def release(self) -> None:
@@ -147,6 +151,7 @@ class VLMTextGen:
         stream: bool = True,
         max_new_tokens: Optional[int] = None,
         temperature: Optional[float] = None,
+        enable_thinking: Optional[bool] = None,
     ) -> Union[Iterator[str], str]:
         """Generate from ``prompt`` (optionally multimodal) using the warm pipeline.
 
@@ -154,7 +159,8 @@ class VLMTextGen:
         non-streaming returns the full string. ``images`` (a list of
         ``ov.Tensor`` frames, already decoded by the caller) enables the
         multimodal path used by content-search video summarization; when
-        omitted the call is text-only.
+        omitted the call is text-only. ``enable_thinking=False`` suppresses
+        Qwen3 thinking for this request only; ``None`` keeps the model default.
         """
         if self._pipe is None:
             raise RuntimeError("VLM pipeline is not loaded")
@@ -162,6 +168,8 @@ class VLMTextGen:
             raise ValueError("Invalid prompt provided.")
 
         config = self._generation_config(max_new_tokens, temperature)
+        if enable_thinking is False:
+            prompt = self._apply_no_think_template(prompt, config, bool(images))
         if stream:
             return self._generate_stream(prompt, config, images)
         if images:
@@ -169,6 +177,21 @@ class VLMTextGen:
                 self._pipe.generate(prompt, images=images, generation_config=config)
             )
         return str(self._pipe.generate(prompt, generation_config=config))
+
+    def _apply_no_think_template(
+        self, prompt: str, config: "ov_genai.GenerationConfig", has_images: bool
+    ) -> str:
+        try:
+            media_tags = "<ov_genai_image_0>" if has_images else ""
+            history = [{"role": "user", "content": media_tags + prompt}]
+            templated = self._pipe.get_tokenizer().apply_chat_template(
+                history, True, "", None, {"enable_thinking": False}
+            )
+            config.apply_chat_template = False
+            return templated
+        except Exception as exc:  # noqa: BLE001 - fall back to raw prompt with think
+            logger.warning("no-think template failed (%s); using raw prompt", exc)
+            return prompt
 
     def _generation_config(
         self, max_new_tokens: Optional[int], temperature: Optional[float]

--- a/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/data_models.py
+++ b/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/data_models.py
@@ -87,6 +87,10 @@ class ChatRequest(BaseModel):
         None,
         json_schema_extra={"example": 42, "description": "Seed for reproducibility"},
     )
+    enable_thinking: Optional[bool] = Field(
+        None,
+        json_schema_extra={"example": False, "description": "Set False to suppress Qwen3 thinking; None keeps model default"},
+    )
 
 
 class ChatCompletionDelta(BaseModel):

--- a/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/utils.py
+++ b/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/utils.py
@@ -24,6 +24,8 @@ __all__ = ["convert_model", "is_model_ready", "load_images", "load_model_config"
 _PRECONVERTED_OV_MODELS = {
     ("Qwen/Qwen3-VL-8B-Instruct", "int4"): "OpenVINO/Qwen3-VL-8B-Instruct-int4-ov",
     ("Qwen/Qwen3-VL-8B-Instruct", "int8"): "OpenVINO/Qwen3-VL-8B-Instruct-int8-ov",
+    ("Qwen/Qwen3.5-9B", "int4"): "OpenVINO/Qwen3.5-9B-int4-ov",
+    ("Qwen/Qwen3.5-9B", "int8"): "OpenVINO/Qwen3.5-9B-int8-ov",
 }
 
 


### PR DESCRIPTION
### Description

- Adds support for `Qwen/Qwen3.5-9B` as the warm VLM backing text_gen, and introduces a per-request thinking toggle so latency-sensitive callers (e.g. grading) can suppress Qwen3 chain-of-thought output while other callers keep the model default.

- **Existing Qwen3 users need no changes** — config stays the same, the `AutoTokenizer` path and `thinking` behaviour are identical to before; only Qwen3.5 triggers the new fallback, and `enable_thinking` defaults to the model's normal behaviour for all callers that don't set it.

- New optional `enable_thinking` field on `ChatRequest` (default None = model default; **unchanged behaviour for existing callers**).

- When `enable_thinking=False`, the prompt is templated with `enable_thinking=False` (empty <think></think>) and the pipeline's auto chat-template is disabled, matching the standalone VLM server's behaviour.

- No dependency changes required — `Qwen3.5` runs on the existing pinned versions (`openvino-genai / openvino 2026.2.1`, `transformers 4.57.6`). The tokenizer fallback (item 2) is what makes this work without bumping transformers: rather than upgrading to a version that recognizes `Qwen3.5`'s `TokenizersBackend`, we use the OpenVINO pipeline tokenizer at runtime.


Qwen3.5 9B is a strong requirement for the Grading service. other components can stay on qwen3.

#### Usage:

config.yaml
   text_gen:
     enabled: true 
     provider: vlm
     vlm_name: **_Qwen/Qwen3.5-9B_**
     device: GPU
     weight_format: **_int4_**
     max_new_tokens: 5120
     concurrency: 1


Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

