### PR TITLE
Add standalone Qwen VLM fine-tuning toolkit for weld defect detection.

### DIFF
--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/README.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/README.md
@@ -1,0 +1,341 @@
+# Weld VLM Fine-Tuning
+
+Standalone, self-contained toolkit to prepare a multimodal (image + sensor
+telemetry) weld-defect dataset and fine-tune a Qwen vision-language model
+(VLM) on it using [Unsloth](https://github.com/unslothai/unsloth) + LoRA.
+
+This directory is **not integrated** with the rest of
+`industrial-edge-insights-multimodal` — it does not wire into the
+`docker-compose*.yml` stacks, `configs/`, or the vLLM serving setup in this
+repo. It is a self-contained data-prep + fine-tuning + inference workflow you
+run independently (e.g. on a dev box or training server) to produce a LoRA
+adapter. Once you have an adapter, you can serve it with the existing
+[`docker-compose-vllm.yml`](../docker-compose-vllm.yml) in this repo, or with
+any OpenAI-compatible VLM server that supports LoRA adapters.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Directory Layout](#directory-layout)
+- [Prerequisites](#prerequisites)
+- [Setup](#setup)
+- [Step 1: Input Data](#step-1-input-data)
+- [Step 2: Prepare the Dataset](#step-2-prepare-the-dataset)
+- [Step 3: Fine-Tune the Model](#step-3-fine-tune-the-model)
+- [Step 4: Run Inference](#step-4-run-inference)
+- [Pipeline Architecture](#pipeline-architecture)
+- [Troubleshooting](#troubleshooting)
+- [License](#license)
+
+## Overview
+
+The pipeline has three independent stages, each its own script:
+
+| Stage | Script | Input | Output |
+|---|---|---|---|
+| 1. Data preparation | `prepare_weld_dataset.py` | Fused CSV + weld images | HF `DatasetDict`, parquet splits, conversation JSONL, `summary.json` |
+| 2. Fine-tuning | `train_qwen.py` | Parquet dataset (from stage 1) | LoRA adapter + tokenizer |
+| 3. Inference | `infer_qwen.py` | Base model or adapter (from stage 2) | Streamed structured weld-quality report |
+
+`common.py` holds small helpers shared by `train_qwen.py` and
+`infer_qwen.py` (device detection, chat-message conversion) so the two
+scripts stay modular and independently runnable.
+
+The fine-tuned model is trained to produce a structured report per weld
+image + sensor reading, covering:
+
+- Weld Classification (Good Weld vs. one of 11 defect types)
+- Visual Observation
+- Sensor Analysis (telemetry vs. expected class profile)
+- Model Confidence + Defect Probability
+- Severity
+- Root Cause
+- Corrective Actions
+
+## Directory Layout
+
+```
+vlm-fine-tuning/
+├── README.md                  # this file
+├── requirements.txt           # pinned Python dependencies
+├── common.py                  # shared chat-format / device-detection helpers
+├── prepare_weld_dataset.py    # Stage 1: dataset preparation
+├── train_qwen.py              # Stage 2: LoRA fine-tuning (Unsloth + TRL)
+└── infer_qwen.py              # Stage 3: standalone inference
+```
+
+Generated artifacts (not checked in — see `.gitignore` note below) land in
+whatever `--output-dir` / `--dataset-path` you pass on the command line,
+e.g. `processed_dataset/` and `qwen_3.5_2b_adapter/`.
+
+> If you fork this into your own repo, add `processed_dataset/`,
+> `*_adapter/`, `checkpoint-*/`, and any downloaded datasets/images to
+> `.gitignore` — none of these generated artifacts should be committed.
+
+## Prerequisites
+
+- Python 3.10+
+- ~16 GB+ RAM for data preparation (image + CSV processing)
+- A GPU/XPU is strongly recommended for fine-tuning and inference:
+  - Intel GPU (Arc / integrated) via Intel XPU PyTorch build, or
+  - CPU (functional but slow; useful only for smoke-testing the pipeline)
+- Access to a fused weld dataset — see [Step 1](#step-1-input-data)
+
+## Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+
+# 1. Install PyTorch for your target device first (pick ONE):
+#    Intel XPU:
+pip install torch --index-url https://download.pytorch.org/whl/xpu
+#    CPU only:
+# pip install torch
+
+# 2. Install the rest of the pipeline dependencies
+pip install -r requirements.txt
+```
+
+Unsloth auto-detects the installed PyTorch backend (XPU/CUDA/CPU) at import
+time, and `common.detect_device()` selects `xpu` > `cpu` for
+tensor placement during training/inference.
+
+## Step 1: Input Data
+
+`prepare_weld_dataset.py` consumes two inputs that you must provide:
+
+1. **A fused CSV** (`--input-csv`), one row per labeled weld image/sample,
+   with (at minimum) these columns:
+
+   | Column | Type | Description |
+   |---|---|---|
+   | `Frame_id` | string | Image filename stem used to resolve the image file under `--images-root` |
+   | `output_prediction_details` | Python-dict literal (string) | Classifier output — see below |
+   | `Category` | string | Canonical weld-session label used for stratified splitting (falls back to the parsed `predicted_category` if absent) |
+   | `Primary Weld Current`, `Secondary Weld Voltage`, `Pressure`, `CO2 Weld Flow`, `Feed`, `Wire Consumed` | numeric | Sensor telemetry injected into the prompt |
+
+   `output_prediction_details` must parse (via `ast.literal_eval`) into a
+   dict shaped like the output of
+   [`classification-training`](../classification-training)'s
+   `WeldDefectPredictor` — see its
+   [Output Format](../classification-training/README.md#output-format)
+   section for the exact shape, e.g.:
+
+   ```python
+   {
+       "predicted_category": "Excessive Penetration",
+       "is_defect": True,
+       "defect_probability": 1.0,
+       "good_weld_probability": 0.0,
+       "confidence": 0.9886,
+       "explanation": {
+           "reason": "...",
+           "top_signal_features": [
+               {"feature": "Primary Weld Current", "value": 89.06,
+                "predicted_mean": 92.1, "good_weld_mean": 60.4,
+                "evidence_score": 0.42},
+               ...
+           ],
+       },
+   }
+   ```
+
+   In practice, this CSV is produced by fusing:
+   - Per-frame classifier predictions (run `classification-training`'s
+     inference over your weld image/sensor dataset to get
+     `output_prediction_details` per row), with
+   - Raw sensor telemetry and image `Frame_id`s, aligned by timestamp.
+
+   This repo does not include a fusion script — build one for your own data
+   pipeline, or provide the CSV in the schema above directly.
+
+2. **An image root** (`--images-root`): a directory tree of weld images
+   (`.jpg`/`.jpeg`/`.png`/`.bmp`/`.webp`), searched recursively. Each image's
+   filename stem (without extension) must match a `Frame_id` value in the
+   CSV. Sub-folder structure (e.g. per-class folders) does not matter — only
+   the filename stem is used for matching.
+
+The underlying raw images and sensor CSVs for weld defect data can be
+sourced from the same public dataset used by `classification-training`:
+[IntelLabs/Intel_Robotic_Welding_Multimodal_Dataset](https://huggingface.co/datasets/IntelLabs/Intel_Robotic_Welding_Multimodal_Dataset).
+
+## Step 2: Prepare the Dataset
+
+```bash
+python prepare_weld_dataset.py \
+  --input-csv /path/to/merged_by_ts_time.csv \
+  --images-root /path/to/dataset/images \
+  --output-dir ./processed_dataset \
+  --train-ratio 0.8 --val-ratio 0.1 --test-ratio 0.1 \
+  --seed 42
+```
+
+Useful flags:
+
+- `--limit N` — cap the number of rows processed, for a quick dry-run.
+- `--skip-missing` — drop rows whose image cannot be resolved instead of
+  raising an error (default: strict, raises on the first missing image).
+
+What it does:
+
+1. Loads and cleans the CSV (strips whitespace from headers and string
+   fields).
+2. Builds an index of `Frame_id → image path` from `--images-root`.
+3. Parses `output_prediction_details` per row.
+4. Builds a sensor-telemetry text block and picks one of 7 rotating user
+   prompt templates (deterministic given `--seed`).
+5. Synthesizes a structured assistant response (classification, visual
+   observation, sensor analysis, confidence, severity, root cause,
+   corrective actions), drawing on a small built-in defect knowledge base
+   with a generic fallback for unseen categories.
+6. Assembles a 3-turn `system` / `user(text+image)` / `assistant`
+   conversation per row.
+7. Performs a stratified train/validation/test split by canonical category,
+   with guardrails so small classes still get at least one sample per
+   split when possible.
+8. Writes:
+   - `hf_dataset/` — HF `DatasetDict`, image column castable to PIL
+   - `parquet/{train,validation,test}.parquet` — used by `train_qwen.py`
+   - `conversations/{train,validation,test}.jsonl` — raw messages, useful
+     for manual inspection or use with other trainers
+   - `summary.json` — row counts, missing-image count, output paths
+
+## Step 3: Fine-Tune the Model
+
+```bash
+python train_qwen.py \
+  --model-name unsloth/Qwen3.5-2B \
+  --dataset-path ./processed_dataset/parquet \
+  --output-dir ./qwen_3.5_2b_adapter \
+  --learning-rate 2e-4 \
+  --num-train-epochs 2
+```
+
+Notable flags (all optional, defaults shown):
+
+| Flag | Default | Description |
+|---|---|---|
+| `--model-name` | `unsloth/Qwen3.5-2B` | Base VLM to fine-tune |
+| `--per-device-train-batch-size` | 4 | Per-device train batch size |
+| `--per-device-eval-batch-size` | 4 | Per-device eval batch size |
+| `--gradient-accumulation-steps` | 4 | Effective batch size = train batch × this |
+| `--max-seq-length` | 2048 | Max token sequence length |
+| `--lora-r` / `--lora-alpha` | 16 / 16 | LoRA rank / alpha |
+| `--preview-only` | off | Load data, print the first converted sample, and exit (no model build/training) |
+| `--skip-save` | off | Skip saving the adapter/tokenizer at the end |
+
+Training details:
+
+- LoRA is applied to vision layers, language layers, attention modules, and
+  MLP modules (`FastVisionModel.get_peft_model`), with 4-bit quantized base
+  weights (`load_in_4bit=True`, default on) and gradient checkpointing.
+- Trains with `trl.SFTTrainer` + `UnslothVisionDataCollator`, evaluating and
+  checkpointing every 50 steps.
+- Optimizer is `adamw_8bit` on CUDA, `adamw_torch` otherwise (Intel
+  XPU/CPU), selected automatically via `common.detect_device()`.
+- On completion, the adapter and tokenizer are saved to `--output-dir`
+  (unless `--skip-save` is set).
+
+## Step 4: Run Inference
+
+Run inference either against samples from your prepared test split, or
+against a single arbitrary image.
+
+```bash
+# Against the first 5 test-split samples, using the fine-tuned adapter
+python infer_qwen.py \
+  --model-path ./qwen_3.5_2b_adapter \
+  --dataset-path ./processed_dataset/parquet \
+  --split test \
+  --num-samples 5
+
+# Against a single external image
+python infer_qwen.py \
+  --model-path ./qwen_3.5_2b_adapter \
+  --image /path/to/weld.jpg \
+  --instruction "Analyze this weld image for quality and identify any anomalies."
+```
+
+`--model-path` accepts either a HuggingFace base model id (to sanity-check
+the un-tuned base model) or a local directory containing a saved LoRA
+adapter from `train_qwen.py`. Output streams token-by-token to stdout via
+`TextStreamer`.
+
+## Pipeline Architecture
+
+```mermaid
+flowchart TD
+    A["Fused CSV\n(--input-csv)"] --> B["CSV Loader and Cleaner"]
+    I["Image Root\n(--images-root)"] --> C["Image Index by Frame_id stem"]
+
+    B --> D["Parse output_prediction_details"]
+    C --> E["Frame_id to Image Resolution"]
+    D --> F["Sensor Block Builder"]
+    E --> F
+
+    F --> G["Prompt Variant Sampler\n7 templates, seeded"]
+    D --> H["Defect Knowledge Lookup + Fallback"]
+
+    G --> J["Assistant Response Composer"]
+    H --> J
+
+    J --> K["Conversation Builder\nsystem + user(text,image) + assistant"]
+    K --> L["Record Assembler\nid, image, label, confidence, conversation_json"]
+    L --> M["Stratified Split by canonical_category\ntrain / validation / test"]
+
+    M --> N["HF DatasetDict Export"]
+    M --> O["Parquet Export per split"]
+    M --> P["JSONL Conversation Export per split"]
+    M --> Q["summary.json"]
+
+    O --> R["train_qwen.py\nload_dataset(parquet)"]
+    R --> S["Conversation Conversion (common.py)"]
+    S --> T["FastVisionModel + LoRA Adapter Setup"]
+    T --> U["SFTTrainer + UnslothVisionDataCollator"]
+    U --> V["Fine-Tuning on XPU / CUDA / CPU"]
+
+    V --> W["LoRA Adapter Save"]
+    W --> X["infer_qwen.py\nStandalone Inference"]
+    X --> Y["Structured Weld-Quality Report\nclassification + evidence + root cause + corrective actions"]
+```
+
+## Troubleshooting
+
+- **`FileNotFoundError` / missing image errors during Step 2** — verify
+  `--images-root` contains files whose stem exactly matches `Frame_id`
+  values in the CSV, or pass `--skip-missing` to drop unmatched rows
+  instead of failing.
+- **Split ratios error** — `--train-ratio` + `--val-ratio` + `--test-ratio`
+  must sum to exactly `1.0`.
+- **Out-of-memory during training** — lower
+  `--per-device-train-batch-size` and/or raise
+  `--gradient-accumulation-steps` to keep the effective batch size
+  constant; ensure `--load-in-4bit` is enabled (it is by default).
+- **No XPU/CUDA detected** — `common.detect_device()` silently falls back
+  to CPU; training/inference will still run but be much slower. Confirm
+  your PyTorch build matches your hardware (see [Setup](#setup)).
+- **Serving the adapter** — this directory only produces the adapter; to
+  serve it with an OpenAI-compatible API, see
+  [`docker-compose-vllm.yml`](../docker-compose-vllm.yml) and
+  [`vllm.env`](../vllm.env) at the root of this component.
+
+## License
+
+Licensed under the Apache License, Version 2.0. See the repository root
+[`LICENSE`](../../../LICENSE) file.
+
+Third-party components used by the scripts in this directory (see
+`requirements.txt`), each under their own upstream license:
+
+- [Unsloth](https://github.com/unslothai/unsloth) — Apache-2.0
+- [Hugging Face `transformers`](https://github.com/huggingface/transformers) — Apache-2.0
+- [Hugging Face `datasets`](https://github.com/huggingface/datasets) — Apache-2.0
+- [TRL](https://github.com/huggingface/trl) — Apache-2.0
+- [PEFT](https://github.com/huggingface/peft) — Apache-2.0
+- [PyTorch](https://github.com/pytorch/pytorch) — BSD-3-Clause
+
+Dataset: sourced from
+[IntelLabs/Intel_Robotic_Welding_Multimodal_Dataset](https://huggingface.co/datasets/IntelLabs/Intel_Robotic_Welding_Multimodal_Dataset)
+(Apache-2.0), see that dataset's card for its own license terms.

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/common.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/common.py
@@ -1,0 +1,123 @@
+#
+# Apache v2 license
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Shared helpers for converting the weld VLM parquet dataset (produced by
+prepare_weld_dataset.py) into Unsloth/Qwen chat-template message formats,
+used by both train_qwen.py and infer_qwen.py.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import torch
+
+
+def detect_device() -> str:
+    """Pick the best available accelerator: Intel XPU > CUDA > CPU."""
+    if hasattr(torch, "xpu") and torch.xpu.is_available():
+        return "xpu"
+    if torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def parse_conversation_json(raw_conversation: Any) -> List[Dict[str, Any]]:
+    """Parse the dataset's `conversation_json` column into a messages list."""
+    if isinstance(raw_conversation, str):
+        return json.loads(raw_conversation)
+    if isinstance(raw_conversation, list):
+        return raw_conversation
+    raise TypeError(
+        f"Unsupported conversation_json type: {type(raw_conversation).__name__}"
+    )
+
+
+def extract_text_from_content(content_items: Any) -> str:
+    """Pull the first text segment out of a chat-template content list."""
+    if isinstance(content_items, str):
+        return content_items
+    for item in content_items or []:
+        if isinstance(item, dict) and item.get("type") == "text":
+            return item.get("text", "")
+    return ""
+
+
+def convert_to_conversation(sample: Dict[str, Any]) -> Dict[str, Any]:
+    """Convert one dataset row into an Unsloth SFTTrainer training conversation."""
+    parsed_conversation = parse_conversation_json(sample["conversation_json"])
+    messages = []
+
+    for message in parsed_conversation:
+        role = message.get("role")
+        if role == "user":
+            user_content = []
+            for item in message.get("content", []):
+                if item.get("type") == "image":
+                    user_content.append({"type": "image", "image": sample["image"]})
+                elif item.get("type") == "text":
+                    user_content.append({"type": "text", "text": item.get("text", "")})
+            messages.append({"role": "user", "content": user_content})
+        elif role in {"system", "assistant"}:
+            messages.append({"role": role, "content": message.get("content", "")})
+
+    return {"messages": messages}
+
+
+def get_sample_prompt(sample: Dict[str, Any]) -> str:
+    """Return the raw user prompt text stored in a dataset row's conversation."""
+    parsed_conversation = parse_conversation_json(sample["conversation_json"])
+    for message in parsed_conversation:
+        if message.get("role") == "user":
+            return extract_text_from_content(message.get("content", []))
+    raise ValueError("No user prompt found in conversation_json")
+
+
+def build_inference_messages(
+    sample: Dict[str, Any], instruction_override: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Build a chat-template message list for running inference on one sample."""
+    parsed_conversation = parse_conversation_json(sample["conversation_json"])
+    system_text = None
+    user_text = None
+
+    for message in parsed_conversation:
+        role = message.get("role")
+        if role == "system" and system_text is None:
+            system_text = message.get("content", "")
+        elif role == "user" and user_text is None:
+            user_text = extract_text_from_content(message.get("content", []))
+
+    if user_text is None:
+        raise ValueError("No user message found in conversation_json")
+
+    user_text = instruction_override or user_text
+
+    messages = []
+    if system_text:
+        messages.append({"role": "system", "content": system_text})
+    messages.append(
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": user_text},
+            ],
+        }
+    )
+    return messages
+
+
+def validate_sample_index(dataset, sample_index: int) -> None:
+    if not 0 <= sample_index < len(dataset):
+        raise IndexError(
+            f"sample-index {sample_index} is out of range for dataset size {len(dataset)}"
+        )

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/infer_qwen.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/infer_qwen.py
@@ -1,0 +1,209 @@
+#
+# Apache v2 license
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Run inference with a Qwen vision-language model (base model or a fine-tuned
+LoRA adapter produced by train_qwen.py) using Unsloth.
+
+Two input modes are supported:
+    1. Dataset mode (default): pull N samples from a parquet split produced by
+       prepare_weld_dataset.py and reuse their image + prompt (or an override
+       instruction).
+    2. Single-image mode: pass --image and --instruction to run inference on
+       an arbitrary weld image outside the prepared dataset.
+
+Usage:
+    # Run the first 5 test-split samples through a saved adapter
+    python infer_qwen.py \\
+        --model-path qwen_3.5_2b_adapter \\
+        --dataset-path processed_dataset/parquet \\
+        --split test \\
+        --num-samples 5
+
+    # Run a single external image through the base model
+    python infer_qwen.py \\
+        --model-path unsloth/Qwen3.5-2B \\
+        --image /path/to/weld.jpg \\
+        --instruction "Analyze this weld image for quality and identify any anomalies."
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from datasets import load_dataset
+from PIL import Image
+from transformers import TextStreamer
+
+from unsloth import FastVisionModel
+
+from common import build_inference_messages
+from common import detect_device
+from common import get_sample_prompt
+
+DEFAULT_MODEL_PATH = "unsloth/Qwen3.5-2B"
+DEFAULT_DATASET_PATH = "processed_dataset/parquet"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run Unsloth-based inference with a base or fine-tuned "
+        "Qwen VLM on weld images."
+    )
+    parser.add_argument(
+        "--model-path",
+        default=DEFAULT_MODEL_PATH,
+        help="Base model repo id, or a local directory containing a saved "
+        "LoRA adapter (as produced by train_qwen.py).",
+    )
+    parser.add_argument("--dataset-path", default=DEFAULT_DATASET_PATH)
+    parser.add_argument(
+        "--split", default="test", choices=["train", "validation", "test"]
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=5,
+        help="Number of dataset samples to run inference on (dataset mode only).",
+    )
+    parser.add_argument(
+        "--sample-index",
+        type=int,
+        default=None,
+        help="Run a single specific sample index instead of the first --num-samples.",
+    )
+    parser.add_argument(
+        "--image",
+        default=None,
+        help="Path to a standalone image file. When set, runs single-image "
+        "mode instead of pulling samples from --dataset-path.",
+    )
+    parser.add_argument(
+        "--instruction",
+        default=None,
+        help="Override the user prompt. Required in single-image mode.",
+    )
+    parser.add_argument("--max-new-tokens", type=int, default=2048)
+    parser.add_argument("--temperature", type=float, default=1.5)
+    parser.add_argument("--min-p", type=float, default=0.1)
+    parser.add_argument(
+        "--load-in-4bit",
+        action="store_true",
+        default=True,
+        help="Load the model with 4-bit quantization (default: on).",
+    )
+    return parser.parse_args()
+
+
+def load_model(model_path: str, load_in_4bit: bool):
+    model, tokenizer = FastVisionModel.from_pretrained(
+        model_path,
+        load_in_4bit=load_in_4bit,
+    )
+    FastVisionModel.for_inference(model)
+    return model, tokenizer
+
+
+def run_inference(
+    model,
+    tokenizer,
+    image,
+    messages,
+    device: str,
+    max_new_tokens: int,
+    temperature: float,
+    min_p: float,
+):
+    input_text = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
+    inputs = tokenizer(
+        image,
+        input_text,
+        add_special_tokens=False,
+        return_tensors="pt",
+    ).to(device)
+
+    streamer = TextStreamer(tokenizer, skip_prompt=True)
+    return model.generate(
+        **inputs,
+        streamer=streamer,
+        max_new_tokens=max_new_tokens,
+        use_cache=True,
+        temperature=temperature,
+        min_p=min_p,
+        eos_token_id=tokenizer.eos_token_id,
+        pad_token_id=tokenizer.eos_token_id,
+    )
+
+
+def run_single_image(args, model, tokenizer, device):
+    if not args.instruction:
+        raise ValueError("--instruction is required when using --image.")
+
+    image = Image.open(args.image).convert("RGB")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "image"},
+                {"type": "text", "text": args.instruction},
+            ],
+        }
+    ]
+    run_inference(
+        model,
+        tokenizer,
+        image,
+        messages,
+        device,
+        args.max_new_tokens,
+        args.temperature,
+        args.min_p,
+    )
+
+
+def run_dataset_samples(args, model, tokenizer, device):
+    dataset = load_dataset(args.dataset_path, split=args.split)
+
+    if args.sample_index is not None:
+        indices = [args.sample_index]
+    else:
+        indices = list(range(min(args.num_samples, len(dataset))))
+
+    for idx in indices:
+        sample = dataset[idx]
+        instruction = args.instruction or get_sample_prompt(sample)
+        messages = build_inference_messages(sample, instruction_override=instruction)
+
+        print(f"\n=== Sample {idx} ({args.split}) ===")
+        print(f"Instruction: {instruction}")
+        run_inference(
+            model,
+            tokenizer,
+            sample["image"],
+            messages,
+            device,
+            args.max_new_tokens,
+            args.temperature,
+            args.min_p,
+        )
+        print("\n" + "=" * 60)
+
+
+def main() -> None:
+    args = parse_args()
+    device = detect_device()
+    print(f"Using device: {device}")
+    print(f"Loading model/adapter from: {args.model_path}")
+    model, tokenizer = load_model(args.model_path, args.load_in_4bit)
+
+    if args.image:
+        run_single_image(args, model, tokenizer, device)
+    else:
+        run_dataset_samples(args, model, tokenizer, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/prepare_weld_dataset.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/prepare_weld_dataset.py
@@ -1,0 +1,811 @@
+#
+# Apache v2 license
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Prepare a Qwen VLM weld-defect fine-tuning dataset.
+
+Source (see README.md "Input data" section for the exact schema):
+    <input-csv>       — fused vision + time-series predictions with raw sensor readings.
+    <images-root>/    — per-class image folders matched by Frame_id stem.
+
+Pipeline:
+    1. Parse CSV → strip whitespace, parse output_prediction_details JSON.
+    2. Match each row's Frame_id to an image file.
+    3. Build a hybrid prompt-response conversation per row:
+         - System  : expert weld quality inspector persona.
+         - User    : one of 7 rotating prompt variants (sensor data injected).
+         - Assistant: classification header + structured analysis block.
+    4. Stratified train / validation / test split by weld-session category.
+    5. Write all three output formats:
+         - HF DatasetDict  (Arrow, castable to PIL image)
+         - Per-split parquet files
+         - Per-split conversation JSONL (Unsloth vision data-collator compatible)
+
+Usage:
+    python prepare_weld_dataset.py \\
+        --input-csv path/to/merged_by_ts_time.csv \\
+        --images-root path/to/dataset/images \\
+        --output-dir path/to/processed_dataset
+
+    Key options:
+        --input-csv      Path to the fused sensor+prediction CSV (required)
+        --images-root    Root dir of per-class image folders (required)
+        --output-dir     Destination for all output artefacts (required)
+        --train-ratio / --val-ratio / --test-ratio  (must sum to 1.0)
+        --seed           RNG seed for reproducibility
+        --limit          Cap rows for dry-runs
+        --skip-missing   Drop rows whose image cannot be located
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import random
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+import pandas as pd
+from datasets import Dataset
+from datasets import DatasetDict
+from datasets import Image as HFImage
+
+SUPPORTED_EXTS = {".jpg", ".jpeg", ".png", ".bmp", ".webp"}
+
+SENSOR_UNITS: Dict[str, str] = {
+    "Primary Weld Current": "A",
+    "Secondary Weld Voltage": "V",
+    "Pressure": "bar",
+    "CO2 Weld Flow": "L/min",
+    "Feed": "mm/min",
+    "Wire Consumed": "mm",
+}
+
+SYSTEM_PROMPT = (
+    "You are an expert weld quality inspector and metallurgical engineer with deep knowledge "
+    "of MIG/MAG/TIG arc welding processes and industrial weld defect analysis per AWS D1.1 "
+    "and ISO 5817 standards. When shown a weld image alongside time-series sensor readings, "
+    "you classify the weld quality, identify any defect type, explain the root cause using "
+    "sensor evidence, assess severity, and recommend corrective actions. "
+    "Always structure your response with clearly labelled sections."
+)
+
+# Promptvariations rotation to add diversity in user queries.
+USER_PROMPT_TEMPLATES: List[str] = [
+    "Analyze this weld image for quality and identify any anomalies.\n{sensor_block}",
+    "Based on the provided image and sensor readings, is this weld defective? "
+    "If so, classify the defect type.\n{sensor_block}",
+    "Inspect this welding process for potential issues such as porosity, undercut, "
+    "lack of fusion, or excessive penetration.\n{sensor_block}",
+    "Evaluate the structural integrity of this joint using the visual and sensor data "
+    "provided. Report your findings.\n{sensor_block}",
+    "Check this weld. Provide a full quality assessment and highlight any defects visible "
+    "in the image, correlated with the sensor readings.\n{sensor_block}",
+    "Review the weld image below and the accompanying process parameters. Classify the weld "
+    "quality, describe the defect mechanism (if any), and suggest corrective actions.\n{sensor_block}",
+    "Given this weld image and the sensor telemetry, produce a structured weld quality report "
+    "covering defect classification, root cause, and remediation steps.\n{sensor_block}",
+]
+
+
+DEFECT_KNOWLEDGE: Dict[str, Dict[str, str]] = {
+    "Good_Weld": {
+        "visual": (
+            "The weld bead exhibits a uniform width, consistent colour, and smooth surface "
+            "with no visible anomalies. The arc appears stable with no spatter or irregular "
+            "formations. Bead edges show proper fusion with the base metal."
+        ),
+        "root_cause": "N/A — no defect present.",
+        "corrective": "Maintain current process parameters. Continue monitoring sensor telemetry.",
+        "severity": "None",
+    },
+    "Burnthrough": {
+        "visual": (
+            "A hole or series of holes is visible where the base metal has been completely "
+            "melted away. The surrounding area shows heavy discolouration and distortion."
+        ),
+        "root_cause": (
+            "Excessive heat input caused by high current and/or low travel speed exceeded "
+            "the material's melting capacity, causing full penetration through the plate."
+        ),
+        "corrective": (
+            "Reduce primary weld current and/or increase travel speed. Verify material "
+            "thickness assumptions. Add a backing strip or chill bar if applicable."
+        ),
+        "severity": "High",
+    },
+    "Crater_Cracks": {
+        "visual": (
+            "A star-shaped fracture is visible at the termination point of the weld bead. "
+            "The crater at the end of the weld has shrinkage cracks radiating outward."
+        ),
+        "root_cause": (
+            "The weld pool cooled and solidified too rapidly at the end of the pass without "
+            "sufficient crater fill, causing shrinkage stress to crack the solidifying metal."
+        ),
+        "corrective": (
+            "Enable and tune crater-fill function (increase crater-fill time and reduce "
+            "current slope). Ensure the arc is not abruptly terminated. Review end-of-pass "
+            "programming."
+        ),
+        "severity": "High",
+    },
+    "Excessive_Convexity": {
+        "visual": (
+            "The weld bead is excessively convex ('ropey'), standing too high above the base "
+            "metal surface relative to its width. Bead toes show incomplete fusion."
+        ),
+        "root_cause": (
+            "Low arc voltage combined with high wire feed speed prevented the filler metal "
+            "from wetting out properly into the joint, causing the bead to pile up."
+        ),
+        "corrective": (
+            "Increase secondary weld voltage to improve wetting. Reduce wire feed speed. "
+            "Adjust torch angle and travel speed to promote proper bead profile."
+        ),
+        "severity": "Medium",
+    },
+    "Excessive_Penetration": {
+        "visual": (
+            "Excess weld metal is visible protruding significantly through the root side of "
+            "the joint. The root bead sags or drips below the base metal surface."
+        ),
+        "root_cause": (
+            "High heat input (elevated current and/or voltage) combined with an oversized "
+            "root gap allowed too much molten metal to flow through the joint."
+        ),
+        "corrective": (
+            "Reduce primary weld current and secondary voltage. Tighten root gap per WPS. "
+            "Consider a backing bar to support the molten pool."
+        ),
+        "severity": "Medium",
+    },
+    "Lack_of_Fusion": {
+        "visual": (
+            "The bead appears 'cold' with incomplete tie-in at the edges. Unfused zones are "
+            "visible between the weld metal and the base metal, often presenting as a groove "
+            "or dark line at the bead toe."
+        ),
+        "root_cause": (
+            "Insufficient heat input — low arc voltage resulting in a short arc length — "
+            "failed to melt the base metal adequately for proper fusion."
+        ),
+        "corrective": (
+            "Increase secondary weld voltage and primary current to raise heat input. "
+            "Slow travel speed. Verify joint fit-up and cleanliness of base metal surfaces."
+        ),
+        "severity": "High",
+    },
+    "Overlap": {
+        "visual": (
+            "Weld metal has flowed over the base metal surface at the toe without fusing to "
+            "it. The overlap forms a cold-lap where the bead simply rests on top of the base."
+        ),
+        "root_cause": (
+            "Low current and fast travel speed produced insufficient heat to melt the base "
+            "metal, causing filler metal to flow over rather than fuse into the surface."
+        ),
+        "corrective": (
+            "Increase current and reduce travel speed. Check torch angle and electrode "
+            "extension. Ensure base metal is clean and free of mill scale or oxide."
+        ),
+        "severity": "Medium",
+    },
+    "Porosity": {
+        "visual": (
+            "Multiple surface pinholes or cavities are visible in or around the weld bead. "
+            "In severe cases the bead surface appears pitted."
+        ),
+        "root_cause": (
+            "Gas entrapment in the solidifying weld pool caused by inadequate shielding gas "
+            "coverage, contaminated base metal, or moisture in the filler wire."
+        ),
+        "corrective": (
+            "Verify CO2/Ar shielding gas flow rate and check for leaks. Clean base metal "
+            "surfaces. Replace any contaminated or wet filler wire. Shield from wind draught."
+        ),
+        "severity": "Medium",
+    },
+    "Porosity_w_Excessive_Penetration": {
+        "visual": (
+            "Multiple surface pinholes are visible alongside excess root protrusion. "
+            "The bead surface is pitted and the root bead sags below the base metal plane."
+        ),
+        "root_cause": (
+            "Critically low shielding gas flow failed to protect the weld pool, while an "
+            "oversized root gap combined with high heat input allowed contaminated molten "
+            "metal to fall through the joint."
+        ),
+        "corrective": (
+            "Restore shielding gas flow to specification. Reduce current and tighten root "
+            "gap. Inspect and replace filler wire if contaminated."
+        ),
+        "severity": "High",
+    },
+    "Porosity_with_Excessive_Penetration": {
+        "visual": (
+            "Multiple surface pinholes are visible alongside excess root protrusion. "
+            "The bead surface is pitted and the root bead sags below the base metal plane."
+        ),
+        "root_cause": (
+            "Critically low shielding gas flow failed to protect the weld pool, while an "
+            "oversized root gap combined with high heat input allowed contaminated molten "
+            "metal to fall through the joint."
+        ),
+        "corrective": (
+            "Restore shielding gas flow to specification. Reduce current and tighten root "
+            "gap. Inspect and replace filler wire if contaminated."
+        ),
+        "severity": "High",
+    },
+    "Spatter": {
+        "visual": (
+            "Numerous small metal droplets are fused to the base metal adjacent to the weld "
+            "bead. The bead surface itself may appear rough or irregular."
+        ),
+        "root_cause": (
+            "An excessively long arc and high current caused an unstable metal transfer "
+            "mode, ejecting molten droplets onto the surrounding base metal."
+        ),
+        "corrective": (
+            "Reduce secondary voltage (shorten arc length). Adjust wire feed speed and "
+            "inductance settings. Verify correct metal transfer mode for material and "
+            "position."
+        ),
+        "severity": "Low",
+    },
+    "Undercut": {
+        "visual": (
+            "A distinct groove or channel is melted into the base metal at the toe of the "
+            "weld, running parallel to the bead. The groove reduces the effective cross "
+            "section of the base metal."
+        ),
+        "root_cause": (
+            "High current and excessive travel speed caused the arc to 'dig' into the base "
+            "metal without leaving enough filler metal to fill the groove."
+        ),
+        "corrective": (
+            "Reduce current and travel speed. Adjust torch angle to direct arc into the "
+            "joint rather than the base metal. Add a second pass to fill undercut if present."
+        ),
+        "severity": "Medium",
+    },
+    "Warping": {
+        "visual": (
+            "The base plates have bowed or twisted significantly from their original plane. "
+            "Thermal distortion is evident across the weld zone."
+        ),
+        "root_cause": (
+            "High interpass temperature and insufficient mechanical clamping allowed "
+            "uncontrolled thermal stresses to pull the plates out of alignment during "
+            "heating and cooling."
+        ),
+        "corrective": (
+            "Reduce heat input (lower current/voltage or increase travel speed). Enforce "
+            "interpass temperature limits. Use mechanical clamping or pre-set fixtures. "
+            "Apply backstep or balanced welding sequence."
+        ),
+        "severity": "Medium",
+    },
+}
+
+# Fallback for any unseen category label
+_DEFAULT_KNOWLEDGE = {
+    "visual": "Visual characteristics are consistent with the classified defect type.",
+    "root_cause": "Root cause aligns with sensor deviations from the nominal good-weld profile.",
+    "corrective": "Review process parameters and align with qualified WPS specifications.",
+    "severity": "Medium",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert merged_by_ts_time.csv + image folders into Unsloth-compatible VLM datasets."
+    )
+    parser.add_argument(
+        "--input-csv",
+        type=Path,
+        required=True,
+        help="Source CSV file fusing weld classifier predictions with sensor "
+        "readings (see README.md 'Input data' section for the required schema).",
+    )
+    parser.add_argument(
+        "--images-root",
+        type=Path,
+        required=True,
+        help="Root directory containing per-class image subfolders, "
+        "searched recursively and matched by filename stem (Frame_id).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Destination folder for all output artefacts "
+        "(HF DatasetDict, parquet, conversation JSONL, summary.json).",
+    )
+    parser.add_argument("--train-ratio", type=float, default=0.8)
+    parser.add_argument("--val-ratio", type=float, default=0.1)
+    parser.add_argument("--test-ratio", type=float, default=0.1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap on rows processed — useful for quick dry-runs.",
+    )
+    parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help="Skip rows whose image cannot be resolved instead of raising an error.",
+    )
+    return parser.parse_args()
+
+
+def build_image_index(images_root: Path) -> Tuple[Dict[str, str], Dict[str, List[str]]]:
+    """Return {stem -> absolute_path} and {stem -> [all_paths]} for duplicates."""
+    index: Dict[str, str] = {}
+    duplicates: Dict[str, List[str]] = defaultdict(list)
+
+    for fp in images_root.rglob("*"):
+        if not fp.is_file() or fp.suffix.lower() not in SUPPORTED_EXTS:
+            continue
+        key = fp.stem
+        full_path = str(fp.resolve())
+        if key in index:
+            if not duplicates[key]:
+                duplicates[key].append(index[key])
+            duplicates[key].append(full_path)
+        else:
+            index[key] = full_path
+
+    return index, duplicates
+
+
+def load_csv(csv_path: Path) -> pd.DataFrame:
+    df = pd.read_csv(csv_path, low_memory=False, skipinitialspace=True)
+    df.columns = df.columns.str.strip()
+    for col in df.select_dtypes(include=["object", "str"]).columns:
+        df[col] = df[col].str.strip()
+    return df
+
+
+def parse_prediction_details(raw: Any) -> Dict[str, Any]:
+    """
+    Parse the output_prediction_details JSON string (stored as a Python-dict literal).
+
+    Returns a normalised dict with keys:
+        predicted_category, is_defect, defect_probability, good_weld_probability,
+        confidence, top_signal_features  (list of dicts)
+    """
+    if not isinstance(raw, str) or not raw:
+        return {}
+    try:
+        d = ast.literal_eval(raw)
+    except Exception:
+        return {}
+
+    explanation = d.get("explanation") or {}
+    return {
+        "predicted_category": d.get("predicted_category", ""),
+        "is_defect": bool(d.get("is_defect", False)),
+        "defect_probability": float(d.get("defect_probability", 0.0)),
+        "good_weld_probability": float(d.get("good_weld_probability", 1.0)),
+        "confidence": float(d.get("confidence", 0.0)),
+        "top_signal_features": explanation.get("top_signal_features", []),
+        "reason": explanation.get("reason", ""),
+    }
+
+
+def build_sensor_block(row: pd.Series) -> str:
+    """Format sensor readings into an inline text block."""
+    parts = []
+    for col, unit in SENSOR_UNITS.items():
+        val = row.get(col)
+        if pd.notna(val):
+            parts.append(f"  • {col}: {val} {unit}")
+    return "Sensor Data:\n" + "\n".join(parts) if parts else ""
+
+
+def build_user_prompt(sensor_block: str, prompt_idx: int) -> str:
+    template = USER_PROMPT_TEMPLATES[prompt_idx % len(USER_PROMPT_TEMPLATES)]
+    return template.format(sensor_block=sensor_block)
+
+
+def _lookup(category: str) -> Dict[str, str]:
+    """Retrieve defect knowledge, normalising category name variants."""
+    clean = category.replace(" ", "_").replace("-", "_")
+    # Try exact match first, then case-insensitive scan
+    for key in DEFECT_KNOWLEDGE:
+        if key.lower() == clean.lower():
+            return DEFECT_KNOWLEDGE[key]
+    return _DEFAULT_KNOWLEDGE
+
+
+def build_assistant_response(
+    row: pd.Series,
+    details: Dict[str, Any],
+) -> str:
+    """
+    Build a hybrid classification + structured analysis response.
+
+    Structure:
+        **Weld Classification:** <label>
+        **Visual Observation:** <description>
+        **Sensor Analysis:** <table of signals vs. expected values>
+        **Confidence:** <pct> | **Defect Probability:** <pct>
+        **Severity:** <level>
+        **Root Cause:** <explanation>
+        **Corrective Actions:** <steps>
+    """
+    predicted_category = details.get("predicted_category", "") or str(
+        row.get("vision_classification", "")
+    )
+    is_defect = details.get("is_defect", False)
+    confidence = details.get("confidence", 0.0)
+    defect_prob = details.get("defect_probability", 0.0)
+    top_features = details.get("top_signal_features", [])
+
+    # Normalise category label for display
+    display_label = predicted_category.replace("_", " ").replace("-", " ").title()
+    knowledge = _lookup(predicted_category)
+
+    if is_defect:
+        classification_line = f"**Weld Classification:** Bad Weld — {display_label}"
+    else:
+        classification_line = "**Weld Classification:** Good Weld"
+
+    visual_line = f"**Visual Observation:** {knowledge['visual']}"
+
+    # Sensor analysis: merge top_signal_features with raw row readings
+    sensor_lines = ["**Sensor Analysis:**"]
+    featured_names = {f["feature"] for f in top_features}
+
+    for feat in top_features:
+        fname = feat["feature"]
+        unit = SENSOR_UNITS.get(fname, "")
+        val = feat.get("value", "N/A")
+        pred_mean = feat.get("predicted_mean", "N/A")
+        gw_mean = feat.get("good_weld_mean", "N/A")
+        ev_score = feat.get("evidence_score", 0.0)
+        sensor_lines.append(
+            f"  • {fname}: {val} {unit} "
+            f"(expected for {display_label}: ~{pred_mean:.2f} {unit}; "
+            f"good weld mean: ~{gw_mean:.2f} {unit}; "
+            f"evidence score: {ev_score:.3f})"
+        )
+
+    # Append remaining sensor columns not covered by top_features
+    for col, unit in SENSOR_UNITS.items():
+        if col not in featured_names:
+            val = row.get(col)
+            if pd.notna(val):
+                sensor_lines.append(f"  • {col}: {val} {unit}")
+
+    # Confidence note — flag low-confidence predictions
+    conf_str = f"{confidence:.1%}"
+    defect_str = f"{defect_prob:.1%}"
+    confidence_line = (
+        f"**Model Confidence:** {conf_str} | **Defect Probability:** {defect_str}"
+    )
+    if confidence < 0.85:
+        confidence_line += "  ⚠️ Lower confidence — visual inspection recommended."
+
+    severity_line = f"**Severity:** {knowledge['severity']}"
+    root_line = f"**Root Cause:** {knowledge['root_cause']}"
+    corrective_line = f"**Corrective Actions:** {knowledge['corrective']}"
+
+    sections = [
+        classification_line,
+        "",
+        visual_line,
+        "",
+        confidence_line,
+        severity_line,
+        "",
+        root_line,
+        "",
+        corrective_line,
+    ]
+    return "\n".join(sections)
+
+
+def build_conversation(
+    image_path: str,
+    user_prompt: str,
+    assistant_response: str,
+) -> List[Dict[str, Any]]:
+    """Return a messages list in Unsloth / Qwen-VL chat format."""
+    return [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": SYSTEM_PROMPT}],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": user_prompt},
+                {"type": "image", "image": image_path},
+            ],
+        },
+        {
+            "role": "assistant",
+            "content": [{"type": "text", "text": assistant_response}],
+        },
+    ]
+
+
+def build_records(
+    df: pd.DataFrame,
+    image_index: Dict[str, str],
+    limit: Optional[int],
+    skip_missing: bool,
+    seed: int,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """
+    Convert each CSV row into one training record with a randomly selected user prompt.
+
+    The prompt variant index is chosen deterministically per row using the RNG seed,
+    so dataset generation is fully reproducible.
+    """
+    records: List[Dict[str, Any]] = []
+    missing_frames: List[str] = []
+    rng = random.Random(seed)
+
+    rows_iter = df.iterrows()
+    processed = 0
+
+    for _, row in rows_iter:
+        if limit is not None and processed >= limit:
+            break
+
+        frame_id = row.get("Frame_id")
+        if not isinstance(frame_id, str) or not frame_id:
+            missing_frames.append("<empty_frame_id>")
+            if skip_missing:
+                continue
+            raise ValueError(f"Empty Frame_id encountered at row index {_}.")
+
+        image_path = image_index.get(frame_id)
+        if image_path is None:
+            missing_frames.append(frame_id)
+            if skip_missing:
+                continue
+            raise FileNotFoundError(
+                f"No image found for Frame_id='{frame_id}'. "
+                "Check --images-root and image naming convention."
+            )
+
+        details = parse_prediction_details(row.get("output_prediction_details"))
+        sensor_block = build_sensor_block(row)
+        prompt_idx = rng.randint(0, len(USER_PROMPT_TEMPLATES) - 1)
+        user_prompt = build_user_prompt(sensor_block, prompt_idx)
+        assistant_response = build_assistant_response(row, details)
+        messages = build_conversation(image_path, user_prompt, assistant_response)
+
+        # Canonical weld-session label for stratified splitting
+        canonical_category = str(
+            row.get("Category") or details.get("predicted_category") or "UNKNOWN"
+        )
+
+        records.append(
+            {
+                "id": frame_id,
+                "frame_id": frame_id,
+                "image": image_path,
+                "image_path": image_path,
+                "canonical_category": canonical_category,
+                "vision_classification": str(row.get("vision_classification") or ""),
+                "is_defect": details.get("is_defect", False),
+                "defect_probability": details.get("defect_probability", 0.0),
+                "confidence": details.get("confidence", 0.0),
+                "prompt_variant": prompt_idx,
+                "conversation_json": json.dumps(messages, ensure_ascii=False),
+                "messages": messages,
+            }
+        )
+        processed += 1
+
+    return records, missing_frames
+
+
+def stratified_split(
+    records: List[Dict[str, Any]],
+    train_ratio: float,
+    val_ratio: float,
+    test_ratio: float,
+    seed: int,
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Split records by canonical_category label to preserve class balance."""
+    by_label: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        by_label[record.get("canonical_category") or "UNKNOWN"].append(record)
+
+    rng = random.Random(seed)
+    split_records: Dict[str, List[Dict[str, Any]]] = {
+        "train": [],
+        "validation": [],
+        "test": [],
+    }
+
+    for label_records in by_label.values():
+        rng.shuffle(label_records)
+        n = len(label_records)
+        n_train = int(n * train_ratio)
+        n_val = int(n * val_ratio)
+        n_test = n - n_train - n_val
+
+        # Guarantee at least one sample per split when enough data exists.
+        if n >= 3:
+            if n_train == 0:
+                n_train = 1
+            if n_val == 0:
+                n_val = 1
+            if n_test == 0:
+                n_test = 1
+            while n_train + n_val + n_test > n:
+                if n_train >= n_val and n_train >= n_test and n_train > 1:
+                    n_train -= 1
+                elif n_val >= n_test and n_val > 1:
+                    n_val -= 1
+                elif n_test > 1:
+                    n_test -= 1
+                else:
+                    break
+
+        split_records["train"].extend(label_records[:n_train])
+        split_records["validation"].extend(label_records[n_train : n_train + n_val])
+        split_records["test"].extend(label_records[n_train + n_val :])
+
+    for split_name in split_records:
+        rng.shuffle(split_records[split_name])
+
+    return split_records
+
+
+# ── Output helpers ─────────────────────────────────────────────────────────────
+
+
+def write_jsonl(records: Iterable[Dict[str, Any]], out_path: Path) -> None:
+    with out_path.open("w", encoding="utf-8") as f:
+        for row in records:
+            # Write only the conversation structure (messages list) per line —
+            # this is what Unsloth's vision data collator expects.
+            f.write(
+                json.dumps({"messages": row["messages"]}, ensure_ascii=False) + "\n"
+            )
+
+
+def build_hf_dataset(split_rows: List[Dict[str, Any]]) -> Dataset:
+    """Build a HF Dataset with scalar columns; cast image column to PIL-loadable Image."""
+    hf_rows = [
+        {
+            "id": row["id"],
+            "frame_id": row["frame_id"],
+            "image": row["image"],
+            "image_path": row["image_path"],
+            "canonical_category": row.get("canonical_category"),
+            "vision_classification": row.get("vision_classification", ""),
+            "is_defect": row.get("is_defect", False),
+            "defect_probability": row.get("defect_probability", 0.0),
+            "confidence": row.get("confidence", 0.0),
+            "prompt_variant": row.get("prompt_variant", 0),
+            "conversation_json": row.get("conversation_json", "[]"),
+        }
+        for row in split_rows
+    ]
+    ds = Dataset.from_list(hf_rows)
+    return ds.cast_column("image", HFImage())
+
+
+def ensure_ratios(train: float, val: float, test: float) -> None:
+    total = train + val + test
+    if abs(total - 1.0) > 1e-9:
+        raise ValueError(
+            f"Split ratios must sum to 1.0. Got {train} + {val} + {test} = {total:.6f}."
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_ratios(args.train_ratio, args.val_ratio, args.test_ratio)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"[info] Building image index from: {args.images_root}")
+    image_index, duplicates = build_image_index(args.images_root)
+    if duplicates:
+        print(
+            f"[warn] {len(duplicates)} duplicate image stems found; first path used for each."
+        )
+
+    print(f"[info] Loading CSV: {args.input_csv}")
+    df = load_csv(args.input_csv)
+    print(f"[info] CSV loaded: {len(df)} rows, {len(df.columns)} columns.")
+
+    print("[info] Building training records ...")
+    records, missing_frames = build_records(
+        df=df,
+        image_index=image_index,
+        limit=args.limit,
+        skip_missing=args.skip_missing,
+        seed=args.seed,
+    )
+
+    if not records:
+        raise RuntimeError(
+            "No records were built. Verify --input-csv and --images-root."
+        )
+
+    print(
+        f"[info] Records built: {len(records)} | Missing images: {len(missing_frames)}"
+    )
+
+    print("[info] Performing stratified split ...")
+    split_rows = stratified_split(
+        records,
+        train_ratio=args.train_ratio,
+        val_ratio=args.val_ratio,
+        test_ratio=args.test_ratio,
+        seed=args.seed,
+    )
+
+    # Build HF datasets
+    split_datasets = {name: build_hf_dataset(rows) for name, rows in split_rows.items()}
+    dataset_dict = DatasetDict(split_datasets)
+
+    # ── Write HF DatasetDict ──
+    hf_dir = args.output_dir / "hf_dataset"
+    print(f"[info] Saving HF DatasetDict to: {hf_dir}")
+    dataset_dict.save_to_disk(str(hf_dir))
+
+    # ── Write per-split parquet + JSONL ──
+    parquet_dir = args.output_dir / "parquet"
+    conv_dir = args.output_dir / "conversations"
+    parquet_dir.mkdir(parents=True, exist_ok=True)
+    conv_dir.mkdir(parents=True, exist_ok=True)
+
+    summary: Dict[str, Any] = {
+        "input_csv": str(args.input_csv.resolve()),
+        "images_root": str(args.images_root.resolve()),
+        "output_dir": str(args.output_dir.resolve()),
+        "total_records": len(records),
+        "missing_frames_count": len(missing_frames),
+        "prompt_variants": len(USER_PROMPT_TEMPLATES),
+        "splits": {},
+    }
+
+    for split_name, ds in dataset_dict.items():
+        parquet_path = parquet_dir / f"{split_name}.parquet"
+        ds.to_parquet(str(parquet_path))
+
+        conv_path = conv_dir / f"{split_name}.jsonl"
+        write_jsonl(split_rows[split_name], conv_path)
+
+        summary["splits"][split_name] = {
+            "count": len(ds),
+            "parquet_path": str(parquet_path.resolve()),
+            "conversation_jsonl_path": str(conv_path.resolve()),
+        }
+        print(
+            f"  [{split_name}] {len(ds)} samples → {parquet_path.name}, {conv_path.name}"
+        )
+
+    summary["missing_frames_sample"] = missing_frames[:20]
+    summary_path = args.output_dir / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+    print("\n Weld VLM dataset prepared successfully.")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/requirements.txt
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/requirements.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Data-prep requirement: Python >= 3.10
+# Fine-tuning/inference requirement: Python >= 3.10, plus a working PyTorch
+# install for your accelerator (Intel XPU / CUDA / CPU) — see README.md
+# "Install PyTorch for your device" before installing this file.
+
+# --- Data preparation (prepare_weld_dataset.py) ---
+pandas==2.3.3
+datasets==5.0.0
+pyarrow==22.0.0
+pillow==12.0.0
+
+# --- Fine-tuning & inference (train_qwen.py / infer_qwen.py) ---
+transformers==4.57.1
+trl==0.24.0
+peft==0.19.1
+accelerate==1.11.0
+unsloth==2025.11.9
+unsloth_zoo==2025.11.10

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/train_qwen.py
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/vlm-fine-tuning/train_qwen.py
@@ -1,0 +1,188 @@
+#
+# Apache v2 license
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+
+"""
+Fine-tune a Qwen vision-language model on the weld VLM dataset using
+Unsloth + LoRA + TRL's SFTTrainer.
+
+Input:
+    A parquet dataset directory produced by prepare_weld_dataset.py, containing
+    train/validation/test splits with an `image` column and a `conversation_json`
+    column (system/user/assistant chat messages).
+
+Output:
+    A LoRA adapter (and tokenizer) saved to --output-dir, loadable later by
+    infer_qwen.py or served via vLLM with `--enable-lora`.
+
+Usage:
+    python train_qwen.py \\
+        --model-name unsloth/Qwen3.5-2B \\
+        --dataset-path processed_dataset/parquet \\
+        --output-dir qwen_3.5_2b_adapter \\
+        --learning-rate 2e-4 \\
+        --num-train-epochs 2
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from datasets import load_dataset
+from trl import SFTConfig
+from trl import SFTTrainer
+
+from unsloth import FastVisionModel
+from unsloth.trainer import UnslothVisionDataCollator
+
+from common import convert_to_conversation
+from common import detect_device
+from common import validate_sample_index
+
+DEFAULT_MODEL_NAME = "unsloth/Qwen3.5-2B"
+DEFAULT_DATASET_PATH = "processed_dataset/parquet"
+DEFAULT_OUTPUT_DIR = "qwen_3.5_2b_adapter"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fine-tune a Qwen vision-language model on the weld VLM dataset."
+    )
+    parser.add_argument("--model-name", default=DEFAULT_MODEL_NAME)
+    parser.add_argument("--dataset-path", default=DEFAULT_DATASET_PATH)
+    parser.add_argument("--output-dir", default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--sample-index", type=int, default=0)
+    parser.add_argument("--num-train-epochs", type=int, default=2)
+    parser.add_argument("--learning-rate", type=float, default=2e-4)
+    parser.add_argument(
+        "--per-device-train-batch-size", type=int, default=4
+    )
+    parser.add_argument("--per-device-eval-batch-size", type=int, default=4)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=4)
+    parser.add_argument("--max-seq-length", type=int, default=2048)
+    parser.add_argument("--lora-r", type=int, default=16)
+    parser.add_argument("--lora-alpha", type=int, default=16)
+    parser.add_argument(
+        "--load-in-4bit",
+        action="store_true",
+        default=True,
+        help="Load the base model with 4-bit quantization (default: on).",
+    )
+    parser.add_argument(
+        "--preview-only",
+        action="store_true",
+        help="Load and print the first converted training sample, then exit "
+        "without building the model or training.",
+    )
+    parser.add_argument(
+        "--skip-save",
+        action="store_true",
+        help="Do not save the trained adapter/tokenizer to --output-dir.",
+    )
+    return parser.parse_args()
+
+
+def build_model(model_name: str, load_in_4bit: bool, lora_r: int, lora_alpha: int):
+    model, tokenizer = FastVisionModel.from_pretrained(
+        model_name,
+        load_in_4bit=load_in_4bit,
+        use_gradient_checkpointing="unsloth",
+    )
+
+    model = FastVisionModel.get_peft_model(
+        model,
+        finetune_vision_layers=True,
+        finetune_language_layers=True,
+        finetune_attention_modules=True,
+        finetune_mlp_modules=True,
+        r=lora_r,
+        lora_alpha=lora_alpha,
+        lora_dropout=0,
+        bias="none",
+        random_state=3407,
+        use_rslora=False,
+        loftq_config=None,
+    )
+    return model, tokenizer
+
+
+def main() -> None:
+    args = parse_args()
+    device = detect_device()
+    optim_name = "adamw_8bit" if device == "cuda" else "adamw_torch"
+
+    train_dataset = load_dataset(args.dataset_path, split="train")
+    eval_dataset = load_dataset(args.dataset_path, split="validation")
+    validate_sample_index(train_dataset, args.sample_index)
+
+    converted_train_dataset = [
+        convert_to_conversation(sample) for sample in train_dataset
+    ]
+    converted_eval_dataset = [
+        convert_to_conversation(sample) for sample in eval_dataset
+    ]
+
+    print(f"Loaded {len(train_dataset)} training samples from {args.dataset_path}")
+    print(f"Loaded {len(eval_dataset)} evaluation samples from {args.dataset_path}")
+    print(f"Using device: {device}")
+    print(converted_train_dataset[args.sample_index])
+
+    if args.preview_only:
+        return
+
+    print(f"Building model from base: {args.model_name} ...")
+    model, tokenizer = build_model(
+        args.model_name, args.load_in_4bit, args.lora_r, args.lora_alpha
+    )
+
+    FastVisionModel.for_training(model)
+    trainer = SFTTrainer(
+        model=model,
+        processing_class=tokenizer,
+        data_collator=UnslothVisionDataCollator(model, tokenizer, resize="max"),
+        train_dataset=converted_train_dataset,
+        eval_dataset=converted_eval_dataset,
+        args=SFTConfig(
+            skip_memory_metrics=False,
+            per_device_train_batch_size=args.per_device_train_batch_size,
+            per_device_eval_batch_size=args.per_device_eval_batch_size,
+            gradient_accumulation_steps=args.gradient_accumulation_steps,
+            warmup_steps=5,
+            num_train_epochs=args.num_train_epochs,
+            learning_rate=args.learning_rate,
+            logging_strategy="steps",
+            logging_steps=5,
+            optim=optim_name,
+            eval_strategy="steps",
+            eval_steps=50,
+            save_strategy="steps",
+            save_steps=50,
+            weight_decay=0.001,
+            lr_scheduler_type="linear",
+            seed=3407,
+            output_dir=args.output_dir,
+            report_to="none",
+            remove_unused_columns=False,
+            dataset_text_field="",
+            dataset_kwargs={"skip_prepare_dataset": True},
+            max_length=args.max_seq_length,
+        ),
+    )
+
+    trainer_stats = trainer.train()
+    print(trainer_stats)
+
+    if not args.skip_save:
+        model.save_pretrained(args.output_dir)
+        tokenizer.save_pretrained(args.output_dir)
+        print(f"Adapter and tokenizer saved to: {args.output_dir}")
+        print(
+            "Run infer_qwen.py --model-path "
+            f"{args.output_dir} to try it out."
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description

Add a new, self-contained `vlm-fine-tuning/` toolkit under `industrial-edge-insights-multimodal` for preparing a multimodal (image + sensor telemetry) weld-defect dataset and fine-tuning a Qwen vision-language model with Unsloth + LoRA.

Not wired into the existing docker-compose/vLLM stacks; runs independently and produces
a LoRA adapter that can be served via the existing docker-compose-vllm.yml or any OpenAI-compatible VLM server.

- `prepare_weld_dataset.py`: builds HF DatasetDict/parquet splits and conversation JSONL from fused CSV + weld images
- `train_qwen.py`: LoRA fine-tuning entry point on the prepared dataset
- `infer_qwen.py`: runs inference with base model or adapter, streaming a structured weld-quality report (classification, observations, sensor analysis, confidence, severity, root cause, corrective actions)
- `common.py`: shared helpers (device detection, chat-message conversion) for train/infer scripts
- `requirements.txt`: pinned dependencies for the toolkit
- `README.md`: usage docs covering setup, pipeline stages, and architecture


### How Has This Been Tested?

PTL 356H, ARL 255H and Xeon+B580

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

