### PR TITLE
Smart Classroom: extend funasr backend pipeline to make chunk optional and add cam++ as speaker diarization model

### DIFF
--- a/education-ai-suite/smart-classroom/components/asr/diarization/base_diarizer.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/base_diarizer.py
@@ -1,0 +1,129 @@
+"""Shared speaker identity registry for the diarization backends.
+
+A backend clusters speakers only within the audio it is handed, so in chunked mode the
+local labels restart on every chunk. The registry maps them onto session-wide
+``SPEAKER_NN`` identities by matching speaker embeddings against the centroids seen so far.
+"""
+import logging
+
+import numpy as np
+
+from utils.config_loader import config
+
+logger = logging.getLogger(__name__)
+
+
+class GlobalSpeakerDiarizer:
+    def __init__(self):
+        self.similarity_threshold = float(
+            config.models.diarization.global_speaker_similarity_threshold
+        )
+        if not 0.0 <= self.similarity_threshold <= 1.0:
+            raise ValueError(
+                "models.diarization.global_speaker_similarity_threshold "
+                "must be between 0.0 and 1.0"
+            )
+
+        # A new diarizer is created for every transcription request. This state
+        # is therefore shared by that request's chunks, but not by later audio.
+        self.global_speakers = {}
+        self.next_global_speaker_id = 0
+
+    def diarize(self, audio_path):
+        """Return [{'start': sec, 'end': sec, 'speaker': 'SPEAKER_NN'}] for audio_path."""
+        raise NotImplementedError("Must implement in subclass.")
+
+    @staticmethod
+    def _normalize_embedding(embedding):
+        embedding = np.asarray(embedding, dtype=np.float32)
+        if embedding.ndim != 1 or not np.all(np.isfinite(embedding)):
+            return None
+        norm = np.linalg.norm(embedding)
+        if norm <= 1e-12:
+            return None
+        return embedding / norm
+
+    def _new_global_speaker(self, embedding, duration):
+        speaker = f"SPEAKER_{self.next_global_speaker_id:02d}"
+        self.next_global_speaker_id += 1
+        self.global_speakers[speaker] = {
+            "centroid": embedding.copy() if embedding is not None else None,
+            "duration": duration if embedding is not None else 0.0,
+        }
+        return speaker
+
+    def _update_global_speaker(self, speaker, embedding, duration):
+        state = self.global_speakers[speaker]
+        previous_duration = state["duration"]
+        total_duration = previous_duration + duration
+        if total_duration <= 0.0:
+            return
+        centroid = self._normalize_embedding(
+            state["centroid"] * previous_duration + embedding * duration
+        )
+        state["centroid"] = centroid
+        state["duration"] = total_duration
+
+    def _match_global_speakers(self, local_speakers):
+        """Map {local_label: {'embedding', 'duration'}} onto global speaker labels."""
+        mapping = {}
+        assigned_local = set()
+        assigned_global = set()
+        candidates = []
+
+        for local_speaker, local_state in local_speakers.items():
+            embedding = local_state["embedding"]
+            if embedding is None:
+                continue
+            for global_speaker, global_state in self.global_speakers.items():
+                centroid = global_state["centroid"]
+                if centroid is None:
+                    continue
+                similarity = float(np.dot(embedding, centroid))
+                if similarity >= self.similarity_threshold:
+                    candidates.append(
+                        (similarity, local_speaker, global_speaker)
+                    )
+
+        # Enforce one-to-one matching within each chunk so two simultaneous
+        # local speakers cannot collapse into the same global identity.
+        for similarity, local_speaker, global_speaker in sorted(
+            candidates,
+            key=lambda item: (-item[0], item[1], item[2]),
+        ):
+            if local_speaker in assigned_local:
+                continue
+            if global_speaker in assigned_global:
+                continue
+            local_state = local_speakers[local_speaker]
+            mapping[local_speaker] = global_speaker
+            assigned_local.add(local_speaker)
+            assigned_global.add(global_speaker)
+            self._update_global_speaker(
+                global_speaker,
+                local_state["embedding"],
+                local_state["duration"],
+            )
+            logger.info(
+                "Mapped local %s to global %s (cosine similarity %.3f)",
+                local_speaker,
+                global_speaker,
+                similarity,
+            )
+
+        for local_speaker in sorted(local_speakers):
+            if local_speaker in mapping:
+                continue
+            local_state = local_speakers[local_speaker]
+            global_speaker = self._new_global_speaker(
+                local_state["embedding"],
+                local_state["duration"],
+            )
+            mapping[local_speaker] = global_speaker
+            logger.info(
+                "Registered local %s as new global %s",
+                local_speaker,
+                global_speaker,
+            )
+
+        return mapping

