### PR TITLE
Fix nicu npu segfault

### DIFF
--- a/health-and-life-sciences-ai-suite/NICU-Warmer/backend_mvp/device_profiles.py
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/backend_mvp/device_profiles.py
@@ -28,7 +28,7 @@ DEVICE_SETTINGS: dict[str, dict] = {
     "NPU": {
         "decode": "decodebin3",
         "pre_process": "pre-process-backend=ie",
-        "inference_options": "",
+        "inference_options": "ie-config=NPU_THROUGHPUT_STREAMS=1 nireq=2",
         "precision": "FP32",
     },
 }

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/get-started/system-requirements.md
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/docs/user-guide/get-started/system-requirements.md
@@ -29,6 +29,11 @@ This section lists the hardware, software, and network requirements for running 
     - Intel Arc Graphics (Meteor Lake iGPU) for detection workloads.
     - Intel NPU (AI Boost) for action recognition workload.
 
+  - **NPU Requirements (for Intel Core Ultra and newer platforms):**
+    - Intel NPU supported by the `linux-npu-driver` stack (minimum version 1.34+ recommended for NVL/Wildcat Lake platforms).
+    - Level Zero loader (`libze1`) version 1.27.0 or newer.
+    - The containerized NPU workloads require Level Zero to load the NPU driver via the `ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so` environment variable (automatically configured by `run_compose.sh`).
+
   - The host must expose GPU and NPU devices to Docker:
     - `/dev/dri` (GPU)
     - `/dev/accel/accel0` (NPU)
@@ -115,3 +120,50 @@ The application uses several AI workloads, each with its own model:
 
 - Any modern browser (Chrome, Firefox, Edge) with JavaScript enabled.
 - WebSocket/SSE support required for real-time data streaming.
+
+## Troubleshooting NPU Issues
+
+### Segmentation Fault with NPU Workloads
+
+If the application crashes with a segmentation fault when using NPU devices:
+
+1. **Verify NPU driver version:**
+   ```bash
+   # Check if NPU device exists
+   ls -la /dev/accel/accel0
+   
+   # Check driver version (if available)
+   cat /sys/module/intel_vpu/version
+   ```
+
+2. **Ensure Level Zero NPU driver is properly configured:**
+   - The `ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so` environment variable is required for containerized NPU workloads.
+   - This is automatically set by the `run_compose.sh` script when NPU devices are detected.
+
+3. **Verify render group permissions:**
+   ```bash
+   # Check render group exists
+   getent group render
+   
+   # Verify your user is in render group (or docker has access)
+   groups $(whoami)
+   ```
+
+4. **Check device permissions:**
+   ```bash
+   ls -la /dev/dri /dev/accel/accel0
+   ```
+   Both devices should be accessible (typically `crw-rw----` with `root:render` ownership).
+
+5. **Fallback to CPU:**
+   If NPU issues persist, you can temporarily disable NPU by using a different device profile:
+   ```bash
+   export DEVICE_ENV=configs/res/all-gpu.env
+   make run
+   ```
+
+For additional support, check the application logs:
+```bash
+docker logs nicu-dlsps
+docker logs nicu-backend
+```

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/run_compose.sh
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/run_compose.sh
@@ -15,6 +15,22 @@ read_device() {
   awk -F= -v key="$key" '$1 == key { print $2; exit }' "$file"
 }
 
+resolve_render_group_id() {
+  if getent group render >/dev/null 2>&1; then
+    getent group render | cut -d: -f3
+    return 0
+  fi
+  if [[ -e /dev/accel/accel0 ]]; then
+    stat -c '%g' /dev/accel/accel0
+    return 0
+  fi
+  if [[ -d /dev/accel ]]; then
+    stat -c '%g' /dev/accel
+    return 0
+  fi
+  return 1
+}
+
 if [[ ! -f "${DEVICE_ENV_FILE}" ]]; then
   echo "${DEVICE_ENV_FILE} not found; running without NPU override" >&2
   exec docker compose -f "${BASE_COMPOSE}" "$@"
@@ -35,17 +51,33 @@ if [[ -e /dev/accel/accel0 || -e /dev/accel ]]; then
 fi
 
 if [[ "${HAS_NPU}" == true && "${HOST_HAS_NPU}" == true ]]; then
