### PR TITLE
[DOCS] Improve cross-linking to existing official docs - 2026.2

### DIFF
--- a/federal-aerospace/docs/deterministic-threat-detection/user-guide/how-to-guides/scenescape-deterministic-inference/integrate-basler-camera-with-scenescape.md
+++ b/federal-aerospace/docs/deterministic-threat-detection/user-guide/how-to-guides/scenescape-deterministic-inference/integrate-basler-camera-with-scenescape.md
@@ -26,7 +26,7 @@ cd scenescape
 
 The standard DL Streamer Pipeline Server image does not include the Basler pylon SDK or the `gencamsrc` GStreamer plugin. Follow the instructions below to build a custom image:
 
-[Integrate Pylon SDK — Step 2: Create the Docker Image](https://github.com/open-edge-platform/edge-ai-suites/blob/main/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/integrate-pylon-sdk.md#step-2-create-the-docker-image)
+[Integrate Pylon SDK — Step 2: Create the Docker Image](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-suites/ai-suite-manufacturing/industrial-edge-insights-vision/pallet-defect-detection/how-to-guides/integrate-camera-sdks.html#step-2-create-the-docker-image)
 
 > **Note:** Patch `gencamsrc` to propagate the PTP timestamp before building the image. By default, `gencamsrc` discards the camera's PTP hardware timestamp after setting the GStreamer buffer PTS. The following patch adds a `GstReferenceTimestampMeta` to each buffer so downstream elements such as `gvapython` can read the original camera timestamp before any clock correction occurs.
 

--- a/federal-aerospace/docs/handheld-multi-modal/user-guide/release-notes.md
+++ b/federal-aerospace/docs/handheld-multi-modal/user-guide/release-notes.md
@@ -14,10 +14,10 @@ compliance (Size, Weight, Power, and Cost).
 
 The application introduces the following features:
 
-- Deployment on top of [Edge Node Infrastructure Blueprint](https://docs.openedgeplatform.intel.com/main/edge-ai-suites/ai-suite-federal-and-aerospace/edge-node-infrastructure-blueprint/index.html), an edge computing platform that enables hardware acceleration capabilities
+- Deployment on top of [Edge Node Infrastructure Blueprint](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-suites/ai-suite-federal-and-aerospace/edge-node-infrastructure-blueprint/index.html), an edge computing platform that enables hardware acceleration capabilities
 - Text and audio modality support through Conversational Agent exposed via Chat UI that is backed by LLM served by OpenVINO Model Server
 - Audio modality support through Speech To Text Service (Whisper)
-- Visual modality support through [Visual Pipeline and Platform Evaluation Tool](https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/visual-pipeline-and-platform-evaluation-tool/index.html).
+- Visual modality support through [Visual Pipeline and Platform Evaluation Tool](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/visual-pipeline-and-platform-evaluation-tool/index.html).
 - Insight into application and platform metrics through the Observability Dashboard
 
 **Known issues and limitations**

--- a/manufacturing-ai-suite/hmi-augmented-worker/docs/user-guide/get-started.md
+++ b/manufacturing-ai-suite/hmi-augmented-worker/docs/user-guide/get-started.md
@@ -118,8 +118,8 @@ To use the application effectively, make sure that all the steps mentioned in th
 - [Edge Microvisor Toolkit Main Page](https://github.com/open-edge-platform/edge-microvisor-toolkit)
 - [Create Edge Microvisor Toolkit bootable USB drive using source code](https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node/blob/main/standalone-node/docs/user-guide/get-started-guide.md#create-a-bootable-usb-drive-using-source-code)
 - [Desktop Virtualization on Edge Microvisor Toolkit](https://github.com/open-edge-platform/edge-microvisor-toolkit-standalone-node/blob/main/standalone-node/docs/user-guide/desktop-virtualization-image-guide.md)
-- [Edge Microvisor Toolkit Documentation](https://github.com/open-edge-platform/edge-microvisor-toolkit/tree/3.0/docs/developer-guide)
-- [Chat Question & Answer Core Main Page](https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/sample-applications/chat-question-and-answer-core)
+- [Edge Microvisor Toolkit Documentation](https://docs.openedgeplatform.intel.com/2026.2/edge-microvisor-toolkit/index.html)
+- [Chat Question & Answer Core Main Page](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/chat-question-and-answer-core/index.html)
 
 <!--hide_directive
 :::{toctree}

--- a/manufacturing-ai-suite/hmi-augmented-worker/docs/user-guide/get-started/system-requirements.md
+++ b/manufacturing-ai-suite/hmi-augmented-worker/docs/user-guide/get-started/system-requirements.md
@@ -4,7 +4,7 @@ This page provides detailed hardware, software, and platform requirements to hel
 
 ## Hardware Platforms used for validation
 
-The `Chat Question & Answer Core` sample application system requirements are documented in [this](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/sample-applications/chat-question-and-answer-core/docs/user-guide/get-started/system-requirements.md) page. The Intel® Core&trade; portfolio mentioned in this page is applicable for `HMI Augmented Worker` sample application too. The delta configurations supported is further described in this page.
+The `Chat Question & Answer Core` sample application system requirements are documented on [this](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/chat-question-and-answer-core/get-started/system-requirements.html) page. The Intel® Core&trade; portfolio mentioned in this page is applicable for `HMI Augmented Worker` sample application too. The delta configurations supported is further described in this page.
 
 The `HMI Augmented worker` sample application has been validated on Intel® Core&trade; i7-14700 based systems. The memory configuration used was 32GB, which is the recommended minimum configuration. This machine hosts an Edge Microvisor Toolkit based host together with Windows VM.
 
@@ -13,7 +13,7 @@ The `HMI Augmented worker` sample application has been validated on Intel® Core
 Required Software:
 
 - Python 3.10
-- [Edge Microvisor Toolkit](https://github.com/open-edge-platform/edge-microvisor-toolkit) configuration requirements are documented in its [system requirement](https://github.com/open-edge-platform/edge-microvisor-toolkit/blob/3.0/docs/developer-guide/emt-system-requirements.md) page.
+- [Edge Microvisor Toolkit](https://docs.openedgeplatform.intel.com/2026.2/edge-microvisor-toolkit/index.html) configuration requirements are documented in its [system requirement](https://docs.openedgeplatform.intel.com/2026.2/edge-microvisor-toolkit/emt-system-requirements.html) page.
 
 ## Supporting Resources
 

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/docs/user-guide/how-to-guides/gpu-npu-stream-density-benchmark.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/docs/user-guide/how-to-guides/gpu-npu-stream-density-benchmark.md
@@ -1,14 +1,11 @@
 # Demonstrating NPU Value: GPU and NPU Stream Density Benchmark
 
 This document describes a structured benchmark workflow to demonstrate the value of Neural
-Processing Unit (NPU) offloading in the [Smart Parking](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking)
-application. The workflow has three parts:
-
+Processing Unit (NPU) offloading in the Smart Parking application. The workflow has three parts:
 
 1. [Establish the best GPU-only stream density baseline](#part-1-gpu-baseline---peak-stream-density)
 2. [Establish the best NPU-only stream density baseline](#part-2-npu-baseline---peak-stream-density)
-3. [Establish the best combined stream density with GPU and NPU pipelines running together](#part-3-combined-baseline---gpu-and-npu-simultaneously-gpu--npu)
-
+3. [Establish the best combined stream density with GPU and NPU pipelines running together](#part-3-combined-baseline---gpu-and-npu-simultaneously-gpunpu)
 
 ---
 
@@ -35,7 +32,6 @@ Use the `yolov11s_gpu` pipeline as defined in
 [smart-parking/benchmark_app_payload.json](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/benchmark_app_payload.json).
 The pipeline uses the original configuration; note that metro pipelines are latency-focused by
 default.
-
 
 ### Run the GPU Stream Density Benchmark
 
@@ -78,6 +74,7 @@ For detailed metric definitions and KPI interpretation, refer to
   of the decode and inference compute (see Fig. 2).
 
 ### Part 1 Section Summary
+
 - **Standalone GPU ceiling**: `Stream Density(GPU)(9)` at target FPS.
 - **Hardware takeaway**: GPU engines carry primary inference/media load (see Fig. 1), while
   CPU is mainly utilized for host-side data-feeding tasks (see Fig. 2).
@@ -85,11 +82,11 @@ For detailed metric definitions and KPI interpretation, refer to
 **Supporting screenshots (cropped to include only benchmark-relevant telemetry)**:
 ![GPU telemetry (qmassa) at 9 streams](../_assets/npu-val-add/gpu_9_focus.png)
 
- *Fig. 1: GPU telemetry (qmassa) at 9 streams*
+_Fig. 1: GPU telemetry (qmassa) at 9 streams_
 
 ![CPU telemetry (htop) during GPU baseline run](../_assets/npu-val-add/cpu_9_focus.png)
 
- *Fig. 2: CPU telemetry (htop) during GPU baseline run*
+_Fig. 2: CPU telemetry (htop) during GPU baseline run_
 
 ---
 
@@ -140,6 +137,7 @@ For detailed metric definitions and KPI interpretation, refer to
     signals visible during the same run.
 
 ### Part 2 Section Summary
+
 - **Standalone NPU ceiling**: `Stream Density(NPU)(7)` at target FPS.
 - **Hardware takeaway**: NPU carries inference load (see Fig. 3), and GPU decode/frame-handling
   activity (`VCS`/`VECS`) remains part of the end-to-end path (see Fig. 4).
@@ -148,11 +146,11 @@ For detailed metric definitions and KPI interpretation, refer to
 
 ![NPU telemetry monitor at 7 streams](../_assets/npu-val-add/npu_7_monitor_focus.png)
 
-*Fig. 3: NPU telemetry (npu-monitor-tool) at 7 streams*
+_Fig. 3: NPU telemetry (npu-monitor-tool) at 7 streams_
 
 ![GPU/qmassa telemetry during NPU baseline run](../_assets/npu-val-add/npu_7_qmassa_focus.png)
 
-*Fig. 4: GPU telemetry (qmassa) during NPU baseline run*
+_Fig. 4: GPU telemetry (qmassa) during NPU baseline run_
 
 ---
 
@@ -171,12 +169,12 @@ This section evaluates the best performance when **GPU and NPU pipelines run sim
   streams.
 
 > **Note:** In this document, `GPU!NPU` is shorthand for the combined run (GPU and NPU
-  together), not logical negation.
+> together), not logical negation.
 
 ### Run the Combined Stream Density Benchmark
 
 Run the combined workflow with 7 GPU streams and 5 NPU streams, using **nstreams** mode from
-[Benchmark Performance](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking/docs/user-guide/how-to-guides/benchmark.md):
+[Benchmark Performance](./benchmark.md):
 
 ```bash
 # Navigate to the metro-vision-ai-app-recipe directory
@@ -188,21 +186,21 @@ cd edge-ai-suites/metro-ai-suite/metro-vision-ai-app-recipe/
 
 ### Example Results (GPU!NPU)
 
-| Symbol | Value | Notes |
-|---|---:|---|
-| Stream Density(GPU) | 9 | GPU-only peak stream density |
-| Stream Density(NPU) | 7 | NPU-only peak stream density |
-| Stream Density(GPU!NPU) | 12 | Combined run with 7 GPU streams and 5 NPU streams |
-| Throughput median | 29.8523 | Combined run KPI |
-| Throughput average | 29.9193 | Combined run KPI |
-| Throughput cumulative | 359.031 | Combined run KPI |
-| Throughput min | 29.8098 | Combined run KPI |
+| Symbol                  |   Value | Notes                                             |
+| ----------------------- | ------: | ------------------------------------------------- |
+| Stream Density(GPU)     |       9 | GPU-only peak stream density                      |
+| Stream Density(NPU)     |       7 | NPU-only peak stream density                      |
+| Stream Density(GPU!NPU) |      12 | Combined run with 7 GPU streams and 5 NPU streams |
+| Throughput median       | 29.8523 | Combined run KPI                                  |
+| Throughput average      | 29.9193 | Combined run KPI                                  |
+| Throughput cumulative   | 359.031 | Combined run KPI                                  |
+| Throughput min          | 29.8098 | Combined run KPI                                  |
 
 For detailed metric definitions and KPI interpretation, refer to
 [Benchmark Performance](./benchmark.md).
 
-
 ### Part 3 Section Summary
+
 - **Combined stream density**: `Stream Density(GPU!NPU)(12)`
 - **GPU stream share**: `7`
 - **NPU stream share**: `5`
@@ -215,11 +213,11 @@ shown in Fig. 6.
 
 ![Combined GPU telemetry at 7 GPU streams](<../_assets/npu-val-add/gpu_npu_7_5(qmassa).png>)
 
-*Fig. 5: Combined run, GPU telemetry (qmassa) at 7 GPU streams*
+_Fig. 5: Combined run, GPU telemetry (qmassa) at 7 GPU streams_
 
 ![Combined NPU telemetry at 5 NPU streams](<../_assets/npu-val-add/gpu_npu_7_5(npu).v3.png>)
 
-*Fig. 6: Combined NPU telemetry (npu-monitor-tool) at 5 NPU streams*
+_Fig. 6: Combined NPU telemetry (npu-monitor-tool) at 5 NPU streams_
 
 ---
 
@@ -233,12 +231,11 @@ shown in Fig. 6.
 - [Part 3 Section Summary](#part-3-section-summary) shows the combined result
   `Stream Density(GPU!NPU)(12)` with 7 GPU streams and 5 NPU streams.
 
-Overall, **NPU offloading provides clear system-level value addition** for
-[Smart Parking](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-parking).
+Overall, **NPU offloading provides clear system-level value addition** for Smart Parking.
 Applying a tuned backoff (for example, 2 streams per pipeline on this platform) creates GPU
 headroom for NPU-related media work, and enables higher total stream density than either
 standalone path while maintaining stable throughput.
 
 > **Note:** The values in this document are example reference results. Actual stream density
-  and throughput can vary by platform setup, software stack, and runtime conditions. Re-run the
-  benchmark in your target environment to validate expected behavior.
+> and throughput can vary by platform setup, software stack, and runtime conditions. Re-run the
+> benchmark in your target environment to validate expected behavior.

--- a/robotics-ai-suite/docs/robotics/dev_guide/gmsl-guide/configure-gmsl-serdes-acpi.md
+++ b/robotics-ai-suite/docs/robotics/dev_guide/gmsl-guide/configure-gmsl-serdes-acpi.md
@@ -307,7 +307,7 @@ To enable multiple GMSL cameras, for the same or different vendors, define the M
    <!--hide_directive:::::
    :::::{tab-item}hide_directive--> **Axiomtek® ROBOX500**
 
-   The [Axiomtek® ROBOX500](https://www.axiomtek.com/ROBOX500/) may provide either 4x GMSL or 8x GMSL camera interfaces (FAKRA universal type).
+   The [Axiomtek® ROBOX500](https://www.axiomtek.com/products/intelligent-solutions/autonomous-mobile-robots/amr-controller/robox500) may provide either 4x GMSL or 8x GMSL camera interfaces (FAKRA universal type).
 
    <!--hide_directive::::{tab-set}
    :::{tab-item}hide_directive--> **RealSense™ D457**

--- a/robotics-ai-suite/docs/robotics/gsg_robot/index.md
+++ b/robotics-ai-suite/docs/robotics/gsg_robot/index.md
@@ -115,7 +115,7 @@ An alternative method for setup is to create a pre-configured OS image with ROS 
 
 Image Composer Tool supports creating both ISO images (for installation via USB) and raw disk images (for direct deployment to storage devices or VMs). ISO images are suitable for interactive installations, while raw images can be directly written to storage media or VMs for immediate use. If you prefer to start with a base Ubuntu installation, without needing to reimage a system, use the [Express Setup](#express-setup) or the [Step-by-step Setup](#step-by-step-setup) guide.
 
-For detailed instructions, see the [Image Composer Tool installation guide](https://docs.openedgeplatform.intel.com/dev/image-composer-tool/tutorial/installation.html). An abbreviated ISO image creation follows:
+For detailed instructions, see the [Image Composer Tool installation guide](https://docs.openedgeplatform.intel.com/2026.2/image-composer-tool/get-started/installation.html). An abbreviated ISO image creation follows:
 
 1. Install Go (Go 1.24+ required) + build dependencies:
 


### PR DESCRIPTION
### Description

This is a continuation of the effort from #3365 and should nearly complete it (there is a minor update incoming in a separate PR).

- Update/fix links from GH to OEP URLs for targets inside `/docs/user-guide/` for components published on the OEP site
- fix some broken external links

Port from #3732 

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.