### PR TITLE
Smart Classroom: Content Search Upgrade to OV 2026.3

### DIFF
--- a/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/embedding/clip_handler.py
+++ b/education-ai-suite/smart-classroom/content_search/providers/file_ingest_and_retrieve/embedding/clip_handler.py
@@ -46,8 +46,18 @@ class CLIPHandler:
             self._export_to_openvino(model_dir)
 
         core = ov.Core()
-        self._visual_model = core.compile_model(str(visual_path), self.device)
-        self._text_model = core.compile_model(str(text_path), self.device)
+        try:
+            self._visual_model = core.compile_model(str(visual_path), self.device)
+            self._text_model = core.compile_model(str(text_path), self.device)
+        except RuntimeError:
+            # The text tower's GatherND has no GPU/NPU kernel, so CPU is the only
+            # device that can run both towers.
+            if self.device.upper() == "CPU":
+                raise
+            logger.warning(f"CLIP cannot be compiled on {self.device}, falling back to CPU")
+            self.device = "CPU"
+            self._visual_model = core.compile_model(str(visual_path), self.device)
+            self._text_model = core.compile_model(str(text_path), self.device)
 
         tokenizer_dir = model_dir / "tokenizer"
         if tokenizer_dir.exists():
@@ -74,7 +84,9 @@ class CLIPHandler:
         model.eval()
 
         # Export visual encoder
-        dummy_image = torch.randn(1, 3, IMAGE_SIZE, IMAGE_SIZE)
+        # Batch dims are exported with a size-2 dummy: torch.export specializes a
+        # dim of size 1 to a constant, which would bake batch=1 into the IR.
+        dummy_image = torch.randn(2, 3, IMAGE_SIZE, IMAGE_SIZE)
         onnx_visual = str(model_dir / "visual.onnx")
         torch.onnx.export(
             model.visual, dummy_image, onnx_visual,
@@ -86,7 +98,7 @@ class CLIPHandler:
         )
 
         # Export text encoder
-        dummy_text = torch.randint(0, 250002, (1, MAX_SEQ_LEN), dtype=torch.long)
+        dummy_text = torch.randint(0, 250002, (2, MAX_SEQ_LEN), dtype=torch.long)
         onnx_text = str(model_dir / "text.onnx")
         torch.onnx.export(
             model.text, dummy_text, onnx_text,

--- a/education-ai-suite/smart-classroom/content_search/requirements.txt
+++ b/education-ai-suite/smart-classroom/content_search/requirements.txt
@@ -7,9 +7,9 @@ uvicorn==0.38.0
 pydantic==2.11.7
 pydantic-settings==2.10.1
 
-openvino==2026.2.1
-openvino-tokenizers==2026.2.1
-openvino-genai==2026.2.1
+openvino==2026.3.0
+openvino-tokenizers==2026.3.0
+openvino-genai==2026.3.0
 
 optimum-intel==2.0.0
 nncf>=2.14.0

--- a/education-ai-suite/smart-classroom/content_search/requirements.txt
+++ b/education-ai-suite/smart-classroom/content_search/requirements.txt
@@ -11,12 +11,12 @@ openvino==2026.3.0
 openvino-tokenizers==2026.3.0
 openvino-genai==2026.3.0
 
-optimum-intel==2.0.0
-nncf>=2.14.0
+optimum-intel==2.1.0
+nncf==3.3.0
 
 torch>=2.9.1
 torchvision>=0.24.0
-transformers==5.0.0
+transformers==5.5.0
 onnxscript>=0.5.0
 
 llama-index==0.14.23
@@ -45,4 +45,4 @@ starlette==0.50.0
 psycopg2==2.9.11
 python-multipart>=0.0.27
 
-hf_xet==1.4.3
+hf_xet==1.6.0


### PR DESCRIPTION
### Description

This pull request updates dependency versions in `requirements.txt` and improves the robustness and correctness of the CLIP model export and loading process in `clip_handler.py`. The main changes include better handling of device compatibility for OpenVINO, preventing batch size specialization during export, and updating several ML-related dependencies.

**Dependency updates:**

* Upgraded `openvino`, `openvino-tokenizers`, and `openvino-genai` to version 2026.3.0 for improved compatibility and features.
* Updated `optimum-intel` to 2.1.0, pinned `nncf` to 3.3.0, and bumped `transformers` to 5.5.0 for better support and bug fixes.
* Upgraded `hf_xet` to 1.6.0 for improved functionality.

**Model export and loading improvements:**

* Enhanced error handling in `load_model` to gracefully fall back to CPU if the selected device cannot compile the CLIP model, logging a warning instead of failing outright.
* Changed dummy input batch sizes from 1 to 2 in `_export_to_openvino` to prevent the export process from baking in a fixed batch size, ensuring the exported IR supports variable batch sizes. [[1]](diffhunk://#diff-74d11884fab4b783e46c9007bdc68d666dfaec03d8670f19634e756766f837a1L77-R89) [[2]](diffhunk://#diff-74d11884fab4b783e46c9007bdc68d666dfaec03d8670f19634e756766f837a1L89-R101)
Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

