### PR TITLE
[Agentic-Smart-Community] mcp-server: skip poll tick while previous poll is in flight

### DIFF
--- a/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/video-worker/task-poller.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/video-worker/task-poller.ts
@@ -34,9 +34,20 @@ export class TaskPoller {
     if (this.intervals.has(monitorId)) return;
 
     const interval = setInterval(() => {
-      const promise = this.poll(monitorId).then(() => {
-        this.activePoll.delete(monitorId);
-      });
+      // Skip this tick if the previous poll for this monitor is still in
+      // flight. Otherwise, while a poll waits on yieldManager.acquire() (which
+      // can take minutes under backlog), every subsequent tick re-reads the
+      // same still-"pending" task and the clip gets summarized multiple times.
+      if (this.activePoll.has(monitorId)) return;
+      const promise = this.poll(monitorId)
+        .catch((err) => {
+          // poll() handles per-task errors internally; this catches failures
+          // outside that path (e.g. DB errors) so polling never stalls.
+          logger.error(`[task-poller] poll cycle failed for ${monitorId}: ${err?.message ?? err}`);
+        })
+        .then(() => {
+          this.activePoll.delete(monitorId);
+        });
       this.activePoll.set(monitorId, promise);
     }, this.config.pollIntervalMs);
 


### PR DESCRIPTION
Under backlog, poll() waits on yieldManager.acquire() before marking the task "processing". Since setInterval keeps firing every pollIntervalMs, each subsequent tick re-reads the same still-pending task and the clip gets summarized many times (observed up to 18x per clip), wasting VLM capacity and overwriting results with nondeterministic VLM output.

Skip the tick when a poll is already in flight for the monitor, and catch rejections from poll() so a failure outside its internal try/catch (e.g. DB error) cannot leave activePoll set and stall polling for that monitor permanently.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

