### PR TITLE
Smart Classroom: rm VA unused param

### DIFF
--- a/education-ai-suite/smart-classroom/model_manager/feature_bootstrap.py
+++ b/education-ai-suite/smart-classroom/model_manager/feature_bootstrap.py
@@ -58,14 +58,6 @@ def startup(app: FastAPI) -> None:
 
     ModelManager.instance().warmup(list(eff.capabilities))
 
-    if eff.is_enabled("video_analytics"):
-        from components.va.media_service import ensure_media_service_running
-        ensure_media_service_running()  # health-polled, idempotent
-        logger.info("MediaMTX ensured running for video_analytics.")
-
-    if eff.is_enabled("content_search"):
-        logger.info("content_search enabled; will start via feature build().")
-
     for feature in in_dependency_order():
         if not eff.is_enabled(feature.id):
             continue

--- a/education-ai-suite/smart-classroom/model_manager/features/va_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/va_feature.py
@@ -3,8 +3,6 @@ from typing import Dict, List
 
 from fastapi import APIRouter
 
-from utils.config_loader import config
-
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
@@ -19,21 +17,12 @@ class VideoAnalyticsFeature:
 
     def __init__(self) -> None:
         self._media_service = None
-        self.front_enabled = True
-        self.back_enabled = True
-        self.board_enabled = False
 
     def build(self) -> None:
-        """Trigger the MediaMTX/VA launch and read camera sub-flags."""
-        self._read_subflags()
-
+        """Trigger the MediaMTX/VA launch."""
         from components.va.media_service import ensure_media_service_running
         self._media_service = ensure_media_service_running()
-        logger.info(
-            "VideoAnalyticsFeature built; media service running "
-            "(front=%s, back=%s, board=%s).",
-            self.front_enabled, self.back_enabled, self.board_enabled,
-        )
+        logger.info("VideoAnalyticsFeature built; media service running.")
 
     def teardown(self) -> None:
         """Stop the MediaMTX server if this feature started it."""
@@ -48,20 +37,4 @@ class VideoAnalyticsFeature:
     def ui_descriptor(self) -> Dict:
         return {
             "id": self.id,
-            "type": "panel",
-            "panel": "video_analytics",
-            "title": "Video Analytics",
-            "cameras": {
-                "front": self.front_enabled,
-                "back": self.back_enabled,
-                "board": self.board_enabled,
-            },
         }
-
-    def _read_subflags(self) -> None:
-        va_cfg = getattr(config, "va_pipeline", None)
-        self.front_enabled = bool(getattr(va_cfg, "front_enabled", True))
-        self.back_enabled = bool(getattr(va_cfg, "back_enabled", True))
-
-        board_cfg = getattr(config, "board_ocr", None)
-        self.board_enabled = bool(getattr(board_cfg, "enabled", False))

--- a/education-ai-suite/smart-classroom/ui/src/hooks/useFeatureConfig.ts
+++ b/education-ai-suite/smart-classroom/ui/src/hooks/useFeatureConfig.ts
@@ -53,11 +53,3 @@ export function useFeatureEndpoint(featureId: string, endpointKey: string): stri
   const { guard, loaded } = useFeatureConfig();
   return loaded ? guard.getEndpoint(featureId, endpointKey) : null;
 }
-
-/**
- * Hook to get camera configuration
- */
-export function useCameraConfig() {
-  const { guard, loaded } = useFeatureConfig();
-  return loaded ? guard.getCameraConfig() : { front: false, back: false, board: false };
-}

--- a/education-ai-suite/smart-classroom/ui/src/redux/slices/featureConfigSlice.ts
+++ b/education-ai-suite/smart-classroom/ui/src/redux/slices/featureConfigSlice.ts
@@ -9,18 +9,8 @@ export interface FeatureDescriptor {
   requires: string[];
   
   // Optional UI-specific fields
-  type?: string;
-  panel?: string;
-  title?: string;
   endpoints?: Record<string, string>;
   mode?: string;
-  
-  // Video Analytics specific
-  cameras?: {
-    front?: boolean;
-    back?: boolean;
-    board?: boolean;
-  };
 }
 
 interface FeatureConfigState {

--- a/education-ai-suite/smart-classroom/ui/src/services/api.ts
+++ b/education-ai-suite/smart-classroom/ui/src/services/api.ts
@@ -57,16 +57,8 @@ export interface FeatureDescriptor {
   id: string;
   dependency: string[];
   requires: string[];
-  type?: string;
-  panel?: string;
-  title?: string;
   endpoints?: Record<string, string>;
   mode?: string;
-  cameras?: {
-    front?: boolean;
-    back?: boolean;
-    board?: boolean;
-  };
 }
 
 /**


### PR DESCRIPTION
### Description


This pull request removes the camera-specific configuration and related UI fields for the Video Analytics feature from both the backend and frontend. The changes simplify the feature's configuration by eliminating sub-flags for individual cameras (front, back, board) and the associated UI descriptors, hooks, and type definitions.

**Backend changes:**

* Removed logic for reading and storing camera sub-flags (`front_enabled`, `back_enabled`, `board_enabled`) in the `VideoAnalyticsFeature` class, as well as the `_read_subflags` method and related logging and UI descriptor fields. [[1]](diffhunk://#diff-f0fc7eb80af1300d13d6e6e10eca443c9056bad5c35bb39ad6c07e18944f5047L22-R25) [[2]](diffhunk://#diff-f0fc7eb80af1300d13d6e6e10eca443c9056bad5c35bb39ad6c07e18944f5047L51-L67)
* Removed conditional startup logic for the media service based on feature flags from `feature_bootstrap.py`.

**Frontend changes:**

* Removed camera configuration fields (`cameras`, `type`, `panel`, `title`) from the `FeatureDescriptor` interface in both Redux and API service definitions. [[1]](diffhunk://#diff-4a0be01dc3e7de2bb0998a8b5e921b5e2a1539a506ed32c4fb1938838e47c02cL12-L23) [[2]](diffhunk://#diff-4bbadd7872f3e79922b2707c923ed42632c1f31ffa8f958d05b696da8535aee4L60-L69)
* Removed the `useCameraConfig` React hook, which previously provided camera configuration to UI components.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