--- a/education-ai-suite/smart-classroom/components/asr/diarization/campplus_diarizer.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/campplus_diarizer.py
@@ -1,0 +1,140 @@
+"""FunASR CAM++ speaker diarization.
+
+VAD -> fixed-length windows over speech only -> CAM++ embeddings -> spectral clustering.
+Unlike ``AutoModel(spk_model=...)`` this never runs ASR, which is what makes it cheap
+enough to run on every chunk or over a whole lecture.
+"""
+import logging
+import os
+
+import numpy as np
+import soundfile as sf
+import torch
+from funasr import AutoModel
+from funasr.models.campplus.cluster_backend import ClusterBackend
+from funasr.models.campplus.utils import correct_labels, postprocess
+
+from components.asr.diarization.base_diarizer import GlobalSpeakerDiarizer
+from utils.ensure_model import get_asr_model_path
+from utils.model_download_helper import get_or_download_model_dir
+
+logger = logging.getLogger(__name__)
+
+CAMPPLUS_MODEL = "iic/speech_campplus_sv_zh-cn_16k-common"
+CAMPPLUS_REVISION = "v2.0.2"
+# Same snapshot the FunASR ASR pipeline downloads, reused instead of fetched twice.
+VAD_MODEL = "iic/speech_fsmn_vad_zh-cn-16k-common-pytorch"
+VAD_REVISION = "v2.0.4"
+
+SAMPLE_RATE = 16000
+SEG_DUR = 1.5       # embedding window length in seconds
+SEG_SHIFT = 0.75    # embedding window hop in seconds
+MERGE_THR = 0.78    # cosine threshold used to merge similar speaker clusters
+EMBEDDING_BATCH = 64
+
+
+class CamPlusPlusDiarizer(GlobalSpeakerDiarizer):
+    def __init__(self, device="cpu"):
+        super().__init__()
+        models_dir = os.path.dirname(get_asr_model_path())
+        spk_dir = get_or_download_model_dir(
+            model=CAMPPLUS_MODEL,
+            revision=CAMPPLUS_REVISION,
+            local_dir=os.path.join(models_dir, CAMPPLUS_MODEL),
+        )
+        vad_dir = get_or_download_model_dir(
+            model=VAD_MODEL,
+            revision=VAD_REVISION,
+            local_dir=os.path.join(models_dir, VAD_MODEL),
+        )
+
+        self.device = device
+        self.vad_model = AutoModel(model=vad_dir, device=device, disable_update=True)
+        self.spk_model = AutoModel(model=spk_dir, device=device, disable_update=True)
+        # AutoModel leaves the module in training mode, where BatchNorm uses batch
+        # statistics: the embeddings degenerate into noise and everything clusters as a
+        # single speaker (or a one-item batch raises outright).
+        self.spk_model.model.eval()
+        self.cluster = ClusterBackend(merge_thr=MERGE_THR)
+
+    def _read_audio(self, audio_path):
+        audio, sample_rate = sf.read(audio_path, dtype="float32", always_2d=False)
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1)
+        if sample_rate != SAMPLE_RATE:
+            import librosa
+            audio = librosa.resample(audio, orig_sr=sample_rate, target_sr=SAMPLE_RATE)
+        return audio
+
+    def _speech_windows(self, audio_path, audio):
+        """Split VAD speech into [start_s, end_s, samples] windows of SEG_DUR each."""
+        result = self.vad_model.generate(input=audio_path)
+        if not result:
+            return []
+
+        window_len = int(SEG_DUR * SAMPLE_RATE)
+        window_shift = int(SEG_SHIFT * SAMPLE_RATE)
+        windows = []
+        for start_ms, end_ms in result[0].get("value") or []:
+            speech = audio[int(start_ms / 1000.0 * SAMPLE_RATE): int(end_ms / 1000.0 * SAMPLE_RATE)]
+            offset = start_ms / 1000.0
+            last_end = 0
+            for start in range(0, speech.shape[0], window_shift):
+                end = min(start + window_len, speech.shape[0])
+                if end <= last_end:
+                    break
+                last_end = end
+                start = max(0, end - window_len)
+                samples = speech[start:end]
+                if samples.shape[0] < window_len:
+                    samples = np.pad(samples, (0, window_len - samples.shape[0]), "constant")
+                windows.append([start / SAMPLE_RATE + offset, end / SAMPLE_RATE + offset, samples])
+        return windows
+
+    def _embed(self, windows):
+        batches = []
+        with torch.no_grad():
+            for i in range(0, len(windows), EMBEDDING_BATCH):
+                samples = [w[2] for w in windows[i: i + EMBEDDING_BATCH]]
+                result, _ = self.spk_model.model.inference(
+                    samples, device=self.device, fs=SAMPLE_RATE
+                )
+                batches.append(result[0]["spk_embedding"].detach().cpu())
+        return torch.cat(batches).numpy()
+
+    def _local_speakers(self, windows, labels, embeddings):
+        local = {}
+        for label in set(labels):
+            selected = labels == label
+            local[int(label)] = {
+                "embedding": self._normalize_embedding(embeddings[selected].mean(axis=0)),
+                "duration": float(sum(w[1] - w[0] for w, keep in zip(windows, selected) if keep)),
+            }
+        return local
+
+    def diarize(self, audio_path):
+        try:
+            audio = self._read_audio(audio_path)
+            windows = self._speech_windows(audio_path, audio)
+            if not windows:
+                return []
+
+            embeddings = self._embed(windows)
+            # correct_labels() before clustering results are used, so the labels below
+            # match the ones postprocess() emits.
+            labels = correct_labels(self.cluster(torch.from_numpy(embeddings)))
+            global_mapping = self._match_global_speakers(
+                self._local_speakers(windows, labels, embeddings)
+            )
+
+            return [
+                {
+                    "start": float(start),
+                    "end": float(end),
+                    "speaker": global_mapping[int(label)],
+                }
+                for start, end, label in postprocess(windows, None, labels, embeddings)
+            ]
+        except Exception as e:
+            logger.error(f"[Diarization] CAM++ diarization error: {e}", exc_info=True)
+            return []

