### PR TITLE
Fix milvus schema based on new dlstreamer tensor metadata changes

### DIFF
--- a/metro-ai-suite/image-based-video-search/src/feature-matching/schemas.py
+++ b/metro-ai-suite/image-based-video-search/src/feature-matching/schemas.py
@@ -1,7 +1,11 @@
-from marshmallow import Schema, fields, ValidationError
+from marshmallow import Schema, fields, ValidationError, EXCLUDE
 
 # Define a schema for validation
 class TensorSchema(Schema):
+    class Meta:
+        # Ignore any additional fields emitted by newer DL Streamer versions
+        unknown = EXCLUDE
+
     data = fields.List(fields.Float(), required=False)
     layer_name = fields.Str(required=False)
     dims = fields.List(fields.Int(), required=False)
@@ -11,9 +15,17 @@ class TensorSchema(Schema):
     layout = fields.Str(required=False)
     label_id = fields.Int(required=False)
     confidence = fields.Float(required=False)
-    
+    tensor_name = fields.Str(required=False)
+    dims_order = fields.Str(required=False)
+    type = fields.Str(required=False)
+    semantic_tag = fields.Str(required=False)
+
 
 class MetadataSchema(Schema):
+    class Meta:
+        # Ignore any additional fields emitted by newer DL Streamer versions
+        unknown = EXCLUDE
+
     time = fields.Int(required=True)
     objects = fields.List(fields.Dict(), required=False)
     caps = fields.Str(required=False)
@@ -32,5 +44,9 @@ class MetadataSchema(Schema):
     timestamp = fields.Int(required=False)
 
 class PayloadSchema(Schema):
+    class Meta:
+        # Ignore any additional fields emitted by newer DL Streamer versions
+        unknown = EXCLUDE
+
     metadata = fields.Nested(MetadataSchema, required=True)
     blob = fields.Raw(required=False)

--- a/metro-ai-suite/image-based-video-search/src/feature-matching/server.py
+++ b/metro-ai-suite/image-based-video-search/src/feature-matching/server.py
@@ -104,8 +104,9 @@ def on_message(client, userdata, message):
                     # Validate tensor schema
                     validated_tensor = TensorSchema().load(tensor)
 
-                    # Process only tensors with layer_name == "prob"
-                    if validated_tensor["layer_name"] == "prob":
+                    # Process only the embedding tensor named "prob".
+                    layer = validated_tensor.get("tensor_name") or validated_tensor.get("layer_name")
+                    if layer == "prob":
                         tensor_data = validated_tensor["data"]
 
                         if confidence > CONFIDENCE_THRESHOLD:
@@ -258,7 +259,9 @@ async def search(
             for obj in objects:
                 tensors = obj.get("tensors", [])
                 for tensor in tensors:
-                    if tensor.get("layer_name") == "prob":  # Filter by layer_name
+                    # Filter by the embedding layer name "prob". Newer DL Streamer
+                    # emits it in "tensor_name"; older versions used "layer_name".
+                    if (tensor.get("tensor_name") or tensor.get("layer_name")) == "prob":
                         tensor_data = tensor.get("data", [])
                         if tensor_data:
                             tensor_data_list.append(tensor_data)


### PR DESCRIPTION
### Description

After switching to latest 2026.2.0-rc1 image of dlstreamer , the latest tensor output has changed. Fixing milvus schema based on new output

Fixes # https://jira.devtools.intel.com/browse/ITEP-95271 

### Any Newly Introduced Dependencies

No new dependency introduced

### How Has This Been Tested?

Tested basic functionality for both docker and helm deployment

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

