### PR TITLE
Smart Classroom: Add model conversion functionality and refactor subprocess handling

### DIFF
--- a/education-ai-suite/smart-classroom/api/__init__.py
+++ b/education-ai-suite/smart-classroom/api/__init__.py
@@ -1,0 +1,9 @@
+#
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# NOTE: this file is required, not optional. ``content_search/api`` is a regular
+# package and gets onto ``sys.path`` once the content-search helpers are loaded.
+# Without an ``__init__.py`` here, this directory is only a namespace portion and
+# loses to that regular package, so ``api.endpoints`` stops resolving in any
+# freshly started interpreter (e.g. a spawned model-conversion subprocess).

--- a/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/convert_worker.py
+++ b/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/convert_worker.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone model-conversion entry point.
+
+Run as a script (``python convert_worker.py ...``) by
+:func:`utils.utils.convert_model` so that all memory used during quantization and
+export is reclaimed by the OS when the process exits.
+
+This module is deliberately self-contained: it imports nothing from the
+smart-classroom application packages. Using ``multiprocessing.Process`` here
+would make Windows' spawn start method re-execute the parent's ``__main__``
+(``main.py``) in the child, which both re-runs the whole application import
+graph and is sensitive to top-level package-name collisions on ``sys.path``.
+"""
+
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger("convert_worker")
+
+
+def convert(model_id: str, cache_dir: str, model_type: str, weight_format: str) -> None:
+    import openvino as ov
+    from openvino_tokenizers import convert_tokenizer
+    from optimum.exporters.openvino.utils import save_preprocessors
+    from optimum.intel import (
+        OVModelForCausalLM,
+        OVModelForFeatureExtraction,
+        OVModelForSequenceClassification,
+        OVModelForVisualCausalLM,
+    )
+    from optimum.utils.save_utils import maybe_load_preprocessors
+    from transformers import AutoTokenizer
+
+    hf_tokenizer = AutoTokenizer.from_pretrained(model_id)
+    hf_tokenizer.save_pretrained(cache_dir)
+    add_special_tokens = model_type in ("embedding", "reranker")
+    needs_detokenizer = model_type in ("llm", "vlm")
+    if needs_detokenizer:
+        ov_tokenizer, ov_detokenizer = convert_tokenizer(
+            hf_tokenizer, add_special_tokens=add_special_tokens, with_detokenizer=True
+        )
+        ov.save_model(ov_tokenizer, f"{cache_dir}/openvino_tokenizer.xml")
+        ov.save_model(ov_detokenizer, f"{cache_dir}/openvino_detokenizer.xml")
+    else:
+        ov_tokenizer = convert_tokenizer(hf_tokenizer, add_special_tokens=add_special_tokens)
+        ov.save_model(ov_tokenizer, f"{cache_dir}/openvino_tokenizer.xml")
+
+    if model_type == "embedding":
+        embedding_model = OVModelForFeatureExtraction.from_pretrained(
+            model_id, export=True
+        )
+        embedding_model.save_pretrained(cache_dir)
+    elif model_type == "reranker":
+        reranker_model = OVModelForSequenceClassification.from_pretrained(
+            model_id, export=True
+        )
+        reranker_model.save_pretrained(cache_dir)
+    elif model_type == "llm":
+        llm_model = OVModelForCausalLM.from_pretrained(
+            model_id, export=True, weight_format=weight_format
+        )
+        llm_model.save_pretrained(cache_dir)
+    elif model_type == "vlm":
+        vlm_model = OVModelForVisualCausalLM.from_pretrained(
+            model_id, export=True, weight_format=weight_format
+        )
+        vlm_model.save_pretrained(cache_dir)
+        preprocessors = maybe_load_preprocessors(model_id)
+        save_preprocessors(preprocessors, vlm_model.config, cache_dir, True)
+    else:
+        raise ValueError(f"Unsupported model type: {model_type}")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Convert a model to OpenVINO IR.")
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument("--cache-dir", required=True)
+    parser.add_argument("--model-type", required=True,
+                        choices=("embedding", "reranker", "llm", "vlm"))
+    parser.add_argument("--weight-format", required=True)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(process)d] [%(levelname)s] %(name)s: %(message)s",
+    )
+    try:
+        convert(args.model_id, args.cache_dir, args.model_type, args.weight_format)
+    except Exception:
+        logger.exception("Model conversion failed for %s", args.model_id)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/utils.py
+++ b/education-ai-suite/smart-classroom/components/vlm/vlm_openvino_serving/utils/utils.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
-import multiprocessing
 import os
 import random
+import subprocess
 import sys
 from io import BytesIO
 from pathlib import Path
@@ -47,62 +47,7 @@ def _download_preconverted_ov_model(repo_id: str, cache_dir: str):
     logger.info("Pre-converted OpenVINO IR download complete.")
 
 
-def _convert_model_worker(
-    model_id: str, cache_dir: str, model_type: str, weight_format: str
-):
-    """
-    Worker function that runs in a subprocess to perform the actual model conversion.
-    When the subprocess exits, all memory used during conversion is fully reclaimed by the OS.
-    """
-    from openvino_tokenizers import convert_tokenizer
-    from optimum.exporters.openvino.utils import save_preprocessors
-    from optimum.intel import (
-        OVModelForCausalLM,
-        OVModelForFeatureExtraction,
-        OVModelForSequenceClassification,
-        OVModelForVisualCausalLM,
-    )
-    from optimum.utils.save_utils import maybe_load_preprocessors
-    from transformers import AutoTokenizer
-
-    hf_tokenizer = AutoTokenizer.from_pretrained(model_id)
-    hf_tokenizer.save_pretrained(cache_dir)
-    add_special_tokens = model_type in ("embedding", "reranker")
-    needs_detokenizer = model_type in ("llm", "vlm")
-    if needs_detokenizer:
-        ov_tokenizer, ov_detokenizer = convert_tokenizer(
-            hf_tokenizer, add_special_tokens=add_special_tokens, with_detokenizer=True
-        )
-        ov.save_model(ov_tokenizer, f"{cache_dir}/openvino_tokenizer.xml")
-        ov.save_model(ov_detokenizer, f"{cache_dir}/openvino_detokenizer.xml")
-    else:
-        ov_tokenizer = convert_tokenizer(hf_tokenizer, add_special_tokens=add_special_tokens)
-        ov.save_model(ov_tokenizer, f"{cache_dir}/openvino_tokenizer.xml")
-
-    if model_type == "embedding":
-        embedding_model = OVModelForFeatureExtraction.from_pretrained(
-            model_id, export=True
-        )
-        embedding_model.save_pretrained(cache_dir)
-    elif model_type == "reranker":
-        reranker_model = OVModelForSequenceClassification.from_pretrained(
-            model_id, export=True
-        )
-        reranker_model.save_pretrained(cache_dir)
-    elif model_type == "llm":
-        llm_model = OVModelForCausalLM.from_pretrained(
-            model_id, export=True, weight_format=weight_format
-        )
-        llm_model.save_pretrained(cache_dir)
-    elif model_type == "vlm":
-        vlm_model = OVModelForVisualCausalLM.from_pretrained(
-            model_id, export=True, weight_format=weight_format
-        )
-        vlm_model.save_pretrained(cache_dir)
-        preprocessors = maybe_load_preprocessors(model_id)
-        save_preprocessors(preprocessors, vlm_model.config, cache_dir, True)
-    else:
-        raise ValueError(f"Unsupported model type: {model_type}")
+_CONVERT_WORKER = Path(__file__).resolve().parent / "convert_worker.py"
 
 
 def convert_model(
@@ -136,23 +81,26 @@ def convert_model(
             _download_preconverted_ov_model(preconverted_repo, cache_dir)
         else:
             logger.info(f"Converting {model_id} model to OpenVINO format in subprocess...")
-            _orig_pythonpath = os.environ.get("PYTHONPATH")
-            os.environ["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p)
-            try:
-                process = multiprocessing.Process(
-                    target=_convert_model_worker,
-                    args=(model_id, cache_dir, model_type, weight_format),
-                )
-                process.start()
-                process.join()
-            finally:
-                if _orig_pythonpath is None:
-                    os.environ.pop("PYTHONPATH", None)
-                else:
-                    os.environ["PYTHONPATH"] = _orig_pythonpath
-            if process.exitcode != 0:
+            # Run a standalone script rather than multiprocessing.Process: on
+            # Windows the spawn start method re-executes the parent's __main__
+            # (main.py) in the child, which needlessly re-imports the whole app
+            # and breaks on top-level package-name collisions in sys.path.
+            env = os.environ.copy()
+            env["PYTHONPATH"] = os.pathsep.join(dict.fromkeys(p for p in sys.path if p))
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(_CONVERT_WORKER),
+                    "--model-id", model_id,
+                    "--cache-dir", cache_dir,
+                    "--model-type", model_type,
+                    "--weight-format", weight_format,
+                ],
+                env=env,
+            )
+            if completed.returncode != 0:
                 raise RuntimeError(
-                    f"Model conversion subprocess failed with exit code {process.exitcode}"
+                    f"Model conversion subprocess failed with exit code {completed.returncode}"
                 )
             logger.info(f"Model conversion completed. Subprocess memory released.")
     except Exception as e:


### PR DESCRIPTION
### Description

This pull request refactors how model conversion to OpenVINO format is performed in the VLM component. Instead of using a Python multiprocessing worker (which can cause issues on Windows due to re-importing the main application), it now launches a standalone subprocess that runs a dedicated script. This improves reliability, especially on Windows, and simplifies memory management for the conversion process.

**Model Conversion Refactor:**

* Replaces the in-process `multiprocessing.Process`-based worker with a subprocess that runs a new standalone script (`convert_worker.py`) to perform model conversion, avoiding issues with re-importing the application and package name collisions on Windows.
* Introduces the new `convert_worker.py` script, which provides a self-contained entry point for model conversion, including argument parsing and error handling.
* Removes the now-unused `_convert_model_worker` function from `utils.py` and replaces its invocation with a subprocess call to the new script.

**Environment and Path Handling:**

* Ensures the subprocess receives a clean `PYTHONPATH` environment variable to avoid import errors and package collisions.

**Other:**

* Adds a missing `__init__.py` to the `api` package to guarantee correct package resolution in subprocesses.
Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