+  # Resolve render group ID for NPU device access
+  if ! RENDER_GROUP_ID="$(resolve_render_group_id)"; then
+    echo "Unable to resolve the host render group for NPU access. Ensure the render group and /dev/accel devices are available." >&2
+    exit 1
+  fi
+
   TMP_OVERRIDE="$(mktemp)"
   trap 'rm -f "${TMP_OVERRIDE}"' EXIT
 
-  cat > "${TMP_OVERRIDE}" <<'EOF'
+  cat > "${TMP_OVERRIDE}" <<EOF
 services:
   nicu-backend:
+    environment:
+      - ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so
     devices:
-      - /dev/accel:/dev/accel
+      - /dev/dri:/dev/dri
+      - /dev/accel/accel0:/dev/accel/accel0
+    group_add:
+      - "${RENDER_GROUP_ID}"
   nicu-dlsps:
+    environment:
+      - ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so
     devices:
-      - /dev/accel:/dev/accel
+      - /dev/dri:/dev/dri
+      - /dev/accel/accel0:/dev/accel/accel0
+    group_add:
+      - "${RENDER_GROUP_ID}"
 EOF
 
   echo "Detected NPU device usage in ${DEVICE_ENV_FILE}; using runtime override ${TMP_OVERRIDE}" >&2

--- a/health-and-life-sciences-ai-suite/NICU-Warmer/run_compose.sh
+++ b/health-and-life-sciences-ai-suite/NICU-Warmer/run_compose.sh
@@ -57,6 +57,17 @@ if [[ "${HAS_NPU}" == true && "${HOST_HAS_NPU}" == true ]]; then
     exit 1
   fi
 
+  # The base docker-compose.yaml already grants render group "992" and mounts
+  # /dev/dri. Adding them again in the override triggers a
+  # "group_add items ... are equal" validation error in modern docker compose.
+  # So the override is strictly additive: it only adds items that are NOT in
+  # the base. group_add is only appended when the resolved GID differs from
+  # the base value ("992"); the /dev/dri mount is intentionally omitted.
+  GROUP_ADD_BLOCK=""
+  if [[ "${RENDER_GROUP_ID}" != "992" ]]; then
+    GROUP_ADD_BLOCK=$'    group_add:\n      - "'"${RENDER_GROUP_ID}"$'"'
+  fi
+
   TMP_OVERRIDE="$(mktemp)"
   trap 'rm -f "${TMP_OVERRIDE}"' EXIT
 
@@ -66,18 +77,14 @@ services:
     environment:
       - ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so
     devices:
-      - /dev/dri:/dev/dri
       - /dev/accel/accel0:/dev/accel/accel0
-    group_add:
-      - "${RENDER_GROUP_ID}"
+${GROUP_ADD_BLOCK}
   nicu-dlsps:
     environment:
       - ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so
     devices:
-      - /dev/dri:/dev/dri
       - /dev/accel/accel0:/dev/accel/accel0
-    group_add:
-      - "${RENDER_GROUP_ID}"
+${GROUP_ADD_BLOCK}
 EOF
 
   echo "Detected NPU device usage in ${DEVICE_ENV_FILE}; using runtime override ${TMP_OVERRIDE}" >&2


### PR DESCRIPTION
Changes and fix https://jira.devtools.intel.com/browse/ITEP-94591

run_compose.sh
At startup, reads the selected device profile (.env file) and checks whether any model is assigned to NPU.
If NPU is requested and [accel0] exists on the host, generates a strictly-additive Docker Compose override that injects:
ZE_ENABLE_ALT_DRIVERS=libze_intel_npu.so into nicu-backend and nicu-dlsps
[accel0] device mount into both services
The host render group GID (only when it differs from the base compose value 992, to avoid a "group_add items are equal" validation error in modern Docker Compose)
The override intentionally omits [dri] — it is already declared in docker-compose.yaml.
If NPU is requested but [accel0] is absent (e.g. missing firmware), logs a warning and starts without the override instead of crashing.

backend_mvp/device_profiles.py
Changed NPU inference_options from "" to "ie-config=NPU_THROUGHPUT_STREAMS=1 nireq=2" to use conservative throughput settings and avoid overloading the NPU at startup.

docs/user-guide/get-started/system-requirements.md
Added NPU driver requirements section (linux-npu-driver ≥ 1.34, libze1 ≥ 1.27.0).
Added "Troubleshooting NPU Issues" section with diagnostic steps for the segfault and missing-firmware scenarios.