### PR TITLE
[IRD Apps][SDLE]fix shellcheck issues in industrial-edge-insights-vision scripts

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pallet-defect-detection/setup.sh
@@ -2,7 +2,7 @@
 
 # Download artifacts for a specific sample application
 #   by calling respective app's setup.sh script
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 MODEL_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/06bb0d621cb14a1791672552a538beddddcc4066/models/INT8/pallet_defect_detection.zip"
 VIDEO_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/c13b8dbf23d514c2667d39b66615bd1400cb889d/videos/warehouse.avi"
 
@@ -89,8 +89,8 @@ download_artifacts() {
 download_artifacts "pallet-defect-detection"
 
 
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
+mkdir -p "$SCRIPT_DIR/configs/nginx/ssl"
+cd "$SCRIPT_DIR/configs/nginx/ssl" || exit
 if [ ! -f server.key ] || [ ! -f server.crt ]; then
     echo "Generate self-signed certificate..."
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/apps/pcb-anomaly-detection/setup.sh
@@ -2,7 +2,7 @@
 
 # Download artifacts for a specific sample application
 #   by calling respective app's setup.sh script
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 MODEL_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/6bde8bb1d2317cf16824b8812b845fff34cb0f76/models/FP16/pcb-anomaly-detection.zip"
 VIDEO_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/c13b8dbf23d514c2667d39b66615bd1400cb889d/videos/anomalib_pcb_test.avi"
 
@@ -93,8 +93,8 @@ download_artifacts() {
 
 download_artifacts "pcb-anomaly-detection"
 
-mkdir -p $SCRIPT_DIR/configs/nginx/ssl
-cd $SCRIPT_DIR/configs/nginx/ssl
+mkdir -p "$SCRIPT_DIR/configs/nginx/ssl"
+cd "$SCRIPT_DIR/configs/nginx/ssl" || exit
 if [ ! -f server.key ] || [ ! -f server.crt ]; then
     echo "Generate self-signed certificate..."
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout server.key -out server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Intel/OU=Edge AI/CN=localhost"

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/benchmark_start.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/benchmark_start.sh
@@ -59,19 +59,19 @@ awk_utils='
 DLSPS_NODE_IP="localhost"
 
 function get_pipeline_status() {
-    curl -k -s "https://$DLSPS_NODE_IP/api/pipelines/status" "$@"
+    curl -k -s "https://$DLSPS_NODE_IP/api/pipelines/status"
 }
 
 function check_and_loop_video() {
   local payload=$1
-  local source_uri=$(echo "$payload" | jq -r '.source.uri // empty')
+  local source_uri; source_uri=$(echo "$payload" | jq -r '.source.uri // empty')
   
   if [ -z "$source_uri" ]; then
     return 0
   fi
   
   # Extract just the filename from the URI (handle file:// prefix and paths)
-  local filename=$(basename "$source_uri")
+  local filename; filename=$(basename "$source_uri")
   
   # Check if filename ends with _looped.mp4
   if [[ "$filename" =~ _looped\.mp4$ ]]; then
@@ -98,7 +98,7 @@ function check_and_loop_video() {
     fi
     
     # Determine output path (same directory as base file)
-    local output_file="$(dirname "$base_file")/$filename"
+    local output_file; output_file="$(dirname "$base_file")/$filename"
     
     # Skip if looped file already exists
     if [ -f "$output_file" ]; then
@@ -417,7 +417,7 @@ if [ -z "$SAMPLE_APP" ]; then
 fi
 
 # Set APP_DIR using the same logic as sample_start.sh
-APP_DIR="$(dirname $(readlink -f "$0"))/apps/$SAMPLE_APP"
+APP_DIR="$(dirname "$(readlink -f "$0")")/apps/$SAMPLE_APP"
 
 # Check if APP_DIR directory exists
 if [ ! -d "$APP_DIR" ]; then
@@ -450,7 +450,7 @@ tns=0
 lns=$lower_bound
 uns=$upper_bound
 
-[[ "$@" = *"--trace"* && $lns -lt $uns ]] || echo "Start-Trace:"
+[[ "$*" = *"--trace"* && $lns -lt $uns ]] || echo "Start-Trace:"
 while [ $((uns - lns)) -gt 1 ] || [[ "$records" != *" $lns:"* ]] || [[ "$records" != *" $uns:"* ]]; do
   if [[ "$records" = *" $ns:"* ]]; then
     throughput=${records##* $ns:}
@@ -473,7 +473,7 @@ while [ $((uns - lns)) -gt 1 ] || [[ "$records" != *" $lns:"* ]] || [[ "$records
 done
 tns=$lns
 
-if [[ "$@" = *"--trace"* && $lns -lt $uns ]]; then
+if [[ "$*" = *"--trace"* && $lns -lt $uns ]]; then
   echo "Start-Trace:"
   throughput=$(run_workload_with_retries "$tns" "$pipeline_name_arg" "$payload_file")
 fi

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pallet-defect-detection/setup.sh
@@ -2,7 +2,7 @@
 
 # Download artifacts for a specific sample application
 #   by calling respective app's setup.sh script
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 MODEL_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/06bb0d621cb14a1791672552a538beddddcc4066/models/INT8/pallet_defect_detection.zip"
 VIDEO_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/c13b8dbf23d514c2667d39b66615bd1400cb889d/videos/warehouse.avi"
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/helm/apps/pcb-anomaly-detection/setup.sh
@@ -2,7 +2,7 @@
 
 # Download artifacts for a specific sample application
 #   by calling respective app's setup.sh script
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 MODEL_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/6bde8bb1d2317cf16824b8812b845fff34cb0f76/models/FP16/pcb-anomaly-detection.zip"
 VIDEO_URL="https://github.com/open-edge-platform/edge-ai-resources/raw/c13b8dbf23d514c2667d39b66615bd1400cb889d/videos/anomalib_pcb_test.avi"
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/run.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Start and stop all containers for the instances defined in config.yml
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 CONFIG_FILE="$SCRIPT_DIR/config.yml"
 
 err() {

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/sample_list.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/sample_list.sh
@@ -6,16 +6,14 @@
 # ------------------------------------------------------------------
 
 # Default values
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-PIPELINE_ROOT="user_defined_pipelines" # Default root directory for pipelines
-PIPELINE="all"                         # Default to running all pipelines
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 DEPLOYMENT_TYPE=""                     # Default deployment type (empty for existing flow)
 CONFIG_FILE=$SCRIPT_DIR/config.yml     # Config file path for multiple instances
 
 init() {
     # load environment variables from .env file if it exists
     if [[ -f "$ENV_PATH" ]]; then
-        export $(grep -v -E '^\s*#' "$ENV_PATH" | sed -e 's/#.*$//' -e '/^\s*$/d' | xargs)
+        while IFS= read -r _line; do export "$_line"; done < <(grep -v -E '^\s*#' "$ENV_PATH" | sed -e 's/#.*$//' -e '/^\s*$/d')
         echo "Environment variables loaded from $ENV_PATH"
     else
         err "No .env file found in $ENV_PATH"

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/sample_start.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/sample_start.sh
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------
 
 # Default values
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 PIPELINE_ROOT="user_defined_pipelines" # Default root directory for pipelines
 PIPELINE="all"                         # Default to running all pipelines
 PAYLOAD_COPIES=1                       # Default to running a single copy of the payloads

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/sample_status.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/sample_status.sh
@@ -5,8 +5,7 @@
 # ------------------------------------------------------------------
 
 # Default values
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-PIPELINE_ROOT="user_defined_pipelines" # Default root directory for pipelines
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 DEPLOYMENT_TYPE=""                     # Default deployment type (empty for existing flow)
 CONFIG_FILE=$SCRIPT_DIR/config.yml     # Config file path for multiple instances
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/sample_stop.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/sample_stop.sh
@@ -6,9 +6,7 @@
 # ------------------------------------------------------------------
 
 # Default values
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
-PIPELINE_ROOT="user_defined_pipelines" # Default root directory for pipelines
-PIPELINE="all"                         # Default to running all pipelines
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 DEPLOYMENT_TYPE=""                     # Default deployment type (empty for existing flow)
 CONFIG_FILE="$SCRIPT_DIR/config.yml"   # Config file path (For multiple instances)
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/setup.sh
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/setup.sh
@@ -2,7 +2,7 @@
 # Download artifacts for a specific sample application 
 #   by calling respective app's setup.sh script
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 CONFIG_FILE="$SCRIPT_DIR/config.yml"      # Config file path for multiple instances
 
 err() {
@@ -35,7 +35,7 @@ init() {
                 ((instance_count++))
                 instance_names+=("$instance_name")
                 # Add to sample_app_names if not already present
-                if [[ ! " ${sample_app_names[@]} " =~ " ${sample_app} " ]]; then
+                if [[ ! " ${sample_app_names[*]} " =~ " ${sample_app} " ]]; then
                     sample_app_names+=("$sample_app")
                 fi
             else
@@ -558,7 +558,7 @@ init_helm() {
                 ((instance_count++))
                 instance_names+=("$instance_name")
                 # Add to sample_app_names if not already present
-                if [[ ! " ${sample_app_names[@]} " =~ " ${sample_app} " ]]; then
+                if [[ ! " ${sample_app_names[*]} " =~ " ${sample_app} " ]]; then
                     sample_app_names+=("$sample_app")
                 fi
             else


### PR DESCRIPTION
Errors fixed (shellcheck --severity=error):
- SC2199: replace [@] with [*] in [[ ]] array comparisons (setup.sh)
- SC2199: replace "$@" with "$*" in [[ ]] string comparisons (benchmark_start.sh)

Warnings fixed:
- SC2046: quote $(readlink -f "$0") in SCRIPT_DIR assignments (all scripts)
- SC2046: quote $(readlink -f "$0") in APP_DIR assignment (benchmark_start.sh)
- SC2164: add || exit to cd commands (apps/*/setup.sh)
- SC2155: separate local declare and assign (benchmark_start.sh)
- SC2120: remove unused "$@" from get_pipeline_status curl call (benchmark_start.sh)
- SC2034: remove unused PIPELINE_ROOT/PIPELINE variables (sample_list/status/stop.sh)


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