--- a/education-ai-suite/smart-classroom/components/asr/diarization/factory.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/factory.py
@@ -1,0 +1,20 @@
+import logging
+
+from utils.config_loader import config
+from utils.pipeline_modes import resolve_diarization_backend
+
+logger = logging.getLogger(__name__)
+
+
+def build_diarizer():
+    """Instantiate the configured diarization backend. Backends are imported lazily
+    because each pulls in a different heavy dependency."""
+    backend = resolve_diarization_backend()
+    logger.info(f"Building {backend} diarizer")
+
+    if backend == "campplus":
+        from components.asr.diarization.campplus_diarizer import CamPlusPlusDiarizer
+        return CamPlusPlusDiarizer()
+
+    from components.asr.diarization.pyannote_diarizer import PyannoteDiarizer
+    return PyannoteDiarizer(hf_token=config.models.asr.hf_token)

--- a/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
+++ b/education-ai-suite/smart-classroom/components/asr/diarization/pyannote_diarizer.py
@@ -1,7 +1,6 @@
 import logging
 import os
 
-import numpy as np
 from pyannote.audio import Pipeline
 import torch
 import torchaudio
@@ -10,14 +9,16 @@ from torch.serialization import safe_globals
 # Import all task-related globals used in pyannote checkpoints
 import torch.torch_version
 from pyannote.audio.core.task import Specifications, Problem, Resolution, Task
+from components.asr.diarization.base_diarizer import GlobalSpeakerDiarizer
 from utils.config_loader import config
 from utils.ensure_model import get_diarization_model_path
 
 logger = logging.getLogger(__name__)
 
 
-class PyannoteDiarizer:
+class PyannoteDiarizer(GlobalSpeakerDiarizer):
     def __init__(self, device="cpu", hf_token=None):
+        super().__init__()
         pipeline_source = config.models.diarization.name
         local_model_path = get_diarization_model_path()
         local_config_path = os.path.join(local_model_path, "config.yaml")
@@ -41,123 +42,12 @@ class PyannoteDiarizer:
         self.device = torch.device(device)
         self.pipeline.to(self.device)
 
-        threshold = getattr(
-            config.models.diarization,
-            "global_speaker_similarity_threshold",
-            0.65,
-        )
-        self.similarity_threshold = float(threshold)
-        if not 0.0 <= self.similarity_threshold <= 1.0:
-            raise ValueError(
-                "models.diarization.global_speaker_similarity_threshold "
-                "must be between 0.0 and 1.0"
-            )
-
-        # A new diarizer is created for every transcription request. This state
-        # is therefore shared by that request's chunks, but not by later audio.
-        self.global_speakers = {}
-        self.next_global_speaker_id = 0
-
-    @staticmethod
-    def _normalize_embedding(embedding):
-        embedding = np.asarray(embedding, dtype=np.float32)
-        if embedding.ndim != 1 or not np.all(np.isfinite(embedding)):
-            return None
-        norm = np.linalg.norm(embedding)
-        if norm <= 1e-12:
-            return None
-        return embedding / norm
-
     @staticmethod
     def _speaker_durations(diarization):
         durations = {speaker: 0.0 for speaker in diarization.labels()}
         for turn, _, speaker in diarization.itertracks(yield_label=True):
             durations[speaker] += turn.duration
         return durations
-
-    def _new_global_speaker(self, embedding, duration):
-        speaker = f"SPEAKER_{self.next_global_speaker_id:02d}"
-        self.next_global_speaker_id += 1
-        self.global_speakers[speaker] = {
-            "centroid": embedding.copy() if embedding is not None else None,
-            "duration": duration if embedding is not None else 0.0,
-        }
-        return speaker
-
-    def _update_global_speaker(self, speaker, embedding, duration):
-        state = self.global_speakers[speaker]
-        previous_duration = state["duration"]
-        total_duration = previous_duration + duration
-        if total_duration <= 0.0:
-            return
-        centroid = self._normalize_embedding(
-            state["centroid"] * previous_duration + embedding * duration
-        )
-        state["centroid"] = centroid
-        state["duration"] = total_duration
-
-    def _match_global_speakers(self, local_speakers):
-        mapping = {}
-        assigned_local = set()
-        assigned_global = set()
-        candidates = []
-
-        for local_speaker, local_state in local_speakers.items():
-            embedding = local_state["embedding"]
-            if embedding is None:
-                continue
-            for global_speaker, global_state in self.global_speakers.items():
-                centroid = global_state["centroid"]
-                if centroid is None:
-                    continue
-                similarity = float(np.dot(embedding, centroid))
-                if similarity >= self.similarity_threshold:
-                    candidates.append(
-                        (similarity, local_speaker, global_speaker)
-                    )
-
-        # Enforce one-to-one matching within each chunk so two simultaneous
-        # local speakers cannot collapse into the same global identity.
-        for similarity, local_speaker, global_speaker in sorted(
-            candidates,
-            key=lambda item: (-item[0], item[1], item[2]),
-        ):
-            if local_speaker in assigned_local:
-                continue
-            if global_speaker in assigned_global:
-                continue
-            local_state = local_speakers[local_speaker]
-            mapping[local_speaker] = global_speaker
-            assigned_local.add(local_speaker)
-            assigned_global.add(global_speaker)
-            self._update_global_speaker(
-                global_speaker,
-                local_state["embedding"],
-                local_state["duration"],
-            )
-            logger.info(
-                "Mapped local %s to global %s (cosine similarity %.3f)",
-                local_speaker,
-                global_speaker,
-                similarity,
-            )
-
-        for local_speaker in sorted(local_speakers):
-            if local_speaker in mapping:
-                continue
-            local_state = local_speakers[local_speaker]
-            global_speaker = self._new_global_speaker(
-                local_state["embedding"],
-                local_state["duration"],
-            )
-            mapping[local_speaker] = global_speaker
-            logger.info(
-                "Registered local %s as new global %s",
-                local_speaker,
-                global_speaker,
-            )
-
-        return mapping
 
     def diarize(self, audio_path):
         waveform, sample_rate = torchaudio.load(audio_path)

