### PR TITLE
Added demo mode to metro-ai-apps-recipe

### DIFF
--- a/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/SKILL.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/SKILL.md
@@ -9,9 +9,12 @@ description: >-
   spatial-analysis path. USE FOR standing up an object-detection, classification,
   counting, or zone-alerting pipeline for any vertical (smart city/ITS, retail,
   industrial, logistics, healthcare, or a custom OpenVINO/ONNX model) where only
-  the model, class filter, alert rule, and dashboard change. DO NOT USE FOR
-  non-Intel or cloud-only deployments, Prometheus/OpenTelemetry metrics stacks,
-  or training and exporting models.
+  the model, class filter, alert rule, and dashboard change. Also USE FOR a
+  lightweight **demo/PoC** single application (no full stack) — a simple DL
+  Streamer pipeline (via the `dlstreamer-coding-agent` skill) or a simple
+  OpenVINO inference app (guided by the OpenVINO 2026 docs) selected via the
+  mode question. DO NOT USE FOR non-Intel or cloud-only deployments,
+  Prometheus/OpenTelemetry metrics stacks, or training and exporting models.
 license: Apache-2.0
 compatibility: >-
   Requires Docker + Docker Compose v2, host with Intel CPU (and optionally
@@ -67,14 +70,19 @@ skeleton changes across verticals.
 ## How to use this skill
 
 1. Read this file end-to-end.
-2. Ask the 7 questions in ONE batched message (defaults in brackets); accept
+2. Ask **Question 0 (mode)** first. If the user selects **Demo/PoC**, branch
+   immediately to the [Demo/PoC mode](#demopoc-mode) section and load
+   [`references/DEMO_POC.md`](references/DEMO_POC.md) — skip questions 1–7 and
+   the full-stack build entirely. Otherwise (**Full-stack production**, the
+   default) continue with the steps below.
+3. Ask the 7 questions in ONE batched message (defaults in brackets); accept
    `go` / `defaults` / empty to proceed. Question 7 selects the **SceneScape**
    opt-in spatial-analysis path.
-3. Run parameter validation (see below). Refuse to proceed on any failure.
-4. Load reference file(s) on demand per component — **do not load all up
+4. Run parameter validation (see below). Refuse to proceed on any failure.
+5. Load reference file(s) on demand per component — **do not load all up
    front**. Load [`references/SCENESCAPE.md`](references/SCENESCAPE.md) only
    when `{{SCENESCAPE}}=yes`.
-5. Verify against the completion criteria before declaring success, and
+6. Verify against the completion criteria before declaring success, and
    record measured throughput/latency against the baselines in `benchmark.md`.
 
 ## Reference files (load on demand)
@@ -87,11 +95,13 @@ skeleton changes across verticals.
 | [`references/INSTALL.md`](references/INSTALL.md) | `.env`, `validate_env.sh`, `install.sh`, `docker-compose.yml` (MediaMTX + Coturn) volumes |
 | [`references/TESTS.md`](references/TESTS.md) | `conftest.py`, `test_webrtc_stream.py`, assertion contracts for other tests |
 | [`references/SCENESCAPE.md`](references/SCENESCAPE.md) | **Only when `{{SCENESCAPE}}=yes`** — opt-in multi-camera scene-fusion path (Scene Controller + InfluxDB + Grafana Flux + Scene Management UI), delegating to the external `scenescape-setup` skill |
+| [`references/DEMO_POC.md`](references/DEMO_POC.md) | **Only when `{{MODE}}=demo`** — lightweight single-app demo/PoC path: simple DL Streamer pipeline (via `dlstreamer-coding-agent`) or simple OpenVINO inference app (via OpenVINO 2026 docs); no full stack |
 
 ## Parameters (from invoking prompt)
 
 | Param | Purpose |
 |---|---|
+| `{{MODE}}` | `demo` \| `production` (default `production`). `demo` selects the lightweight single-app demo/PoC path — see [`references/DEMO_POC.md`](references/DEMO_POC.md); parameters below apply only to `production` |
 | `{{OBJECT}}` | class label in dashboard/alerts (e.g. `person`, `vehicle`, `hardhat`, `defect`, `fall`) — any string valid for MQTT topics and Grafana titles |
 | `{{STACK_DIR}}` | e.g. `person-detect-stack`, `ppe-compliance-stack`, `retail-queue-stack`, `anpr-stack` |
 | `{{DEFAULT_MODEL}}`, `{{OTHER_MODELS}}` | allowed model options |
@@ -113,6 +123,11 @@ skeleton changes across verticals.
 
 ## Questions (single batched prompt)
 
+**Question 0 — Mode** [`production`]: `demo` (lightweight single-app PoC) or
+`production` (full end-to-end stack). If `demo`, STOP here and follow
+[Demo/PoC mode](#demopoc-mode) / [`references/DEMO_POC.md`](references/DEMO_POC.md);
+do **not** ask questions 1–7. Questions 1–7 below apply only to `production`.
+
 1. Model [`{{DEFAULT_MODEL}}`] (also: `{{OTHER_MODELS}}`)
 2. Classifier [`{{CLASSIFIER}}`] (or `none`)
 3. Device [CPU] (GPU, NPU, AUTO)
@@ -131,6 +146,7 @@ and call as step 0 of `install.sh`. Rules:
 
 | Param | Rule | Failure mode |
 |---|---|---|
+| `MODE` | `demo`\|`production` | wrong path selected |
 | `HOST_IP` | `^([0-9]{1,3}\.){3}[0-9]{1,3}$`, not `0.0.0.0`/`127.0.0.1` | LAN clients can't reach Grafana |
 | `NUM_SOURCES` | int, 1–16 | CPU saturates before REST launcher finishes |
 | `DEVICE` | `cpu`\|`gpu`\|`npu`\|`auto` | REST 404 on missing variant |
@@ -165,6 +181,24 @@ DLSPS ─WebRTC/WHIP───────▶ MediaMTX (peer-id={{DETECTIONS_TOPI
                               │
                          Grafana <iframe src="/mediamtx/{{DETECTIONS_TOPIC_PREFIX}}_N/">
 ```
+
+## Demo/PoC mode
+
+When Question 0 selects `demo`, **do not build the full stack** — no Docker
+Compose topology, no MediaMTX/Coturn/Node-RED/Grafana/Nginx, no SceneScape.
+Instead produce a single lightweight application that proves a model runs on
+Intel hardware and emits inference output. Two sub-paths (ask the user which):
+
+- **DL Streamer app** — a simple DL Streamer / GStreamer pipeline (detect and
+  overlay/print results). Delegate to the `dlstreamer-coding-agent` skill.
+- **OpenVINO app** — a minimal Python inference script using the OpenVINO
+  runtime (load → `compile_model` → infer → post-process). No dedicated skill
+  exists; follow the OpenVINO 2026 docs.
+
+Full authoring guidance, delegation details, and the lightweight completion
+criteria live in [`references/DEMO_POC.md`](references/DEMO_POC.md) — load it
+only on this branch. The production completion criteria (1–11 below) do **not**
+apply in demo mode.
 
 ## SceneScape spatial-analysis path (optional, `{{SCENESCAPE}}=yes`)
 
@@ -256,7 +290,8 @@ JSON, or the test files is a syntax error.
 
 If available in the session, invoke; otherwise write files from the reference
 templates.
-- `dlstreamer-coding-agent` — pipeline JSON authoring
+- `dlstreamer-coding-agent` — pipeline JSON authoring (also the **demo/PoC** DL Streamer single-app path when `{{MODE}}=demo`)
+- `dlsps-user` (open-edge-platform/skills) — DL Streamer Pipeline Server deploy/config/REST operations; invoke when building the **full-stack multi-microservice** app that runs DLSPS (this recipe's default `{{MODE}}=production` path — see [`references/PIPELINE.md`](references/PIPELINE.md))
 - `model-download` (open-edge-platform/edge-ai-libraries) — OMZ model IR
 - `scenescape-setup` (open-edge-platform/skills) — **only when `{{SCENESCAPE}}=yes`**; orchestrates the multi-camera SceneScape deploy (see [`references/SCENESCAPE.md`](references/SCENESCAPE.md))
 

--- a/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/references/DEMO_POC.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/references/DEMO_POC.md
@@ -1,0 +1,128 @@
+<!--
+SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Demo/PoC mode reference (`{{MODE}}=demo`)
+
+Load this file **only** when Question 0 selected `demo`. The goal is a
+**single, lightweight application** that proves an AI model runs on Intel
+hardware and produces inference output — nothing else. Explicitly do **not**:
+
+- generate a Docker Compose stack, `.env`, `install.sh`, or the `{{STACK_DIR}}/`
+  layout from the main skill;
+- stand up MediaMTX/WebRTC, Coturn, Mosquitto, Node-RED, Grafana, or Nginx;
+- run parameter validation or the production completion criteria (1–11).
+
+Ask the user **one** question to pick a sub-path, then follow it:
+
+> Demo/PoC framework? `dlstreamer` (video-analytics pipeline) or
+> `openvino` (minimal inference script). [default `dlstreamer`]
+
+Keep the scope tiny: one model, one input, one device. Confirm the app runs
+and prints/overlays results, then stop.
+
+## Sub-path A — DL Streamer demo app (`dlstreamer`)
+
+Best when the demo is a **video-analytics pipeline** (decode → infer →
+overlay/print detections) on a file, RTSP stream, or `/dev/video*` camera.
+
+**Delegate to the `dlstreamer-coding-agent` skill** (open-edge-platform/skills)
+when it is available in the session — it translates a natural-language pipeline
+description into a working DL Streamer app (Python, C/C++, or a `gst-launch-1.0`
+command line). Pass it the minimal inputs:
+
+| Input | Example | Notes |
+|---|---|---|
+| Task | object detection / classification | one task only for a PoC |
+| Model | `yolov11s` (OpenVINO IR) | reuse an OMZ / DL Streamer model; `model-download` skill can fetch IR |
+| Input source | `file:///path/sample.mp4`, `rtsp://…`, `/dev/video0` | one source |
+| Device | `CPU` (default), `GPU`, `NPU`, `AUTO` | Intel target |
+| Output | `gvawatermark` overlay + `gvametaconvert`/`gvametapublish` to stdout | no MQTT/WebRTC needed for a PoC |
+
+If the skill is **not** available, hand-write a minimal pipeline, e.g.:
+
+```bash
+gst-launch-1.0 filesrc location=sample.mp4 ! decodebin ! \
+  gvadetect model=yolov11s.xml device=CPU ! gvawatermark ! \
+  gvametaconvert ! gvametapublish method=file file-path=/dev/stdout ! \
+  fakesink sync=false
+```
+
+Swap `gvadetect` device to `GPU`/`NPU` per the user's choice; add a single
+`gvaclassify` stage only if a classifier was requested.
+
+**Done when:** the pipeline runs to EOS (or steady state for live sources) and
+prints detection metadata (and/or writes an annotated output) without errors.
+
+## Sub-path B — OpenVINO demo app (`openvino`)
+
+Best when the demo is a **standalone inference script** over an image/video or
+a non-video model, with no GStreamer dependency.
+
+There is **no dedicated OpenVINO skill** — follow the OpenVINO 2026
+documentation as the authoritative reference:
+
+- Get Started / install: <https://docs.openvino.ai/2026/index.html>
+- Python API (`ov.Core`, `read_model`, `compile_model`, `infer`)
+- Model conversion (`ov.convert_model`) and OpenVINO IR (`.xml`/`.bin`)
+
+Minimal pattern (adapt model/pre/post-processing to the chosen model):
+
+```python
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+import cv2
+import numpy as np
+import openvino as ov
+
+DEVICE = "CPU"  # or "GPU", "NPU", "AUTO"
+
+core = ov.Core()
+model = core.read_model("model.xml")          # OpenVINO IR (or an .onnx model)
+compiled = core.compile_model(model, DEVICE)
+out_port = compiled.output(0)
+
+img = cv2.imread("sample.jpg")
+_, _, h, w = compiled.input(0).shape          # NCHW
+blob = cv2.resize(img, (w, h)).transpose(2, 0, 1)[np.newaxis, ...].astype(np.float32)
+
+result = compiled([blob])[out_port]           # run inference
+print("output shape:", result.shape)          # post-process per model spec
+```
+
+Guidance:
+
+- Install with `pip install openvino` (add `openvino-dev`/`nncf` only if the
+  demo needs model conversion or INT8 quantization).
+- Get an IR via the `model-download` skill (OMZ) or `ov.convert_model` from a
+  PyTorch/ONNX/TensorFlow source.
+- Device selection uses the same `CPU`/`GPU`/`NPU`/`AUTO` string the user chose.
+
+**Done when:** the script loads the model, runs at least one inference on real
+input, and prints/writes a sensible result (class, boxes, or output tensor)
+without errors.
+
+## Demo/PoC completion criteria (all must pass)
+
+1. Exactly one application is produced for the chosen sub-path — no full-stack
+   containers, no MediaMTX/Node-RED/Grafana/Nginx.
+2. The app targets the user's Intel device (`CPU`/`GPU`/`NPU`/`AUTO`).
+3. The app runs end-to-end and produces inference output (printed metadata,
+   annotated frames, or an output tensor).
+4. Any generated source file carries the SPDX header
+   (`SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0`).
+5. A short README/usage note states how to run it and what output to expect.
+
+## Optional external skills (demo mode)
+
+If available in the session, invoke; otherwise write the app from the templates
+above.
+
+- `dlstreamer-coding-agent` (open-edge-platform/skills) — Sub-path A pipeline
+  authoring.
+- `dlsps-user` (open-edge-platform/skills) — **not needed for a demo**; use it
+  only if the PoC grows into a REST-driven Pipeline Server microservice, in
+  which case switch back to the full-stack (`{{MODE}}=production`) path.
+- `model-download` (open-edge-platform/edge-ai-libraries) — fetch/convert model
+  IR for either sub-path.

--- a/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/references/PIPELINE.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/.github/skills/metro-ai-apps-recipe/references/PIPELINE.md
@@ -1,5 +1,11 @@
 # DLSPS pipeline reference
 
+> **Skill pointer:** for deploying, configuring, and operating DL Streamer
+> Pipeline Server (container startup, `config.json` pipeline definitions, REST
+> API launch/stop/status, MQTT/publisher wiring, GPU/NPU device access), invoke
+> the external `dlsps-user` skill (open-edge-platform/skills) when available.
+> The settings below are the recipe-specific overrides this stack requires.
+
 ## Required env
 
 - `REST_SERVER_PORT=8080`, `RUN_MODE=EVA`,

--- a/metro-ai-suite/prompt-library/.github/skills/metro-ai-apps-builder/references/SKILL_CATALOG.md
+++ b/metro-ai-suite/prompt-library/.github/skills/metro-ai-apps-builder/references/SKILL_CATALOG.md
@@ -14,13 +14,17 @@ refresh with [`DISCOVERY.md`](DISCOVERY.md) when it drifts.
 
 | If the user wants… | Primary skill | Supporting |
 |---|---|---|
-| A full **end-to-end analytics stack** (live annotated video + dashboard + alerts) for detection/classification/counting/zone-alerting on any vertical (smart city, retail, industrial, PPE, parking, healthcare…) | **`metro-ai-apps-recipe`** *(this repo)* | `model-download-user` (custom IR), `dlstreamer-coding-agent` (custom pipeline JSON) |
+| A full **end-to-end analytics stack** (live annotated video + dashboard + alerts) for detection/classification/counting/zone-alerting on any vertical (smart city, retail, industrial, PPE, parking, healthcare…) | **`metro-ai-apps-recipe`** *(this repo)* — production mode (`MODE=production`, the default) | `model-download-user` (custom IR), `dlstreamer-coding-agent` (custom pipeline JSON) |
+| A **quick local demo / PoC** — a single lightweight app (no full stack) that just proves a model runs and emits inference: a simple DL Streamer pipeline **or** a minimal OpenVINO inference script | **`metro-ai-apps-recipe`** *(this repo)* — demo/PoC mode (`MODE=demo`) | `dlstreamer-coding-agent` (DL Streamer sub-path), OpenVINO 2026 docs (OpenVINO sub-path), `model-download-user` (model IR) |
 | **Multi-camera / spatial** cross-camera tracking & scene fusion (smart-intersection style) | **`scenescape-setup`** — reached via the `metro-ai-apps-recipe` SceneScape opt-in path | `metro-ai-apps-recipe` for the detection front-end |
 | A **custom vision pipeline / sample app in code** (Python/C/C++/GStreamer): detection, classification, tracking, VLM, recording, custom elements | **`dlstreamer-coding-agent`** | `model-download-user` |
 
 Deliverable shape: *end-to-end solution* (Compose stack) for
-`metro-ai-apps-recipe`; *single app / code* for `dlstreamer-coding-agent`;
-*multi-camera solution* for the SceneScape path.
+`metro-ai-apps-recipe` in **production mode**; *quick single app / PoC* for
+`metro-ai-apps-recipe` in **demo mode** (`MODE=demo`) or for
+`dlstreamer-coding-agent`; *multi-camera solution* for the SceneScape path. Map
+the Step 1 **deployment-target** answer to the recipe mode: "quick local
+demo/POC" → `MODE=demo`; "Docker Compose end-to-end" → `MODE=production`.
 
 ## 2. Conversational AI — chatbot / Q&A / RAG over documents
 
@@ -95,7 +99,15 @@ Typical robot pipeline: train (`physicalai-train-*`) → export
   *detect/count/track + camera* → §1; *ask/answer + documents* → §2;
   *search/summarize + video* → §3; *download/convert + model* → §4;
   *train/fine-tune + dataset* → §5; *run/deploy + robot policy* → §6.
-- **Deployment target** picks the Docker vs Helm variant (chatqna, vss).
+- **Deployment target** picks the Docker vs Helm variant (chatqna, vss) and the
+  `metro-ai-apps-recipe` mode: a *quick local demo/POC* → recipe **demo mode**
+  (`MODE=demo`, a single DL Streamer or OpenVINO app); a *Docker Compose
+  end-to-end* stack → recipe **production mode** (`MODE=production`). Prefer the
+  recipe's demo mode over calling `dlstreamer-coding-agent` directly when the
+  user came in via a **business objective** (it wraps the same DL Streamer
+  hand-off and also offers the OpenVINO path); route straight to
+  `dlstreamer-coding-agent` only when the user explicitly wants to author custom
+  pipeline **code**.
 - **"Custom model"** almost always adds `model-download-user` as a supporting
   step before a deploy/build skill.
 - When two domains appear (e.g. *train then deploy*), sequence the skills and

--- a/metro-ai-suite/prompt-library/docs/user-guide/index.md
+++ b/metro-ai-suite/prompt-library/docs/user-guide/index.md
@@ -3,11 +3,11 @@
 The Metro AI Suite **Prompt Library** is a collection of reusable,
 business-objective prompts that turn a plain-language goal (for example,
 "I want to detect people in my camera feeds") into a running Intel® Edge AI
-application. Each prompt states **only a business outcome** — no framework, model,
-precision, or device — and hands off to the `metro-ai-apps-builder` orchestrator
+application. Each prompt states **only a business outcome**; no framework, model,
+precision, or device and hands off to the `metro-ai-apps-builder` orchestrator
 skill, which asks a few business questions, discovers the right
 [open-edge-platform](https://github.com/open-edge-platform/skills) skill,
-proposes a plan, and — after you confirm — builds the deliverable on Intel
+proposes a plan, and after you confirm builds the deliverable on Intel
 hardware.
 
 ---
@@ -23,9 +23,8 @@ technical decision to the orchestrator skill.
    violations"), or simply describe your goal in your own words.
 2. **The orchestrator takes over.** The
    [`metro-ai-apps-builder`](https://github.com/open-edge-platform/skills)
-   skill runs a short **business** Q&A — what you want to achieve, your inputs,
-   where it runs, and your hardware — never asking you to choose a framework,
-   model, or device.
+   skill runs a short **business** Q&A, what you want to achieve, your inputs,
+   where it runs, and your hardware.
 3. **Skill discovery.** From your answers the orchestrator discovers the relevant
    open-edge-platform skill(s) — vision analytics, multi-camera scene analysis,
    conversational Q&A/RAG, video search and summarization, multimodal embeddings,
@@ -49,15 +48,10 @@ your own, and run it:
 ```text
 I want to <state the business outcome in one or two sentences>.
 
-Use the metro-ai-apps-builder skill to guide this process. Install and
-invoke it:
+Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
 npx skills add open-edge-platform/skills --skill metro-ai-apps-builder
 ```
-
-Keep it **business-only** — describe what you want to achieve, not which model,
-framework, precision, or device to use. The orchestrator infers all of that for
-you.
 
 ---
 

--- a/metro-ai-suite/prompt-library/prompts/crowd-safety-monitoring.yaml
+++ b/metro-ai-suite/prompt-library/prompts/crowd-safety-monitoring.yaml
@@ -10,11 +10,8 @@ tags:
   - metro-ai-apps-builder
   - intel
 prompt: |
-  I want to detect and keep track of people across my public-space and transit
-  camera feeds for occupancy, crowd safety, or after-hours awareness and be
-  notified when someone appears.
+  I want to detect and keep track of people across my public-space and transit camera feeds for occupancy, crowd safety, or after-hours awareness and be notified when someone appears.
 
-  Use the metro-ai-apps-builder skill to guide this process. Install and
-  invoke it:
+  Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
   npx skills add open-edge-platform/skills --skill metro-ai-apps-builder

--- a/metro-ai-suite/prompt-library/prompts/smart-city-object-detection.yaml
+++ b/metro-ai-suite/prompt-library/prompts/smart-city-object-detection.yaml
@@ -9,11 +9,8 @@ tags:
   - metro-ai-apps-builder
   - intel
 prompt: |
-  I want to detect objects of interest across my smart-city camera feeds,
-  understand what is happening, and receive notifications when relevant objects
-  appear.
+  I want to detect objects of interest across my smart-city camera feeds, understand what is happening, and receive notifications when relevant objects appear.
 
-  Use the metro-ai-apps-builder skill to guide this process. Install and
-  invoke it:
+  Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
   npx skills add open-edge-platform/skills --skill metro-ai-apps-builder

--- a/metro-ai-suite/prompt-library/prompts/traffic-flow-monitoring.yaml
+++ b/metro-ai-suite/prompt-library/prompts/traffic-flow-monitoring.yaml
@@ -11,11 +11,8 @@ tags:
   - metro-ai-apps-builder
   - intel
 prompt: |
-  I want to detect and count vehicles across my roadway and parking camera
-  feeds for traffic flow, parking occupancy, or congestion monitoring and be
-  notified when counts cross a threshold.
+  I want to detect and count vehicles across my roadway and parking camera feeds for traffic flow, parking occupancy, or congestion monitoring and be notified when counts cross a threshold.
 
-  Use the metro-ai-apps-builder skill to guide this process. Install and
-  invoke it:
+  Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
   npx skills add open-edge-platform/skills --skill metro-ai-apps-builder

--- a/metro-ai-suite/prompt-library/prompts/unauthorized-access-detection.yaml
+++ b/metro-ai-suite/prompt-library/prompts/unauthorized-access-detection.yaml
@@ -10,10 +10,8 @@ tags:
   - metro-ai-apps-builder
   - intel
 prompt: |
-  I want to be alerted in real time when someone enters a restricted or
-  after-hours area they shouldn't, so my team can respond quickly.
+  I want to be alerted in real time when someone enters a restricted or after-hours area they shouldn't, so my team can respond quickly.
 
-  Use the metro-ai-apps-builder skill to guide this process. Install and
-  invoke it:
+  Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
   npx skills add open-edge-platform/skills --skill metro-ai-apps-builder

--- a/metro-ai-suite/prompt-library/prompts/worker-safety-compliance.yaml
+++ b/metro-ai-suite/prompt-library/prompts/worker-safety-compliance.yaml
@@ -9,11 +9,8 @@ tags:
   - metro-ai-apps-builder
   - intel
 prompt: |
-  I want to keep my workers safe by flagging anyone missing required protective
-  gear such as a hard hat or safety vest and raise an alert so a supervisor
-  can act.
+  I want to keep my workers safe by flagging anyone missing required protective gear such as a hard hat or safety vest and raise an alert so a supervisor can act.
 
-  Use the metro-ai-apps-builder skill to guide this process. Install and
-  invoke it:
+  Use the metro-ai-apps-builder skill to guide this process. Install and invoke it:
 
   npx skills add open-edge-platform/skills --skill metro-ai-apps-builder


### PR DESCRIPTION
### Description

- Currently the metro-ai-apps-recipe skill is lacking the instructions to develop the simple demo/poc applications based on openvino or dlstreamer. So updated the skill to have a demo mode.
- Updated the Prompt library documentation site.

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Not Tested

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

