### PR TITLE
Enhance report download feature

### DIFF
--- a/education-ai-suite/smart-classroom/api/report.py
+++ b/education-ai-suite/smart-classroom/api/report.py
@@ -34,6 +34,19 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _pdf_export_available() -> bool:
+    """True when server-side PDF conversion is possible (LibreOffice on PATH)."""
+    return shutil.which("soffice") is not None
+
+
+_PDF_UNAVAILABLE_DETAIL = (
+    "PDF export is unavailable because LibreOffice is not installed or "
+    "'soffice' is not on PATH. Install LibreOffice from "
+    "https://www.libreoffice.org/download/, add 'soffice' to PATH, "
+    "then restart services."
+)
+
+
 def _ensure_docx_report(session_id: str) -> tuple[str, str]:
     """Return ``(session_dir, docx_path)`` for a session report, creating .docx
     from markdown when needed.
@@ -115,6 +128,17 @@ def get_report_template_fields():
     """Return the report field catalog (grouped, bilingual) for the checkboxes."""
     from components.report_generator.field_catalog import REPORT_TEMPLATE_FIELD_GROUPS
     return {"groups": REPORT_TEMPLATE_FIELD_GROUPS}
+
+
+@router.get("/report/capabilities")
+def get_report_capabilities():
+    """Report which download formats the server can produce.
+
+    ``pdf_export`` is False when LibreOffice ('soffice') is not on PATH, so the
+    UI can disable the PDF option up front (with an install hint) instead of
+    letting the teacher click and hit a 501.
+    """
+    return {"pdf_export": _pdf_export_available()}
 
 
 @router.post("/report/{session_id}/mindmap-image")
@@ -234,10 +258,7 @@ def download_report(
 
     soffice = shutil.which("soffice")
     if not soffice:
-        raise HTTPException(
-            status_code=501,
-            detail="PDF export is unavailable on server: LibreOffice (soffice) is not installed.",
-        )
+        raise HTTPException(status_code=501, detail=_PDF_UNAVAILABLE_DETAIL)
 
     try:
         subprocess.run(

--- a/education-ai-suite/smart-classroom/components/report_generator/report_generator.py
+++ b/education-ai-suite/smart-classroom/components/report_generator/report_generator.py
@@ -224,25 +224,38 @@ class ReportGenerator:
             yield {"type": "partial_report", "content": interim_md}
 
         llm_values = {}
+        # Fallback for AI-generated fields we can't fill: when the LLM errors out
+        # or returns unparseable/partial JSON, mark ONLY those fields as
+        # unavailable instead of discarding the whole report. The measured raw
+        # fields (statistics, mindmap, transcription, manual inputs) are already
+        # resolved and stay intact, so the teacher keeps a usable report.
+        na_placeholder = "无数据" if self.language == "zh" else "N/A"
         if gen_codes:
             gen_prompt = self._build_generated_fill_prompt(structure, gen_codes, raw_values)
+            llm_failed = False
+            json_response = None
             try:
                 json_response = self.model.generate(gen_prompt, stream=False)
                 if isinstance(json_response, str) and json_response.startswith("[ERROR]:"):
                     raise RuntimeError(json_response)
             except RuntimeError as e:
-                logger.error(f"[ReportGenerator] LLM failed during template fill: {e}")
-                err_msg = (
-                    "报告生成失败：LLM服务超时或出错，请稍后重试。"
-                    if self.language == "zh"
-                    else "Report generation failed. Please try again."
-                )
-                yield {"type": "token", "content": f"[ERROR]: {err_msg}"}
-                return
+                logger.error(f"[ReportGenerator] LLM failed during template fill: {e}. "
+                             f"Marking {len(gen_codes)} generated fields as '{na_placeholder}'.")
+                llm_failed = True
 
             first_token_time = time.perf_counter()
-            llm_values = parse_llm_json_response(json_response)
-            logger.info(f"[ReportGenerator] Parsed {len(llm_values)} generated fields from LLM.")
+            llm_values = {} if llm_failed else parse_llm_json_response(json_response)
+            # Any generated field the LLM omitted (or all of them, on failure /
+            # parse error) defaults to N/A so no interim "Generating…" or raw
+            # {{placeholder}} leaks into the finished report.
+            missing = 0
+            for c in gen_codes:
+                v = llm_values.get(c)
+                if v is None or (isinstance(v, str) and not v.strip()):
+                    llm_values[c] = na_placeholder
+                    missing += 1
+            logger.info(f"[ReportGenerator] Filled {len(gen_codes) - missing} generated fields "
+                        f"from LLM, {missing} defaulted to '{na_placeholder}'.")
         else:
             first_token_time = time.perf_counter()
             logger.info("[ReportGenerator] No generated fields; skipping LLM.")

--- a/education-ai-suite/smart-classroom/docs/dev-guide/report-generator/report-generator-api.md
+++ b/education-ai-suite/smart-classroom/docs/dev-guide/report-generator/report-generator-api.md
@@ -39,6 +39,7 @@ and report generation requests should be treated as unavailable by frontend logi
 |---|---|---|---|---|
 | `POST` | `/report/generate` | Generate class report with streaming events | `ReportRequest` (`session_id`, `selected_fields`, `manual_fields`, optional `query`) | NDJSON stream (`partial_report`, `report`, `report_ready`, `token`) |
 | `GET` | `/report/template-fields` | Get field catalog for UI checkbox selection | None | JSON (`groups`) |
+| `GET` | `/report/capabilities` | Report which download formats the server can produce (PDF availability) | None | JSON (`pdf_export`) |
 | `POST` | `/report/{session_id}/mindmap-image` | Upload rendered mindmap image for report embedding | `multipart/form-data` with `file` | JSON (`session_id`, `path`) |
 | `GET` | `/report/{session_id}/mindmap-image` | Fetch uploaded mindmap image for inline markdown preview | None | `image/png` file |
 | `GET` | `/report/{session_id}` | Read generated report markdown | None | JSON (`session_id`, `report`) |
@@ -235,6 +236,28 @@ Additional PDF notes:
 - Requires `LibreOffice` (`soffice`) installed on the server.
 - Returns `501` when `soffice` is unavailable.
 - Reuses cached PDF when it exists and is up-to-date.
+
+---
+
+### 5.1 Report Capabilities (Download Format Availability)
+
+- Method: `GET`
+- Path: `/report/capabilities`
+- Response: JSON
+
+### Response Example
+
+```json
+{
+  "pdf_export": true
+}
+```
+
+Notes:
+- `pdf_export` is `true` only when `LibreOffice` (`soffice`) is on the server's `PATH`.
+- Lets the frontend disable the PDF download option up front (with an install hint) instead of letting the user click and hit a `501`.
+- DOCX download is always available and is not gated by this flag.
+- Frontend suggestion: probe this before showing the PDF download option; treat a failed/unreachable request as `pdf_export: false` so an unsupported format is never offered.
 
 ---
 

--- a/education-ai-suite/smart-classroom/model_manager/features/report_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/report_feature.py
@@ -30,6 +30,7 @@ class ReportFeature:
             "endpoints": {
                 "generate": "/report/generate",
                 "template_fields": "/report/template-fields",
+                "capabilities": "/report/capabilities",
                 "get_report": "/report/{session_id}",
                 "download": "/report/{session_id}/download",
                 "reselect": "/report/{session_id}/reselect",

--- a/education-ai-suite/smart-classroom/ui/src/assets/css/ReportPanel.css
+++ b/education-ai-suite/smart-classroom/ui/src/assets/css/ReportPanel.css
@@ -345,12 +345,145 @@
 }
 
 .report-download-btn:disabled {
-  opacity: 0.6;
+  /* This button is only disabled while a download/convert is in progress, so
+     keep full blue-on-white contrast (the "⏳ Converting…" label must stay
+     legible) and just signal the busy state via the cursor. Must override the
+     global `button:disabled` rule (index.css) that greys the button out. */
+  background: var(--intel-blue);
+  color: #fff;
+  opacity: 1;
   cursor: progress;
 }
 
 .report-download-btn:disabled:hover {
   background: var(--intel-blue);
+}
+
+/* Download control: a single button that opens a format menu (DOCX / PDF). */
+.report-download {
+  position: relative;
+  display: inline-block;
+}
+
+.report-download-caret {
+  margin-left: 8px;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.report-download-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  min-width: 220px;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid #dfe3e8;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.14);
+}
+
+.report-download-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.report-download-item:hover {
+  background: var(--surface-hover, #f1f4f8);
+}
+
+.report-download-item:disabled {
+  color: var(--text-secondary, #8a94a6);
+  cursor: not-allowed;
+}
+
+.report-download-item:disabled:hover {
+  background: transparent;
+}
+
+.report-download-item-icon {
+  font-size: 15px;
+  line-height: 1;
+}
+
+/* PDF row: disabled item + an info icon carrying the install hint. */
+.report-download-item-row {
+  display: flex;
+  align-items: center;
+}
+
+.report-download-item-row .report-download-item {
+  flex: 1;
+}
+
+.report-pdf-hint {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin: 0 6px 0 2px;
+}
+
+.report-pdf-hint-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 50%;
+  color: var(--text-secondary, #8a94a6);
+  font-size: 14px;
+  line-height: 1;
+  cursor: help;
+}
+
+.report-pdf-hint-icon:hover {
+  color: var(--intel-blue, #0071c5);
+}
+
+.report-pdf-hint-bubble {
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 30;
+  width: 240px;
+  padding: 8px 10px;
+  background: #1a1a2e;
+  color: #fff;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-align: left;
+  white-space: normal;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.22);
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: none;
+}
+
+.report-pdf-hint:hover .report-pdf-hint-bubble,
+.report-pdf-hint-bubble.open {
+  visibility: visible;
+  opacity: 1;
 }
 
 /* Done-state action row */

--- a/education-ai-suite/smart-classroom/ui/src/components/ReportPanel.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/ReportPanel.tsx
@@ -12,6 +12,7 @@ import {
   reselectReport,
   downloadReport,
   downloadReportPdf,
+  getReportCapabilities,
   getTemplateFields,
   getReport,
   type TemplateFieldGroup,
@@ -86,6 +87,17 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
   // click repeatedly, firing a fresh conversion each time. Disabling + showing a
   // progress label makes the wait visible and blocks duplicate requests.
   const [downloading, setDownloading] = useState<null | 'docx' | 'pdf'>(null);
+  // Whether the server can produce a PDF (LibreOffice present). Until we know,
+  // assume unavailable so we never offer a format the backend can't deliver;
+  // the PDF menu item stays disabled with an install hint in that case.
+  const [pdfExportAvailable, setPdfExportAvailable] = useState(false);
+  // The Download menu (DOCX / PDF) open state. A single Download button opens
+  // this so format choice lives in the menu, not in button colors.
+  const [downloadMenuOpen, setDownloadMenuOpen] = useState(false);
+  // The PDF "unavailable" hint bubble next to the disabled item. Shows on hover
+  // (desktop, via CSS) and toggles on tap (touch) through this flag.
+  const [pdfHintOpen, setPdfHintOpen] = useState(false);
+  const downloadMenuRef = useRef<HTMLDivElement>(null);
   const [reportAvailable, setReportAvailable] = useState(true);
   const [reportUnavailableReason, setReportUnavailableReason] = useState('');
   // After a report exists, changing fields/inputs marks the view dirty; the
@@ -131,6 +143,33 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
     if (!reportAvailable || !isOpen || !sessionId || reportStatus !== 'done' || reportText) return;
     getReport(sessionId).then(setReportText).catch(() => { /* no report yet */ });
   }, [reportAvailable, isOpen, sessionId, reportStatus]);
+
+  // Probe which download formats the server can produce, so the PDF menu item
+  // reflects LibreOffice availability up front. Runs once the report is ready
+  // (when the Download control appears) and the panel is open.
+  useEffect(() => {
+    if (!reportAvailable || !isOpen || reportStatus !== 'done') return;
+    getReportCapabilities()
+      .then(c => setPdfExportAvailable(!!c.pdf_export))
+      .catch(() => setPdfExportAvailable(false));
+  }, [reportAvailable, isOpen, reportStatus]);
+
+  // Close the Download menu on outside click or Escape.
+  useEffect(() => {
+    if (!downloadMenuOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!downloadMenuRef.current?.contains(e.target as Node)) setDownloadMenuOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDownloadMenuOpen(false);
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [downloadMenuOpen]);
 
   // Auto-start report generation if requested
   useEffect(() => {
@@ -261,6 +300,7 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
       return;
     }
     if (!sessionId || downloading) return;
+    setDownloadMenuOpen(false);
     setDownloading('docx');
     try {
       await downloadReport(sessionId);
@@ -277,6 +317,7 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
       return;
     }
     if (!sessionId || downloading) return;
+    setDownloadMenuOpen(false);
     setDownloading('pdf');
     try {
       await downloadReportPdf(sessionId);
@@ -341,6 +382,10 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
   const canGenerate = reportAvailable && Boolean(sessionId) && pipelineSettled && (audioStatus === 'complete' || videoOnlyReady);
   const generating = reportStatus === 'generating';
   const hasContent = selected.size > 0;
+  const pdfHintText = t(
+    'reportPanel.pdfUnavailableTooltip',
+    "PDF export requires LibreOffice on the server. Install it and make sure 'soffice' is on the PATH, then reopen this panel (restart services if you changed PATH).",
+  );
 
   if (!isOpen) return null;
 
@@ -563,24 +608,73 @@ const ReportPanel: React.FC<ReportPanelProps> = ({ isOpen, onClose, featureGuard
                 </div>
               )}
               <div className="report-done-actions">
-                <button
-                  className="report-download-btn"
-                  onClick={handleDownload}
-                  disabled={downloading !== null}
-                >
-                  {downloading === 'docx'
-                    ? t('reportPanel.preparingDownload', '⏳ Preparing...')
-                    : t('reportPanel.downloadDocx', '📥 Download .docx')}
-                </button>
-                <button
-                  className="report-download-btn"
-                  onClick={handleDownloadPdf}
-                  disabled={downloading !== null}
-                >
-                  {downloading === 'pdf'
-                    ? t('reportPanel.convertingPdf', '⏳ Converting to PDF...')
-                    : t('reportPanel.downloadPdf', '📄 Download .pdf')}
-                </button>
+                {/* Single Download control with a format menu (DOCX / PDF), so
+                    color never has to carry format meaning. PDF is disabled with
+                    an install hint when LibreOffice is missing. */}
+                <div className="report-download" ref={downloadMenuRef}>
+                  <button
+                    type="button"
+                    className="report-download-btn"
+                    onClick={() => { setDownloadMenuOpen(o => !o); setPdfHintOpen(false); }}
+                    disabled={downloading !== null}
+                    aria-haspopup="menu"
+                    aria-expanded={downloadMenuOpen}
+                  >
+                    {downloading === 'docx'
+                      ? t('reportPanel.preparingDownload', '⏳ Preparing...')
+                      : downloading === 'pdf'
+                      ? t('reportPanel.convertingPdf', '⏳ Converting to PDF...')
+                      : <>📥 {t('reportPanel.download', 'Download')}<span className="report-download-caret">▾</span></>}
+                  </button>
+
+                  {downloadMenuOpen && downloading === null && (
+                    <div className="report-download-menu" role="menu">
+                      <button
+                        type="button"
+                        className="report-download-item"
+                        role="menuitem"
+                        onClick={handleDownload}
+                      >
+                        <span className="report-download-item-icon">📘</span>
+                        {t('reportPanel.downloadDocxItem', 'Word document (.docx)')}
+                      </button>
+                      <div className="report-download-item-row">
+                        <button
+                          type="button"
+                          className="report-download-item"
+                          role="menuitem"
+                          onClick={handleDownloadPdf}
+                          disabled={!pdfExportAvailable}
+                        >
+                          <span className="report-download-item-icon">📕</span>
+                          {t('reportPanel.downloadPdfItem', 'PDF document (.pdf)')}
+                        </button>
+                        {!pdfExportAvailable && (
+                          <span
+                            className="report-pdf-hint"
+                            onMouseLeave={() => setPdfHintOpen(false)}
+                          >
+                            <button
+                              type="button"
+                              className="report-pdf-hint-icon"
+                              aria-label={pdfHintText}
+                              aria-expanded={pdfHintOpen}
+                              onClick={e => { e.stopPropagation(); setPdfHintOpen(o => !o); }}
+                            >
+                              ⓘ
+                            </button>
+                            <span
+                              className={`report-pdf-hint-bubble ${pdfHintOpen ? 'open' : ''}`}
+                              role="tooltip"
+                            >
+                              {pdfHintText}
+                            </span>
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </div>
           )}

--- a/education-ai-suite/smart-classroom/ui/src/i18n/en.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/en.json
@@ -548,8 +548,10 @@
     "reportGenerationFailed": "Report generation failed",
     "updatingFields": "Updating fields...",
     "reportReady": "Report ready",
-    "downloadDocx": "📥 Download .docx",
-    "downloadPdf": "📄 Download .pdf",
+    "download": "Download",
+    "downloadDocxItem": "Word document (.docx)",
+    "downloadPdfItem": "PDF document (.pdf)",
+    "pdfUnavailableTooltip": "PDF export requires LibreOffice on the server. Install it and make sure 'soffice' is on the PATH, then reopen this panel (restart services if you changed PATH).",
     "preparingDownload": "⏳ Preparing...",
     "convertingPdf": "⏳ Converting to PDF..."
   },

--- a/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
@@ -549,8 +549,10 @@
     "reportGenerationFailed": "报告生成失败",
     "updatingFields": "正在更新字段...",
     "reportReady": "报告已就绪",
-    "downloadDocx": "📥 下载 .docx",
-    "downloadPdf": "📄 下载 .pdf",
+    "download": "下载",
+    "downloadDocxItem": "Word 文档 (.docx)",
+    "downloadPdfItem": "PDF 文档 (.pdf)",
+    "pdfUnavailableTooltip": "PDF 导出需要服务器安装 LibreOffice。请安装后确认 'soffice' 在服务器的 PATH 中，然后重新打开此面板（若修改了 PATH，请重启服务）。",
     "preparingDownload": "⏳ 正在准备...",
     "convertingPdf": "⏳ 正在转换为 PDF..."
   },

--- a/education-ai-suite/smart-classroom/ui/src/services/api.ts
+++ b/education-ai-suite/smart-classroom/ui/src/services/api.ts
@@ -1756,6 +1756,17 @@ export async function downloadReportPdf(sessionId: string): Promise<void> {
   URL.revokeObjectURL(url);
 }
 
+// Which download formats the server can produce (GET /report/capabilities).
+// pdf_export is false when LibreOffice ('soffice') is missing, so the UI can
+// disable the PDF option up front instead of failing on click. Defaults to
+// pdf_export:false if the endpoint is unreachable, so we never offer a format
+// that can't be produced.
+export async function getReportCapabilities(): Promise<{ pdf_export: boolean }> {
+  const res = await fetch(`${BASE_URL}/report/capabilities`, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Failed to load report capabilities (${res.status})`);
+  return res.json();
+}
+
 // Fetch a previously generated report's markdown (GET /report/{id}).
 // Returns '' when no report exists yet (404), so callers can render an empty state.
 export async function getReport(sessionId: string): Promise<string> {


### PR DESCRIPTION
Enhance report download feature
- Add download toggle for word and pdf download
- Disable pdf download if libreoffice not installed
- Add tips for how to enable pdf download
- Generate report even if AI generation failed
<img width="497" height="609" alt="image" src="https://github.com/user-attachments/assets/fedd0bdf-e2e1-4592-9f9b-cbf3e013d80e" />


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

