### PR TITLE
Release notes: Smart Route Planning Agent v2026.2.0

### DIFF
--- a/metro-ai-suite/smart-route-planning-agent/chart/Chart.yaml
+++ b/metro-ai-suite/smart-route-planning-agent/chart/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: smart-route-planning-agent
 description: A chart for deploying Smart Route Planning Agent Application
 type: application
-version: 2026.1.0-rc1-helm
+version: 2026.2.0-rc1-helm
 appVersion: "1.0.0"

--- a/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
@@ -1,8 +1,15 @@
 # Release Notes: Smart Route Planning Agent
 
-<!--## Version 2026.2.0-->
+## Version 2026.2.0
 
-<!--date TBD-->
+**August 4, 2026**
+
+**Dependency Updates**
+
+- Updated dependency specifications to use compatible-release (`~=`) versioning based on PEP 440 standard.
+- Updated all dependencies to latest compatible versions.
+- Pinned uv installer to semantic versioning range (>=0.9.22,<1.0.0) for reproducible builds in the docker image.
+- Removal of unused and some transitive dependencies for cleaner dependency tree.
 
 ## Version 2026.1.0
 

--- a/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
@@ -4,7 +4,7 @@
 
 **August 4, 2026**
 
-**Dependency Updates**
+**Improved**
 
 - Updated dependency specifications to use compatible-release (`~=`) versioning based on PEP 440 standard.
 - Updated all dependencies to latest compatible versions.

--- a/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/smart-route-planning-agent/docs/user-guide/release-notes.md
@@ -8,8 +8,8 @@
 
 - Updated dependency specifications to use compatible-release (`~=`) versioning based on PEP 440 standard.
 - Updated all dependencies to latest compatible versions.
-- Pinned uv installer to semantic versioning range (>=0.9.22,<1.0.0) for reproducible builds in the docker image.
-- Removal of unused and some transitive dependencies for cleaner dependency tree.
+- Pinned `uv` installer to semantic versioning range (>=0.9.22,<1.0.0) for reproducible docker builds.
+- Removal of unused and few transitive dependencies for cleaner dependency tree.
 
 ## Version 2026.1.0
 


### PR DESCRIPTION
This PR adds a minimal Release Notes entry (Version 2026.2.0, Date: August 4, 2026) for the Smart Route Planning Agent documenting security-related dependency changes from PR #3322: switched to compatible-release (~=) specifiers, pinned uv installer to >=0.9.22,<1.0.0, and removed unused/transitive dependencies.