--- a/education-ai-suite/smart-classroom/components/asr_component.py
+++ b/education-ai-suite/smart-classroom/components/asr_component.py
@@ -7,7 +7,8 @@ import unicodedata
 from utils.config_loader import config
 from utils.storage_manager import StorageManager
 from utils.runtime_config_loader import RuntimeConfig
-from components.asr.diarization.pyannote_diarizer import PyannoteDiarizer
+from components.asr.diarization.factory import build_diarizer
+from utils.pipeline_modes import resolve_chunking
 from model_manager import ModelManager
 import logging
 logger = logging.getLogger(__name__)
@@ -83,11 +84,10 @@ class ASRComponent(PipelineComponent):
         # Get the underlying processor for transcription
         self.asr = self.asr_handler._processor
 
-        self.pyannote_diarizer = None
-        if self.enable_diarization:
-            self.pyannote_diarizer = PyannoteDiarizer(
-                hf_token=config.models.asr.hf_token
-            )
+        # Resolved here so an unsupported combination fails when the pipeline is built.
+        self.chunking = resolve_chunking()
+
+        self.diarizer = build_diarizer() if self.enable_diarization else None
             
     @staticmethod
     def _meaningful_char_count(text: str) -> int:
@@ -186,7 +186,7 @@ class ASRComponent(PipelineComponent):
                 transcribed_lines = []
 
                 if self.enable_diarization and transcription.get("segments"):
-                    speaker_turns = self.pyannote_diarizer.diarize(chunk_path)
+                    speaker_turns = self.diarizer.diarize(chunk_path)
 
                     for sent in transcription["segments"]:
                         if not sent["text"].strip():
@@ -369,6 +369,8 @@ class ASRComponent(PipelineComponent):
                 path=os.path.join(project_path, "performance_metrics.csv"),
                 new_data={
                     "configuration.asr_model": f"{self.asr_handler.provider}/{self.asr_handler.model_name}",
+                    "configuration.chunking": self.chunking,
+                    "configuration.diarization": config.models.diarization.backend if self.enable_diarization else "off",
                     "performance.transcription_time": round(transcription_time, 4)
                 }
             )

--- a/education-ai-suite/smart-classroom/components/ffmpeg/audio_preprocessing.py
+++ b/education-ai-suite/smart-classroom/components/ffmpeg/audio_preprocessing.py
@@ -7,6 +7,7 @@ import platform,time
 import logging
 from utils.config_loader import config
 from utils.runtime_config_loader import RuntimeConfig
+from utils.pipeline_modes import resolve_chunking
 from dto.audiosource import AudioSource
 
 logger = logging.getLogger(__name__)
@@ -195,8 +196,15 @@ def chunk_audiostream_by_silence(session_id: str):
                 logger.warning(f"Could not remove {record_file}: {e}")
         logger.info(f"🎧 Live recording stopped for session {session_id}.")
 
+def whole_file_passthrough(audio_path):
+    """Yield the whole recording as a single chunk, so downstream stages are unchanged."""
+    yield process_audio_segment(audio_path, 0.0, get_audio_duration(audio_path), 0)
+
 def chunk_by_silence(input, session_id: str):
+    chunking = resolve_chunking(input.source_type)
     if input.source_type == AudioSource.MICROPHONE:
         yield from chunk_audiostream_by_silence(session_id)
-    else:
+    elif chunking:
         yield from chunk_audio_by_silence(input.audio_filename)
+    else:
+        yield from whole_file_passthrough(input.audio_filename)

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -2,19 +2,19 @@
   name: Smart Classroom
   cleanup_on_exit: true
   use_ov_genai: True # True or False, applicable for provider: openvino
-  language: zh # en or zh
+  language: en # en or zh
 
 features:
   asr:                { enabled: true }
   summary:            { enabled: true }
   mindmap:            { enabled: true }
-  topic_segmentation: { enabled: false }
+  topic_segmentation: { enabled: true }
   video_analytics:    { enabled: true }
   board_ocr:          { enabled: true }
-  content_search:     { enabled: false }
-  qa:                 { enabled: false }
-  grading:            { enabled: false }
-  report:             { enabled: false }
+  content_search:     { enabled: true }
+  qa:                 { enabled: true }
+  grading:            { enabled: true }
+  report:             { enabled: true }
 
 monitoring:
   logs_dir: ./monitoring/logs
@@ -25,11 +25,11 @@ monitoring:
 
 models:
   asr:
-    provider: funasr # openvino, funasr and openai supported
-    name: paraformer-zh  # can be (whisper-base, whisper-small etc) or paraformer-zh
+    provider: openai # openvino, funasr and openai supported
+    name: whisper-small  # can be (whisper-base, whisper-small etc) or paraformer-zh
     device: CPU # CPU Recommended
     temperature: 0.0
-    diarization: True # requires manual HF token setup, see docs/user-guide/advance-setup-guide.md#f-speaker-diarization-setup-optional
+    diarization: False # requires manual HF token setup, see docs/user-guide/advance-setup-guide.md#f-speaker-diarization-setup-optional
     hf_token: None   # needed only if diarization=true
     models_base_path: "models"
     threads_limit: Null # applied only if > 0 (else defaults are used); value can be tuned based on CPU specifications
@@ -40,7 +40,7 @@ models:
     max_chars_per_segment: 0  # cap characters per merged transcript segment; set to 0 or Null to disable merging entirely
   
   diarization: #Only applicable when diarization is set to True for ASR
