### PR TITLE
[Edge AI Suites] Metro Apps: Update scenescape and metrics manager with 2026.2.0-rc1 tags

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/compose-scenescape.yml
@@ -234,7 +234,7 @@ services:
       start_period: 10s
 
   web:
-    image: intel/scenescape-manager:2026.2.0-20260804-weekly
+    image: intel/scenescape-manager:2026.2.0-rc1
     init: true
     networks:
       scenescape:
@@ -292,7 +292,7 @@ services:
     restart: on-failure:5
 
   scene:
-    image: intel/scenescape-controller:2026.2.0-20260804-weekly
+    image: intel/scenescape-controller:2026.2.0-rc1
     init: true
     environment:
       - http_proxy=${http_proxy}
@@ -334,7 +334,7 @@ services:
     restart: on-failure:5
 
   analytics:
-    image: intel/scenescape-analytics:2026.2.0-20260804-weekly
+    image: intel/scenescape-analytics:2026.2.0-rc1
     init: true
     environment:
       - http_proxy=${http_proxy}

--- a/metro-ai-suite/metro-vision-ai-app-recipe/compose-without-scenescape.yml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/compose-without-scenescape.yml
@@ -190,7 +190,7 @@ services:
       - app_network
 
   metrics-manager:
-    image: intel/metrics-manager:2026.2.0-20260804-weekly
+    image: intel/metrics-manager:2026.2.0-rc1
     container_name: metrics-manager
     privileged: true
     volumes:

--- a/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/helm-chart/values.yaml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/loitering-detection/helm-chart/values.yaml
@@ -28,7 +28,7 @@ nginx:
   imageTag: 1.30.2-alpine
 metrics_service:
   image: intel/metrics-manager
-  imageTag: 2026.2.0-20260804-weekly
+  imageTag: 2026.2.0-rc1
 timezone: ""  # Leave empty; set dynamically at install time: --set timezone=$(cat /etc/timezone)
 env:
   ENABLE_WEBRTC: "true"

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/chart/values.yaml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/chart/values.yaml
@@ -18,7 +18,7 @@ imagePullPolicy: IfNotPresent
 
 # Global version configuration for external dependencies and assets
 version:
-  release: "v2026.1.0-rc2"
+  release: "2026.1"
   modelsRelease: "main"
   modelsReleaseType: branch  # Options: 'tag' or 'branch'
 
@@ -131,7 +131,7 @@ grafana:
 
 scene:
   repository: intel/scenescape-controller
-  tag: 2026.2.0-20260804-weekly
+  tag: 2026.2.0-rc1
 
   service:
     type: ClusterIP
@@ -139,7 +139,7 @@ scene:
 
 analytics:
   repository: intel/scenescape-analytics
-  tag: 2026.2.0-20260804-weekly
+  tag: 2026.2.0-rc1
 
 pgserver:
   repository: postgres
@@ -155,7 +155,7 @@ web:
   replicas: 1
   image:
     repository: intel/scenescape-manager
-    tag: 2026.2.0-20260804-weekly
+    tag: 2026.2.0-rc1
   dbhost: pgserver
   broker: broker.scenescape.intel.com
   service:

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/helm-chart/values.yaml
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/helm-chart/values.yaml
@@ -36,7 +36,7 @@ nginx:
   imageTag: 1.30.2-alpine
 metrics_service:
   image: intel/metrics-manager
-  imageTag: 2026.2.0-20260804-weekly
+  imageTag: 2026.2.0-rc1
 timezone: ""  # Leave empty; set dynamically at install time: --set timezone=$(cat /etc/timezone)
 env:
   ENABLE_WEBRTC: "true"


### PR DESCRIPTION
### Description

Update scenescape and metrics manager with 2026.2.0-rc1 tags (#3657)

### Any Newly Introduced Dependencies

No new dependency introduced

### How Has This Been Tested?

Ran basic app sanity

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