-    backend: campplus  # pyannote, or campplus for funasr/paraformer-zh
+    backend: pyannote  # pyannote, or campplus for funasr/paraformer-zh
     provider: "huggingface"
     name: "pyannote/speaker-diarization-community-1"
     models_base_path: "models"

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -93,7 +93,7 @@ mindmap:
   min_token: 20
 
 audio_preprocessing:
-  chunking: false # false: transcribe and diarize the whole recording in one pass, funasr/paraformer-zh only
+  chunking: true # false: transcribe and diarize the whole recording in one pass, funasr/paraformer-zh only
   chunk_duration_sec: 30
   silence_threshold: -35  # in dB
   silence_duration: 0.3   # minimum silence length in seconds

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -2,19 +2,19 @@
   name: Smart Classroom
   cleanup_on_exit: true
   use_ov_genai: True # True or False, applicable for provider: openvino
-  language: en # en or zh
+  language: zh # en or zh
 
 features:
   asr:                { enabled: true }
   summary:            { enabled: true }
   mindmap:            { enabled: true }
-  topic_segmentation: { enabled: true }
+  topic_segmentation: { enabled: false }
   video_analytics:    { enabled: true }
   board_ocr:          { enabled: true }
-  content_search:     { enabled: true }
-  qa:                 { enabled: true }
-  grading:            { enabled: true }
-  report:             { enabled: true }
+  content_search:     { enabled: false }
+  qa:                 { enabled: false }
+  grading:            { enabled: false }
+  report:             { enabled: false }
 
 monitoring:
   logs_dir: ./monitoring/logs
@@ -25,11 +25,11 @@ monitoring:
 
 models:
   asr:
-    provider: openai # openvino, funasr and openai supported
-    name: whisper-small  # can be (whisper-base, whisper-small etc) or paraformer-zh
+    provider: funasr # openvino, funasr and openai supported
+    name: paraformer-zh  # can be (whisper-base, whisper-small etc) or paraformer-zh
     device: CPU # CPU Recommended
     temperature: 0.0
-    diarization: False # requires manual HF token setup, see docs/user-guide/advance-setup-guide.md#f-speaker-diarization-setup-optional
+    diarization: True # requires manual HF token setup, see docs/user-guide/advance-setup-guide.md#f-speaker-diarization-setup-optional
     hf_token: None   # needed only if diarization=true
     models_base_path: "models"
     threads_limit: Null # applied only if > 0 (else defaults are used); value can be tuned based on CPU specifications
@@ -40,6 +40,7 @@ models:
     max_chars_per_segment: 0  # cap characters per merged transcript segment; set to 0 or Null to disable merging entirely
   
   diarization: #Only applicable when diarization is set to True for ASR
+    backend: campplus  # pyannote, or campplus for funasr/paraformer-zh
     provider: "huggingface"
     name: "pyannote/speaker-diarization-community-1"
     models_base_path: "models"
@@ -92,6 +93,7 @@ mindmap:
   min_token: 20
 
 audio_preprocessing:
+  chunking: false # false: transcribe and diarize the whole recording in one pass, funasr/paraformer-zh only
   chunk_duration_sec: 30
   silence_threshold: -35  # in dB
   silence_duration: 0.3   # minimum silence length in seconds

--- a/education-ai-suite/smart-classroom/docs/user-guide/advance-setup-guide.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/advance-setup-guide.md
@@ -151,8 +151,15 @@ board_ocr:
 
 ### F. Speaker Diarization Setup (Optional)
 
-Speaker diarization is supported using Pyannote Audio models.
-To enable diarization, you must request access to the Pyannote pretrained models and provide a Hugging Face access token.
+Speaker diarization labels each transcript line with the speaker who said it. Two backends are
+available:
+
+| Backend | Gated access | Speed (CPU) | Notes |
+| :--- | :--- | :--- | :--- |
+| `pyannote` (default) | Yes, Hugging Face token required | ~0.43x realtime | Detects overlapping speech |
+| `campplus` | No | ~0.01x realtime | FunASR VAD + CAM++, requires the funASR setup from section C |
+
+Steps a-c below set up the default pyannote backend. Skip to step d for CAM++.
 
 #### a. Request Model Access on Hugging Face
 
@@ -186,6 +193,33 @@ models:
 ```
 
 > **Note:** The diarization model downloads automatically on next startup once `diarization: true` is set.
+
+#### d. CAM++ Backend (funASR only)
+
+`campplus` needs no token and no gated access, but it requires `provider: funasr` and
+`name: paraformer-zh` from section C. Its speaker and VAD models are downloaded from ModelScope
+on first use and reused offline afterwards.
+
+```yaml
+models:
+  asr:
+    diarization: true
+  diarization:
+    backend: campplus
+```
+
+#### e. Whole-File Processing (funASR only)
+
+By default audio is transcribed and diarized in chunks, which streams results to the UI while
+the recording is still being processed. Setting `chunking: false` processes the whole recording
+in a single pass instead: speaker clustering sees all the speech at once, at the cost of no
+intermediate results. It also requires `provider: funasr` and `name: paraformer-zh`, and is
+ignored for microphone capture, where the recording is not available up front.
+
+```yaml
+audio_preprocessing:
+  chunking: false
+```
 
 **Important: After updating the configuration, reload the application for changes to take effect.**
 

--- a/education-ai-suite/smart-classroom/docs/user-guide/index.md
+++ b/education-ai-suite/smart-classroom/docs/user-guide/index.md
@@ -26,7 +26,7 @@ The main features are as follows:
 ## Audio Pipeline
 
 - **Audio transcription** with ASR models (e.g., Whisper, Paraformer)
-- **Speaker diarization** using Pyannote Audio models
+- **Speaker diarization** using Pyannote Audio models or FunASR CAM++
 - **Summarization** using LLMs (e.g., Qwen, LLaMA) optimized with OpenVINO
 - **MindMap generation** using Mermaid.js for visual diagram rendering
 - **Content segmentation** for automatic topic extraction from transcripts

--- a/education-ai-suite/smart-classroom/model_manager/features/asr_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/asr_feature.py
@@ -11,6 +11,7 @@ from components.ffmpeg import audio_preprocessing
 from dto.transcription_dto import TranscriptionRequest
 from pipeline import Pipeline
 from utils.audio_util import save_audio_file
+from utils.config_loader import config
 from utils.locks import audio_pipeline_lock
 
 logger = logging.getLogger(__name__)
@@ -119,6 +120,7 @@ class ASRFeature:
     def ui_descriptor(self) -> Dict:
         return {
             "id": self.id,
+            "chunking": bool(config.audio_preprocessing.chunking),
             "endpoints": {
                 "upload_audio": "/upload-audio",
                 "transcribe": "/transcribe",

--- a/education-ai-suite/smart-classroom/setup-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/setup-smart-classroom.ps1
@@ -1571,6 +1571,18 @@ function Test-HfTokenSet {
     $token = Get-HfTokenRaw -Content $Content
     return -not ([string]::IsNullOrWhiteSpace($token) -or $token -eq "None")
 }
+function Get-DiarizationBackend {
+    param([string]$Content)
+    $diarBlockMatch = [regex]::Match($Content, "(?ms)^  diarization:.*?(?=^  \S)")
+    $diarBlock = if ($diarBlockMatch.Success) { $diarBlockMatch.Value } else { "" }
+    $m = [regex]::Match($diarBlock, 'backend:\s*"?([\w-]+)"?')
+    if ($m.Success) { return $m.Groups[1].Value.ToLower() } else { return "pyannote" }
+}
+
+function Test-DiarizationNeedsHfToken {
+    param([string]$Content)
+    return (Get-DiarizationBackend -Content $Content) -ne "campplus"
+}
 
 # ============================================================================
 # Current Configuration Overview (shown before asking to configure config.yaml)
@@ -1590,10 +1602,10 @@ $currentDiarizationEnabled = if ($diarEnabledMatch.Success) { $diarEnabledMatch.
 $diarizationWasEnabled = ($currentDiarizationEnabled -match "(?i)^true$")
 
 Write-Host "  models.asr:" -ForegroundColor White
-Write-Host ("    {0,-20} enabled: {1}" -f "diarization:", $currentDiarizationEnabled) -ForegroundColor Gray
+Write-Host ("    {0,-20} enabled: {1}  (backend: {2})" -f "diarization:", $currentDiarizationEnabled, (Get-DiarizationBackend -Content $configContent)) -ForegroundColor Gray
 Write-Host ""
 
-if ($diarizationWasEnabled -and -not (Test-HfTokenSet -Content $configContent)) {
+if ($diarizationWasEnabled -and (Test-DiarizationNeedsHfToken -Content $configContent) -and -not (Test-HfTokenSet -Content $configContent)) {
     Write-Host "  [WARNING] Diarization is enabled but hf_token is None. It needs to be filled in." -ForegroundColor Red
     Write-Host "            See the setup guide:" -ForegroundColor Red
     Write-Host "            https://github.com/open-edge-platform/edge-ai-suites/blob/main/education-ai-suite/smart-classroom/docs/user-guide/advance-setup-guide.md#f-speaker-diarization-setup-optional" -ForegroundColor Red
@@ -1816,6 +1828,8 @@ Write-Host "Current Speaker Diarization configuration in config.yaml:" -Foregrou
 Write-Host ""
 Write-Host "  models.asr:" -ForegroundColor White
 Write-Host "    diarization: $currentDiarizationEnabled   # labels TEACHER/STUDENT_XX speakers in ASR transcripts" -ForegroundColor Gray
+Write-Host "  models.diarization:" -ForegroundColor White
+Write-Host "    backend: $(Get-DiarizationBackend -Content $configContent)" -ForegroundColor Gray
 Write-Host ""
 
 if ($Silent) {
@@ -1849,8 +1863,15 @@ if ($changeDiarization.ToUpper() -eq "Y") {
 }
 
 $diarizationJustEnabled = $diarizationIsEnabled -and (-not $diarizationWasEnabled)
+$diarizationNeedsHfToken = Test-DiarizationNeedsHfToken -Content $configContent
 
-if ($diarizationIsEnabled) {
+if ($diarizationIsEnabled -and -not $diarizationNeedsHfToken) {
+    Write-Host ""
+    Write-Host "  Backend 'campplus' (FunASR CAM++) needs no Hugging Face token or access request;" -ForegroundColor Gray
+    Write-Host "  its speaker model is downloaded automatically on first run." -ForegroundColor Gray
+}
+
+if ($diarizationIsEnabled -and $diarizationNeedsHfToken) {
     Write-Host ""
 
     # Resolve the diarization model's local cache path (mirrors utils/ensure_model.py::get_diarization_model_path)
@@ -2064,7 +2085,11 @@ $finalBoardOcr = Get-FeatureState -Content $finalConfig -Id "board_ocr"
 $csFlag  = $finalConfig -match "content_search:\s*\{\s*enabled:\s*true"
 $segFlag = $finalConfig -match "topic_segmentation:\s*\{\s*enabled:\s*true"
 $qaFlag  = $finalConfig -match "qa:\s*\{\s*enabled:\s*true"
-$contentSearchEnabled = $csFlag -or $segFlag -or $qaFlag
+$csTriggers = @()
+if ($csFlag)  { $csTriggers += "content_search" }
+if ($segFlag) { $csTriggers += "topic_segmentation" }
+if ($qaFlag)  { $csTriggers += "qa" }
+$contentSearchEnabled = $csTriggers.Count -gt 0
 
 Write-Host "  Features:" -ForegroundColor White
 foreach ($fid in $featureIds) {
@@ -2077,15 +2102,15 @@ Write-Host "  Language:        $finalLang" -ForegroundColor White
 Write-Host "  ASR Provider:    $finalProvider" -ForegroundColor White
 Write-Host "  ASR Model:       $finalAsrName" -ForegroundColor White
 Write-Host "  ASR Device:      $finalAsrDevice" -ForegroundColor White
-Write-Host "  Diarization:     $finalDiarization" -ForegroundColor White
-if ($finalDiarization -match "(?i)^true$" -and -not (Test-HfTokenSet -Content $finalConfig)) {
+Write-Host "  Diarization:     $finalDiarization$(if ($finalDiarization -match '(?i)^true$') { " (backend: $(Get-DiarizationBackend -Content $finalConfig))" })" -ForegroundColor White
+if ($finalDiarization -match "(?i)^true$" -and (Test-DiarizationNeedsHfToken -Content $finalConfig) -and -not (Test-HfTokenSet -Content $finalConfig)) {
     Write-Host "                   [WARNING] hf_token is None - diarization will not work until it is filled in" -ForegroundColor Red
 }
 Write-Host "  Doc Max (MB):    $finalDocMax" -ForegroundColor White
 Write-Host "  Video Max (MB):  $finalVideoMax" -ForegroundColor White
 Write-Host "  Document OCR:    $finalOcr" -ForegroundColor White
 Write-Host "  Board OCR:       $finalBoardOcr" -ForegroundColor White
-Write-Host "  Content Search:  $(if ($contentSearchEnabled) { 'Enabled' } else { 'Disabled' })" -ForegroundColor White
+Write-Host "  Content Search:  $(if ($contentSearchEnabled) { "Stack enabled (required by: $($csTriggers -join ', '))" } else { 'Stack disabled' })" -ForegroundColor White
 Write-Host ""
 
 # ============================================================================

--- a/education-ai-suite/smart-classroom/ui/src/assets/css/TranscriptsTab.css
+++ b/education-ai-suite/smart-classroom/ui/src/assets/css/TranscriptsTab.css
@@ -116,6 +116,31 @@
   font-style: italic;
 }
 
+.transcript-processing-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.6em;
+  padding: 0.8em 1em;
+  border-radius: 0.75em;
+  background: #eef4ff;
+  color: #1b4f72;
+  font-size: 0.9rem;
+}
+
+.transcript-processing-spinner {
+  flex: 0 0 auto;
+  width: 1em;
+  height: 1em;
+  border: 2px solid #b7d0f2;
+  border-top-color: #1b4f72;
+  border-radius: 50%;
+  animation: transcript-spin 0.9s linear infinite;
+}
+
+@keyframes transcript-spin {
+  to { transform: rotate(360deg); }
+}
+
 .typewriter-cursor {
   font-weight: bold;
   color: #007bff;

--- a/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
+++ b/education-ai-suite/smart-classroom/ui/src/components/Tabs/TranscriptsTab.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 import { useAppDispatch, useAppSelector } from "../../redux/hooks";
 import {
   appendTranscriptChunk,
@@ -45,6 +46,7 @@ const SPEAKER_LABELS: Record<
 
 const TranscriptsTab: React.FC = () => {
   const dispatch = useAppDispatch();
+  const { t } = useTranslation();
   const streamStartedRef = useRef(false);
   const transcriptionStartedRef = useRef(false);
   const finishedRef = useRef(false);
@@ -57,6 +59,7 @@ const TranscriptsTab: React.FC = () => {
   // Check if summary feature is enabled in backend
   const { guard, loaded: featuresLoaded } = useFeatureConfig();
   const hasSummaryFeature = featuresLoaded && guard.hasFeature('summary');
+  const asrChunkingEnabled = !featuresLoaded || guard.isAsrChunkingEnabled();
 
   const [segmentDisplayTexts, setSegmentDisplayTexts] = useState<string[]>([]);
   const [groupedSegments, setGroupedSegments] = useState<GroupedSegment[]>([]);
@@ -503,9 +506,23 @@ const TranscriptsTab: React.FC = () => {
     [renderedGroups]
   );
 
+  // Whole-file mode emits nothing until the entire recording is transcribed
+  const showWholeFileNotice =
+    !asrChunkingEnabled &&
+    aiProcessing &&
+    !transcriptionDone &&
+    uploadedAudioPath !== "MICROPHONE" &&
+    visibleGroups.length === 0;
+
   return (
     <div className="transcripts-tab chat-ui-root">
       <div className="transcript-content chat-ui-content">
+        {showWholeFileNotice && (
+          <div className="transcript-placeholder transcript-processing-notice">
+            <span className="transcript-processing-spinner" aria-hidden="true" />
+            <span>{t('transcript.processingWholeFile')}</span>
+          </div>
+        )}
         {visibleGroups.length > 0 && (
           <div className="transcript-list chat-ui-list">
             {visibleGroups.map((group) => (

--- a/education-ai-suite/smart-classroom/ui/src/i18n/en.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/en.json
@@ -113,6 +113,10 @@
       "summary": "AI Summary",
       "mindmap":"Mind Map"
     },
+
+    "transcript": {
+      "processingWholeFile": "Transcribing the whole recording in a single pass — the transcript appears once processing finishes. Please wait…"
+    },
   
   "accordion": {
       "noData": "No data available",

--- a/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
+++ b/education-ai-suite/smart-classroom/ui/src/i18n/zh.json
@@ -114,6 +114,10 @@
     "mindmap":"思维导图"
   },
 
+  "transcript": {
+    "processingWholeFile": "正在一次性转录整段录音，处理完成后才会显示转录内容，请耐心等待…"
+  },
+
   "accordion": {
     "noData": "暂无数据",
     "noSessionActive": "无活动会话。请上传文件或开始录音以开始监控。",

--- a/education-ai-suite/smart-classroom/ui/src/redux/slices/featureConfigSlice.ts
+++ b/education-ai-suite/smart-classroom/ui/src/redux/slices/featureConfigSlice.ts
@@ -11,6 +11,7 @@ export interface FeatureDescriptor {
   // Optional UI-specific fields
   endpoints?: Record<string, string>;
   mode?: string;
+  chunking?: boolean;
 }
 
 interface FeatureConfigState {

--- a/education-ai-suite/smart-classroom/ui/src/services/api.ts
+++ b/education-ai-suite/smart-classroom/ui/src/services/api.ts
@@ -59,6 +59,7 @@ export interface FeatureDescriptor {
   requires: string[];
   endpoints?: Record<string, string>;
   mode?: string;
+  chunking?: boolean;
 }
 
 /**

--- a/education-ai-suite/smart-classroom/ui/src/utils/featureGuards.ts
+++ b/education-ai-suite/smart-classroom/ui/src/utils/featureGuards.ts
@@ -65,6 +65,14 @@ export class FeatureGuard {
   }
 
   /**
+   * Whether ASR streams partial transcripts. When false, an uploaded file is
+   * transcribed in a single pass and nothing shows up until it completes.
+   */
+  isAsrChunkingEnabled(): boolean {
+    return this.featureMap.get('asr')?.chunking !== false;
+  }
+
+  /**
    * Get list of all enabled feature IDs
    */
   getEnabledFeatures(): string[] {

--- a/education-ai-suite/smart-classroom/utils/pipeline_modes.py
+++ b/education-ai-suite/smart-classroom/utils/pipeline_modes.py
@@ -1,0 +1,60 @@
+"""Chunking and diarization-backend resolution for the audio pipeline.
+
+Kept out of ``utils/config_loader`` because that module is imported by every feature at
+startup and must not raise on a transcription-only misconfiguration.
+"""
+import logging
+from typing import Optional
+
+from dto.audiosource import AudioSource
+from utils.config_loader import config
+
+logger = logging.getLogger(__name__)
+
+BACKENDS = ("pyannote", "campplus")
+
+# Whole-file processing and the CAM++ backend are only supported on this ASR stack:
+# FunASR runs long audio natively, and the CAM++ speaker model is Mandarin-tuned.
+FUNASR_PARAFORMER = ("funasr", "paraformer-zh")
+
+
+def _is_funasr_paraformer() -> bool:
+    asr = config.models.asr
+    return (str(asr.provider).lower(), str(asr.name).lower()) == FUNASR_PARAFORMER
+
+
+def _require_funasr_paraformer(key: str, value) -> None:
+    if not _is_funasr_paraformer():
+        asr = config.models.asr
+        raise ValueError(
+            f"{key}={value} requires models.asr.provider=funasr and "
+            f"models.asr.name=paraformer-zh, got {asr.provider}/{asr.name}."
+        )
+
+
+def resolve_chunking(source_type: Optional[AudioSource] = None) -> bool:
+    """True to process audio in chunks, False for a single pass over the whole recording."""
+    if config.audio_preprocessing.chunking:
+        return True
+
+    if source_type == AudioSource.MICROPHONE:
+        logger.warning(
+            "audio_preprocessing.chunking=false is not supported for microphone capture "
+            "(the recording is not available up front); using chunked processing."
+        )
+        return True
+
+    _require_funasr_paraformer("audio_preprocessing.chunking", False)
+    return False
+
+
+def resolve_diarization_backend() -> str:
+    backend = str(config.models.diarization.backend).lower()
+    if backend not in BACKENDS:
+        raise ValueError(
+            f"Unsupported models.diarization.backend={backend}, "
+            f"expected one of {list(BACKENDS)}."
+        )
+    if backend == "campplus":
+        _require_funasr_paraformer("models.diarization.backend", backend)
+    return backend


### PR DESCRIPTION
### Description

Refactors the speaker diarization infrastructure to support multiple backends (pyannote and FunASR CAM++), introduces a global speaker identity registry to maintain consistent speaker labels across audio chunks, and makes chunking behavior configurable. The main changes include abstraction and unification of diarization logic, backend-specific implementations, a factory for backend selection, and configuration updates for easier backend and chunking management.

- Introduced `GlobalSpeakerDiarizer` as a shared base class for diarization backends, handling global speaker identity mapping and embedding similarity logic. 
- Refactored `PyannoteDiarizer` to inherit from `GlobalSpeakerDiarizer`
- Added `CamPlusPlusDiarizer`, a FunASR CAM++-based diarization backend, supporting efficient chunked or whole-file diarization with VAD, embedding, and clustering. (`campplus_diarizer.py`)
- Made audio chunking behavior configurable via the `chunking` setting(only for funasr). Added logic to pass through the whole file as a single chunk if chunking is disabled. (`audio_preprocessing.py`)
- Updated `config.yaml` to support selecting the diarization backend (`pyannote` or `campplus`) and to control chunking behavior. (`config.yaml`)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

