### PR TITLE
[Agentic-Smart-Community] Harden VSA lifecycle, alert delivery, and task recovery

### DIFF
--- a/metro-ai-suite/agentic-smart-community/config.yaml.example
+++ b/metro-ai-suite/agentic-smart-community/config.yaml.example
@@ -59,6 +59,13 @@ keepalive:
 poll_interval_ms: 5000
 video_summary_max_concurrent: 2
 
+# Alert notification cooldown. A new alert for a monitor+use_case that already
+# produced a *notified* alert within this window is still written to the alerts
+# table (full audit) but with notified=false and no subscriber broadcast —
+# a persistent warn/critical scene does not spam subscribers. 0 disables.
+alerts:
+  cooldown_seconds: 60
+
 # Per-monitor log rotation (write target: logs/monitors/<monitor_id>/<YYYY-MM-DD>.log)
 logging:
   retention_days: 14 # keep this many calendar days of .log files (today + 13 previous); older deleted

--- a/metro-ai-suite/agentic-smart-community/demo/monitors.demo.yaml
+++ b/metro-ai-suite/agentic-smart-community/demo/monitors.demo.yaml
@@ -24,7 +24,7 @@ monitors:
     pipeline_config:
       motion: { enabled: true, diff_threshold: 25, area_ratio: 0.015, stable_frames: 30 }
       prefilter: { enabled: false }
-      recording: { enabled: true, interval_seconds: 60, retention_days: 5 }
+      recording: { enabled: true, interval_seconds: 60 }
       segment: { max_duration: 10 }
 
   cam_child:

--- a/metro-ai-suite/agentic-smart-community/docker/mcp-server/docker-compose.yaml
+++ b/metro-ai-suite/agentic-smart-community/docker/mcp-server/docker-compose.yaml
@@ -52,6 +52,6 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:3101/health"]
       start_period: 600s
       start_interval: 10s
-      interval: 24h
+      interval: 10m
       timeout: 5s
       retries: 3

--- a/metro-ai-suite/agentic-smart-community/docs/user-guide/api-reference/api-reference-videostream-analytics.md
+++ b/metro-ai-suite/agentic-smart-community/docs/user-guide/api-reference/api-reference-videostream-analytics.md
@@ -176,7 +176,7 @@ by `setup_docker.sh`. A deployment that loads a different `VIDEOSTREAM_CONFIG` i
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max_duration` | `float` | `10.0` | Hard ceiling on segment length, in seconds. |
-| `min_duration` | `float` | `1.0` | Minimum clip duration; shorter clips are discarded. |
+| `min_duration` | `float` | `1.0` | Cut-frequency guard: forced cuts (ROI early-split) are rejected while the running segment is younger than this. Finished segments are always emitted — short motion-end tails are never discarded. |
 
 ##### `StaticConfig`
 
@@ -214,7 +214,6 @@ by `setup_docker.sh`. A deployment that loads a different `VIDEOSTREAM_CONFIG` i
 | `enabled` | `bool` | `true` | Enable the continuous recorder branch (independent of motion). |
 | `interval_seconds` (alias `interval`) | `int` | `60` | Duration of each recording segment. |
 | `fps` | `int` | `15` | Recording output frame rate. |
-| `retention_days` | `int` | `5` | Days to retain old recordings on disk. |
 
 ##### `HealthConfig`
 
@@ -252,7 +251,7 @@ by `setup_docker.sh`. A deployment that loads a different `VIDEOSTREAM_CONFIG` i
       "device": "NPU"
     },
     "roi":       { "enabled": true, "mode": "crop", "expand": 0.25, "auto_split_area": 0.35 },
-    "recording": { "enabled": true, "interval_seconds": 60, "retention_days": 5 },
+    "recording": { "enabled": true, "interval_seconds": 60 },
     "health":    { "max_failures": 30, "recovery_strategy": "retry" },
     "keepalive": { "enabled": true, "timeout_seconds": 90.0, "check_interval_seconds": 10.0 }
   }

--- a/metro-ai-suite/agentic-smart-community/packages/db/src/database.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/db/src/database.ts
@@ -490,10 +490,21 @@ export class SmartCommunityDB {
     }));
   }
 
-  ackAlertWithUser(alertId: number, ackBy: string): void {
-    this.db.prepare(
-      "UPDATE alerts SET ack_at = datetime('now', 'localtime'), ack_by = ? WHERE id = ?"
-    ).run(ackBy, alertId);
+  /**
+   * Ack an alert. When monitorId is given the ack is scoped to alerts of that
+   * monitor. Returns false when no row matched (unknown id, or the alert
+   * belongs to another monitor) so callers can report failure instead of
+   * silently succeeding.
+   */
+  ackAlertWithUser(alertId: number, ackBy: string, monitorId?: string): boolean {
+    const info = monitorId === undefined
+      ? this.db.prepare(
+          "UPDATE alerts SET ack_at = datetime('now', 'localtime'), ack_by = ? WHERE id = ?"
+        ).run(ackBy, alertId)
+      : this.db.prepare(
+          "UPDATE alerts SET ack_at = datetime('now', 'localtime'), ack_by = ? WHERE id = ? AND monitor_id = ?"
+        ).run(ackBy, alertId, monitorId);
+    return info.changes > 0;
   }
 
   getAlertStats(
@@ -623,6 +634,19 @@ export class SmartCommunityDB {
     return (this.db.prepare(
       "SELECT * FROM video_summary_tasks WHERE monitor_id = ? AND status = 'pending' ORDER BY created_at ASC LIMIT ?"
     ).all(monitorId, limit) as any[]).map(rowToTask);
+  }
+
+  /**
+   * Requeue tasks stranded in `processing` by a crash/kill mid-summarize.
+   * Call only when no poll for this monitor can be in flight (worker start) —
+   * at that point any `processing` row is by definition stale. Returns the
+   * number of requeued tasks.
+   */
+  resetProcessingTasks(monitorId: string): number {
+    const info = this.db.prepare(
+      "UPDATE video_summary_tasks SET status = 'pending' WHERE monitor_id = ? AND status = 'processing'"
+    ).run(monitorId);
+    return info.changes;
   }
 
   /**

--- a/metro-ai-suite/agentic-smart-community/packages/db/src/schema-manager.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/db/src/schema-manager.ts
@@ -15,6 +15,20 @@ export interface SchemaDefinition {
 export class SchemaManager {
   private db: Database.Database;
 
+  /**
+   * Identifiers are interpolated verbatim into DDL below, so they must be
+   * plain SQL identifiers — same rule updateTaskStatus enforces on its
+   * dynamic column names. `createCustomTable` goes through db.exec (multi
+   * -statement capable), which makes this check load-bearing, not cosmetic.
+   */
+  private static IDENTIFIER_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+  private static assertIdentifier(kind: string, name: string): void {
+    if (!SchemaManager.IDENTIFIER_RE.test(name)) {
+      throw new Error(`invalid ${kind} identifier: ${JSON.stringify(name)}`);
+    }
+  }
+
   constructor(db: Database.Database) {
     this.db = db;
   }
@@ -90,6 +104,7 @@ export class SchemaManager {
   }
 
   private addColumnIfMissing(table: string, ext: SchemaExtension): "exists" | "added" | "type_mismatch" {
+    SchemaManager.assertIdentifier("column", ext.name);
     const existing = this.getExistingColumns(table);
     if (existing.has(ext.name)) {
       const currentType = existing.get(ext.name)!;
@@ -101,6 +116,8 @@ export class SchemaManager {
   }
 
   private createCustomTable(name: string, columns: SchemaExtension[]): void {
+    SchemaManager.assertIdentifier("table", name);
+    for (const c of columns) SchemaManager.assertIdentifier("column", c.name);
     const cols = columns.map((c) => `${c.name} ${c.type.toUpperCase()}`).join(", ");
     this.db.exec(`CREATE TABLE IF NOT EXISTS ${name} (id INTEGER PRIMARY KEY AUTOINCREMENT, ${cols})`);
   }

--- a/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/config.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/config.ts
@@ -105,6 +105,15 @@ export interface ServerConfig {
   };
   pollIntervalMs: number;
   videoSummaryMaxConcurrent: number;
+  /**
+   * Alert notification cooldown. When a new alert fires for a monitor+use_case
+   * that already produced a *notified* alert within this window, the row is
+   * still written (full audit) but with notified=false and no subscriber
+   * broadcast. 0 disables cooldown — every alert notifies.
+   */
+  alerts: {
+    cooldownSeconds: number;
+  };
   mcp?: {
     port?: number;
     /** Evict an MCP session after this long with no open SSE stream AND no HTTP request. Default 30min. */
@@ -188,6 +197,9 @@ export function loadConfig(configPath?: string): ServerConfig {
     },
     pollIntervalMs: parsed?.poll_interval_ms ?? 5000,
     videoSummaryMaxConcurrent: parsed?.video_summary_max_concurrent ?? 2,
+    alerts: {
+      cooldownSeconds: parsed?.alerts?.cooldown_seconds ?? 60,
+    },
     mcp: {
       port: parsed?.mcp?.port ?? 3100,
       sessionIdleTimeoutMs: parsed?.mcp?.session_idle_timeout_ms ?? 30 * 60 * 1000,

--- a/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/tools.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/tools.ts
@@ -455,7 +455,8 @@ export function registerTools(
         "Do not include Markdown code fences, because the video-summary service rejects reserved tokens."
       ),
       schema_extensions: z.array(z.object({
-        name: z.string(),
+        // Names land verbatim in ALTER/CREATE TABLE DDL — plain identifiers only.
+        name: z.string().regex(/^[a-zA-Z_][a-zA-Z0-9_]*$/, "must be a plain SQL identifier ([a-zA-Z_][a-zA-Z0-9_]*)"),
         type: z.enum(["text", "integer", "real"]),
         required: z.boolean(),
       })).optional().describe(
@@ -590,6 +591,7 @@ export function registerTools(
         db,
         {
           useCaseDict: config.useCaseDict,
+          alertCooldownSeconds: config.alerts.cooldownSeconds,
         },
         params as any,
       );

--- a/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/video-worker/task-poller.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/mcp-server/src/video-worker/task-poller.ts
@@ -33,6 +33,14 @@ export class TaskPoller {
   startPolling(monitorId: string): void {
     if (this.intervals.has(monitorId)) return;
 
+    // A previous process may have died mid-summarize, stranding tasks in
+    // `processing` (getPendingTasks only selects `pending`). No poll for this
+    // monitor is in flight at this point, so requeue them.
+    const requeued = this.db.resetProcessingTasks(monitorId);
+    if (requeued > 0) {
+      logger.info(`[task-poller] requeued ${requeued} stale processing task(s) for ${monitorId}`);
+    }
+
     const interval = setInterval(() => {
       // Skip this tick if the previous poll for this monitor is still in
       // flight. Otherwise, while a poll waits on yieldManager.acquire() (which
@@ -136,15 +144,24 @@ export class TaskPoller {
       const ruleResult = await evaluateWithOverride(ruleCtx, overridePath);
 
       if (ruleResult.shouldAlert) {
+        // Cooldown: if a *notified* alert for this monitor+use_case already
+        // fired inside the window, persist the row for audit with
+        // notified=false but skip the subscriber broadcast.
+        const cooldownSeconds = this.config.alerts.cooldownSeconds;
+        const inCooldown =
+          cooldownSeconds > 0 &&
+          this.db.latestAlertWithin(monitorId, useCase, cooldownSeconds) !== undefined;
         this.db.createAlert({
           monitorId,
           taskId: task.id,
           eventId: task.eventId,
           useCase,
           description: ruleResult.alertMessage,
-          notified: true,
+          notified: !inCooldown,
         });
-        if (this.onAlert) {
+        if (inCooldown) {
+          logger.debug(`[task-poller] alert for ${monitorId}/${useCase} suppressed by cooldown (${cooldownSeconds}s)`);
+        } else if (this.onAlert) {
           this.onAlert(monitorId);
         }
       }

--- a/metro-ai-suite/agentic-smart-community/packages/tools/src/alert-query.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/tools/src/alert-query.ts
@@ -57,7 +57,14 @@ export async function alertQuery(
       if (!params.ack_by) {
         throw new Error("ack_by is required for ack action");
       }
-      db.ackAlertWithUser(params.alert_id, params.ack_by);
+      const acked = db.ackAlertWithUser(params.alert_id, params.ack_by, params.monitor_id);
+      if (!acked) {
+        throw new Error(
+          params.monitor_id
+            ? `Alert ${params.alert_id} not found on monitor ${params.monitor_id}`
+            : `Alert not found: ${params.alert_id}`
+        );
+      }
       return { success: true, alert_id: params.alert_id };
     }
 

--- a/metro-ai-suite/agentic-smart-community/packages/tools/src/rule-engine/index.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/tools/src/rule-engine/index.ts
@@ -98,11 +98,25 @@ function alertOutcomeToRuleResult(useCase: string, outcome: AlertOutcome | null 
 }
 
 /**
+ * Parse an override script's stdout as the AlertOutcome JSON.
+ *
+ * Contract: the JSON is the LAST non-empty stdout line. Earlier lines are
+ * free for human debugging (logging/prints) — a stray print() must not fail
+ * the whole task. Exported for the registration smoke test, which enforces
+ * the same contract.
+ */
+export function parseOverrideStdout(stdout: string): unknown {
+  const lines = stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  const text = lines.at(-1) ?? "";
+  return text ? JSON.parse(text) : null;
+}
+
+/**
  * Run a Python rule override at the given path, falling back to defaultRuleEvaluator
  * only when overridePath is null.
  *
  * The override script receives parsed fields as JSON on argv[1]. It prints an
- * AlertOutcome JSON object or null.
+ * AlertOutcome JSON object or null as its last stdout line.
  *
  * Path is supplied by the caller (typically derived from config.useCaseDict[useCase].evaluate_rules_path)
  * rather than hard-coded — use case adapters live anywhere on disk.
@@ -125,8 +139,7 @@ export async function evaluateWithOverride(
       overridePath,
       JSON.stringify(context.payload?.fields ?? {}),
     ], { timeout: 10_000 });
-    const text = stdout.trim();
-    const result = text ? JSON.parse(text) : null;
+    const result = parseOverrideStdout(stdout) as AlertOutcome | null;
     return alertOutcomeToRuleResult(context.useCase, result);
   } catch (err: any) {
     throw new Error(`[rule-engine] Python override failed for ${context.useCase}: ${err.message}`);

--- a/metro-ai-suite/agentic-smart-community/packages/tools/src/rule-eval.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/tools/src/rule-eval.ts
@@ -20,6 +20,11 @@ export interface RuleEvalDeps {
       schema?: SchemaDefinition;
     }
   >;
+  /**
+   * Alert notification cooldown in seconds — same semantics as task-poller:
+   * inside the window the row is written with notified=false. Omit/0 disables.
+   */
+  alertCooldownSeconds?: number;
 }
 
 export interface RuleEvalParams {
@@ -43,6 +48,8 @@ export interface RuleEvalResult {
   rule_result: RuleResult;
   alert_created?: boolean;
   alert_id?: number;
+  /** Present when an alert was created: whether it notified (false = cooled down). */
+  alert_notified?: boolean;
 }
 
 /**
@@ -130,15 +137,23 @@ export async function ruleEval(
     return out;
   }
 
+  // Cooldown, same semantics as task-poller: a *notified* alert for this
+  // monitor+use_case inside the window suppresses notification only — the
+  // row is still written for audit with notified=false.
+  const cooldownSeconds = deps.alertCooldownSeconds ?? 0;
+  const inCooldown =
+    cooldownSeconds > 0 &&
+    db.latestAlertWithin(params.monitor_id, useCase, cooldownSeconds) !== undefined;
   const alert = db.createAlert({
     monitorId: params.monitor_id,
     taskId: task.id,
     eventId: task.eventId,
     useCase,
     description: ruleResult.alertMessage,
-    notified: true,
+    notified: !inCooldown,
   });
   out.alert_created = true;
   out.alert_id = alert.id;
+  out.alert_notified = !inCooldown;
   return out;
 }

--- a/metro-ai-suite/agentic-smart-community/packages/tools/src/use-case-register.ts
+++ b/metro-ai-suite/agentic-smart-community/packages/tools/src/use-case-register.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { parseDocument, isMap, Scalar } from "yaml";
 import { SchemaManager, type SchemaExtension } from "@smart-community-video/db";
+import { parseOverrideStdout } from "./rule-engine/index.js";
 import type { UseCaseValidateResult } from "./use-case-validate.js";
 import { useCaseValidate } from "./use-case-validate.js";
 
@@ -935,8 +936,9 @@ async function validateEvaluateRulesOverride(
       overridePath,
       JSON.stringify(smokeFields),
     ], { timeout: 10_000 });
-    const text = stdout.trim();
-    const parsed = text ? JSON.parse(text) : null;
+    // Same contract as the runtime rule engine: JSON on the LAST stdout line;
+    // earlier lines are debugging output and ignored.
+    const parsed = parseOverrideStdout(stdout) as { alertType?: unknown; severity?: unknown } | null;
     if (parsed === null) return null;
     if (!parsed || typeof parsed !== "object") {
       return `evaluate_rules_path "${overridePath}" must print JSON object or null`;

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/config/config.yaml
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/config/config.yaml
@@ -12,7 +12,7 @@ webhook:
 # Each registered source gets its own subdirectory `<data_dir>/<source_id>/`
 # (or whatever absolute path the register_source body specifies in its
 # `data_dir` field; MCP sends an absolute per-source path).
-data_dir: "~/.mcp-smartbuilding/segments"
+data_dir: "~/.mcp-smart-community/segments"
 
 defaults:
   motion:
@@ -34,7 +34,6 @@ defaults:
     enabled: true
     interval_seconds: 60
     fps: 15
-    retention_days: 5
   prefilter:
     enabled: true
     model_path: /path/to/prefilter-ov-model.xml

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/Dockerfile
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/Dockerfile
@@ -8,7 +8,7 @@
 #
 # Stage layout — build-only tooling (curl, compilers, pip caches) never reaches
 # the shipped image, which keeps trivy findings on the final stage minimal:
-#   python-base    common base: proxy env, shared ARGs
+#   python-base    common base shared by all stages
 #   builder-base   python venv with the app + openvino[npu]; also downloads the
 #                  NPU driver debs (linux-npu-driver release), the libze1 deb
 #                  (kobuk PPA snapshot, direct deb URL) and the iGPU compute
@@ -25,16 +25,7 @@
 # Firmware (NPU) is loaded by the host kernel, so intel-fw-npu is intentionally
 # NOT installed here.
 
-# Global build args (proxy) — redeclared inside each stage that needs them.
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG NO_PROXY
-
 FROM python:3.13-slim AS python-base
-ARG HTTP_PROXY
-ARG HTTPS_PROXY
-ARG NO_PROXY
-ENV http_proxy=${HTTP_PROXY} https_proxy=${HTTPS_PROXY} no_proxy=${NO_PROXY}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # ---------------------------------------------------------------------------

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/docker-compose.yaml
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/docker-compose.yaml
@@ -64,6 +64,6 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8999/health"]
       start_period: 600s
       start_interval: 10s
-      interval: 24h
+      interval: 10m
       timeout: 5s
       retries: 3

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/shared/config.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/shared/config.py
@@ -25,6 +25,12 @@ class SegmentConfig(BaseModel):
 
     `max_duration` — hard ceiling on segment length in seconds; when a running
     segment reaches this, it is closed and a new one starts.
+
+    `min_duration` — cut-frequency guard, NOT a delete filter: forced cuts
+    (ROI early-split) are rejected while the running segment is younger than
+    this, and prefilter motion-exit is held open until it. Finished segments
+    are always emitted regardless of length — short motion-end tails still
+    reach the VLM.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -51,6 +57,8 @@ class RecordingConfig(BaseModel):
 
     `interval_seconds` is the canonical field MCP sends. `interval` is kept as
     a legacy alias accepted on input but written as `interval_seconds`.
+    Recordings on disk are pruned by the MCP server (storage.retention_days);
+    VSA does not do its own retention cleanup.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -58,7 +66,6 @@ class RecordingConfig(BaseModel):
     enabled: bool = True
     interval_seconds: int = Field(default=60, alias="interval")
     fps: int = 15
-    retention_days: int = 5
 
 
 class RoiConfig(BaseModel):

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
@@ -2,7 +2,7 @@
 
 Runs in its own thread with its own VideoCapture, parallel to the motion pipeline.
 Produces time-based segments (default 60s) and optionally emits recording events via sink.
-Old segments are cleaned up based on retention_days.
+Old segments are pruned by the MCP server (storage.retention_days).
 """
 
 from __future__ import annotations
@@ -10,9 +10,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
-import time
-from datetime import datetime, timedelta
-from pathlib import Path
+from datetime import datetime
 
 import cv2
 
@@ -50,6 +48,12 @@ class ContinuousRecorder(BaseMonitor):
         self._running = False
         self._paused = threading.Event()
         self._paused.set()
+        # stop_event makes every sleep in the run loops interruptible, so
+        # stop() actually joins instead of leaving a parked thread behind.
+        self._stop_event = threading.Event()
+        # Bumped by start(); a stale thread from a previous start observes the
+        # mismatch at its next loop check and exits instead of resurrecting.
+        self._generation = 0
         self._status = "stopped"
 
     @property
@@ -63,18 +67,31 @@ class ContinuousRecorder(BaseMonitor):
     def start(self) -> None:
         if self._running:
             return
+        if self._thread and self._thread.is_alive():
+            # Previous thread is parked in a blocking call (cap.read). Safe to
+            # proceed: the generation guard makes it exit when it wakes.
+            logger.warning("[%s] Previous recorder thread still alive; superseding it", self.source_id)
+        self._stop_event.clear()
+        self._generation += 1
         self._running = True
         self._thread = threading.Thread(
-            target=self._run, name=f"recorder-{self.source_id}", daemon=True
+            target=self._run, args=(self._generation,),
+            name=f"recorder-{self.source_id}", daemon=True,
         )
         self._thread.start()
         logger.info("[%s] Continuous recorder started", self.source_id)
 
     def stop(self) -> None:
         self._running = False
+        self._stop_event.set()
         self._paused.set()
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=10)
+            if self._thread.is_alive():
+                # Parked in a blocking cap.read() — it cannot be interrupted,
+                # but the generation guard prevents it from resurrecting on the
+                # next start().
+                logger.warning("[%s] Recorder thread did not exit within 10s", self.source_id)
         self._status = "stopped"
         logger.info("[%s] Continuous recorder stopped", self.source_id)
 
@@ -92,9 +109,9 @@ class ContinuousRecorder(BaseMonitor):
         self._status = "recording"
         logger.info("[%s] Continuous recorder resumed", self.source_id)
 
-    def _run(self):
+    def _run(self, generation: int):
         """Main loop: connect, record segments, reconnect on failure."""
-        while self._running:
+        while self._running and self._generation == generation:
             cap = None
             try:
                 cap = cv2.VideoCapture(self.rtsp_url, cv2.CAP_FFMPEG)
@@ -107,7 +124,7 @@ class ContinuousRecorder(BaseMonitor):
 
                 self._status = "recording"
                 logger.info("[%s] Recording: %dx%d @ %.1f fps", self.source_id, w, h, fps)
-                self._record_loop(cap, fps, w, h)
+                self._record_loop(cap, fps, w, h, generation)
 
             except Exception as e:
                 logger.error("[%s] Recorder error: %s", self.source_id, e)
@@ -116,18 +133,19 @@ class ContinuousRecorder(BaseMonitor):
                 if cap:
                     cap.release()
 
-            if self._running:
+            if self._running and self._generation == generation:
                 self._status = "reconnecting"
                 logger.info("[%s] Recorder reconnecting in 10s...", self.source_id)
-                time.sleep(10)
+                if self._stop_event.wait(10):
+                    break
 
-    def _record_loop(self, cap: cv2.VideoCapture, fps: float, w: int, h: int):
+    def _record_loop(self, cap: cv2.VideoCapture, fps: float, w: int, h: int, generation: int):
         """Record frames in fixed-interval segments."""
-        while self._running:
+        while self._running and self._generation == generation:
             if not self._paused.is_set():
                 if not self._paused.wait(timeout=1.0):
                     continue
-                if not self._running:
+                if not self._running or self._generation != generation:
                     break
 
             segment_path, writer = self._start_segment(fps, w, h)
@@ -138,7 +156,7 @@ class ContinuousRecorder(BaseMonitor):
             frame_count = 0
             target_frames = int(self._cfg.interval_seconds * fps)
 
-            while self._running and frame_count < target_frames:
+            while self._running and self._generation == generation and frame_count < target_frames:
                 if not self._paused.is_set():
                     break
 
@@ -174,15 +192,15 @@ class ContinuousRecorder(BaseMonitor):
                     os.remove(segment_path)
                 break
 
-        self._cleanup_old_segments()
-
     def _start_segment(self, fps: float, w: int, h: int) -> tuple[str, H264SegmentWriter | None]:
         """Create a new segment file and writer."""
         now = datetime.now()
         date_dir = os.path.join(self._output_dir, now.strftime("%Y-%m-%d"))
         os.makedirs(date_dir, exist_ok=True)
 
-        filename = f"{self.source_id}_{now.strftime('%H%M%S')}.mp4"
+        # Millisecond suffix: a rapid read-fail/restart cycle must not reuse the
+        # name of the segment just emitted (1s-resolution names can collide).
+        filename = f"{self.source_id}_{now.strftime('%H%M%S')}_{now.microsecond // 1000:03d}.mp4"
         path = os.path.join(date_dir, filename)
 
         # H.264, not cv2.VideoWriter's mp4v — the dashboard replays these in a
@@ -193,25 +211,3 @@ class ContinuousRecorder(BaseMonitor):
             return path, None
 
         return path, writer
-
-    def _cleanup_old_segments(self):
-        """Remove recording segments older than retention_days."""
-        if self._cfg.retention_days <= 0:
-            return
-
-        cutoff = datetime.now() - timedelta(days=self._cfg.retention_days)
-        try:
-            for date_dir in Path(self._output_dir).iterdir():
-                if not date_dir.is_dir():
-                    continue
-                try:
-                    dir_date = datetime.strptime(date_dir.name, "%Y-%m-%d")
-                except ValueError:
-                    continue
-                if dir_date < cutoff:
-                    for f in date_dir.iterdir():
-                        f.unlink(missing_ok=True)
-                    date_dir.rmdir()
-                    logger.info("[%s] Cleaned up old recordings: %s", self.source_id, date_dir.name)
-        except Exception as e:
-            logger.warning("[%s] Cleanup error: %s", self.source_id, e)

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/prefilter_yolo.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/prefilter_yolo.py
@@ -3,8 +3,6 @@
 Uses OpenVINO for inference. When enabled, each motion segment is evaluated
 per-frame during recording; clips without sufficient target class detections
 are discarded instead of being sent to webhook.
-
-Adapted from openclaw-smarthome-demo/stream_monitor/pipeline/prefilter_yolo.py.
 """
 
 from __future__ import annotations

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/segment_extractor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/segment_extractor.py
@@ -1,4 +1,9 @@
-"""Fixed-interval segment writer with min_duration filter."""
+"""Fixed-interval segment writer.
+
+Segment length is bounded by `max_duration`. Nothing recorded is dropped for
+being short — `min_duration` only gates forced cuts upstream (see the
+early-split logic in rtsp_monitor), so motion-end tails always reach the VLM.
+"""
 
 from __future__ import annotations
 
@@ -32,7 +37,6 @@ class SegmentExtractor:
         frame_size: tuple[int, int] = (640, 480),
     ):
         self.max_duration = config.max_duration
-        self.min_duration = config.min_duration
         self.output_dir = output_dir
         self.source_id = source_id
         self.fps = fps
@@ -49,13 +53,25 @@ class SegmentExtractor:
     def is_recording(self) -> bool:
         return self._writer is not None
 
+    @property
+    def current_duration(self) -> float:
+        """Seconds recorded in the open segment (0 when idle).
+
+        Read by the early-split gate in rtsp_monitor: forced cuts are not
+        allowed before a segment reaches min_duration.
+        """
+        return self._frame_count / self.fps if self.fps > 0 else 0.0
+
     def start_segment(self):
         """Start a new segment."""
         now = datetime.now()
         date_dir = os.path.join(self.output_dir, now.strftime("%Y-%m-%d"))
         os.makedirs(date_dir, exist_ok=True)
 
-        filename = f"{self.source_id}_{now.strftime('%H%M%S')}.mp4"
+        # Millisecond suffix: an ROI early-split (or any sub-second restart) must
+        # not reuse the name of the segment just emitted — a 1s-resolution name
+        # would truncate the file the MCP side is about to read.
+        filename = f"{self.source_id}_{now.strftime('%H%M%S')}_{now.microsecond // 1000:03d}.mp4"
         self._current_path = os.path.join(date_dir, filename)
         self._start_time = now_local_str()
         self._frame_count = 0
@@ -79,7 +95,12 @@ class SegmentExtractor:
         return None
 
     def finish(self) -> Optional[SegmentResult]:
-        """Finalize current segment."""
+        """Finalize the current segment and return it for emission.
+
+        Recorded content is never dropped for being short — a short tail at
+        motion end still reaches the VLM. The only discarded file is an empty
+        one (0 frames written — nothing to analyze).
+        """
         if self._writer is None or self._current_path is None:
             return None
 
@@ -89,7 +110,7 @@ class SegmentExtractor:
         duration = self._frame_count / self.fps
         end_time = now_local_str()
 
-        if duration < self.min_duration:
+        if self._frame_count == 0:
             try:
                 os.unlink(self._current_path)
             except OSError:
@@ -108,15 +129,12 @@ class SegmentExtractor:
         self._frame_count = 0
         return result
 
-    def close(self):
-        if self._writer:
-            self._writer.release()
-            self._writer = None
-            if self._current_path and os.path.exists(self._current_path):
-                duration = self._frame_count / self.fps if self.fps > 0 else 0
-                if duration < self.min_duration:
-                    try:
-                        os.unlink(self._current_path)
-                    except OSError:
-                        pass
-                    self._current_path = None
+    def close(self) -> Optional[SegmentResult]:
+        """Release the writer, finalizing the open segment.
+
+        Delegates to finish(): the segment is returned for the caller to emit
+        (only 0-frame files are removed). Never leaves an un-finalized file
+        behind — the previous implementation could keep a file on disk without
+        handing it to anyone.
+        """
+        return self.finish()

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/rtsp_monitor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/rtsp_monitor.py
@@ -92,6 +92,12 @@ class StreamPipeline(BaseMonitor):
         self._running = False
         self._paused = threading.Event()  # set = not paused (normal running)
         self._paused.set()
+        # stop_event makes every sleep in the run loops interruptible, so
+        # stop() actually joins instead of leaving a parked thread behind.
+        self._stop_event = threading.Event()
+        # Bumped by start(); a stale thread from a previous start observes the
+        # mismatch at its next loop check and exits instead of resurrecting.
+        self._generation = 0
         self._status = "stopped"
         self._cap: cv2.VideoCapture | None = None
         self._frame_count = 0
@@ -114,18 +120,31 @@ class StreamPipeline(BaseMonitor):
     def start(self):
         if self._running:
             return
+        if self._thread and self._thread.is_alive():
+            # Previous thread is parked in a blocking call (cap.read/transcode).
+            # Safe to proceed: the generation guard makes it exit when it wakes.
+            logger.warning("[%s] Previous pipeline thread still alive; superseding it", self.source_id)
+        self._stop_event.clear()
+        self._generation += 1
         self._running = True
         self._thread = threading.Thread(
-            target=self._run, name=f"pipeline-{self.source_id}", daemon=True
+            target=self._run, args=(self._generation,),
+            name=f"pipeline-{self.source_id}", daemon=True,
         )
         self._thread.start()
         logger.info("[%s] Pipeline started", self.source_id)
 
     def stop(self):
         self._running = False
+        self._stop_event.set()
         self._paused.set()  # unblock if paused, so thread can exit
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=10)
+            if self._thread.is_alive():
+                # Parked in a blocking cap.read() or ffmpeg transcode — cannot
+                # be interrupted, but the generation guard prevents it from
+                # resurrecting on the next start().
+                logger.warning("[%s] Pipeline thread did not exit within 10s", self.source_id)
         self._status = "stopped"
         logger.info("[%s] Pipeline stopped", self.source_id)
 
@@ -209,8 +228,11 @@ class StreamPipeline(BaseMonitor):
         delay = self._health_cfg.backoff_base * (2 ** min(self._reconnect_count, 10))
         return min(delay, self._health_cfg.backoff_max)
 
-    def _handle_unhealthy(self):
+    def _handle_unhealthy(self, generation: int):
         """Execute recovery strategy when max_failures threshold is reached."""
+        if self._generation != generation:
+            # Stale thread — must not mutate shared state (a newer thread owns it).
+            return
         strategy = self._health_cfg.recovery_strategy
 
         self._status = "unhealthy"
@@ -222,7 +244,7 @@ class StreamPipeline(BaseMonitor):
             self._status = "paused"
             self._emit_status("paused")
             self._paused.wait()
-            if not self._running:
+            if not self._running or self._generation != generation:
                 return
             self._failure_count = 0
             self._reconnect_count = 0
@@ -234,13 +256,13 @@ class StreamPipeline(BaseMonitor):
         else:  # "retry"
             delay = self._health_cfg.backoff_max
             logger.info("[%s] Unhealthy, retrying in %.1fs...", self.source_id, delay)
-            time.sleep(delay)
+            self._stop_event.wait(delay)
 
-    def _run(self):
+    def _run(self, generation: int):
         """Main pipeline loop with health-aware reconnection."""
         self._start_time = datetime.now().isoformat(timespec="seconds")
 
-        while self._running:
+        while self._running and self._generation == generation:
             try:
                 self._connect()
                 if self._cap and self._cap.isOpened():
@@ -254,7 +276,7 @@ class StreamPipeline(BaseMonitor):
                         self._status = "paused"
                     self._failure_count = 0
                     self._reconnect_count = 0
-                    self._process_loop()
+                    self._process_loop(generation)
             except Exception as e:
                 logger.error("[%s] Pipeline error: %s", self.source_id, e)
                 self._status = "error"
@@ -265,11 +287,11 @@ class StreamPipeline(BaseMonitor):
                 self._cap.release()
                 self._cap = None
 
-            if self._running:
+            if self._running and self._generation == generation:
                 self._reconnect_count += 1
                 if self._failure_count >= self._health_cfg.max_failures:
-                    self._handle_unhealthy()
-                    if not self._running:
+                    self._handle_unhealthy(generation)
+                    if not self._running or self._generation != generation:
                         break
                 else:
                     # Same rule as above: keep the pause label visible while
@@ -280,7 +302,8 @@ class StreamPipeline(BaseMonitor):
                     delay = self._calculate_backoff()
                     logger.info("[%s] Reconnecting in %.1fs (attempt %d)...",
                                self.source_id, delay, self._reconnect_count)
-                    time.sleep(delay)
+                    if self._stop_event.wait(delay):
+                        break
 
         self._emit_status("stopped")
 
@@ -321,7 +344,7 @@ class StreamPipeline(BaseMonitor):
                       or motion_frames / self._fps >= self._segment_cfg.min_duration)
         return detector.is_static and min_dur_ok and self._prefilter.is_decided
 
-    def _process_loop(self):
+    def _process_loop(self, generation: int):
         """Read frames, detect motion, extract segments with fixed interval."""
         detector = MotionDetector(self._motion_cfg)
         if not self._motion_cfg.enabled:
@@ -353,124 +376,138 @@ class StreamPipeline(BaseMonitor):
         static_start_wall: float | None = None
         static_start_iso: str | None = None
 
-        while self._running:
-            ret, frame = self._cap.read()  # type: ignore
-            if not ret:
-                consecutive_failures += 1
-                if consecutive_failures >= self._health_cfg.max_failures:
-                    # Count one connection-level failure; outer loop owns the
-                    # retry/unhealthy decision (counting per-frame failures
-                    # would skip retries entirely on a single bad reconnect).
-                    self._failure_count += 1
-                    self._last_failure_time = datetime.now().isoformat(timespec="seconds")
-                    logger.warning(
-                        "[%s] %d consecutive read failures, reconnecting",
-                        self.source_id,
-                        consecutive_failures,
-                    )
-                    break
-                time.sleep(0.01)
-                continue
-
-            consecutive_failures = 0
-            self._frame_count += 1
-            self._maybe_write_snapshot(frame)
-
-            if not self._paused.is_set():
-                # Paused: keep reading frames (maintain RTSP connection) but skip processing
-                if not self._paused.wait(timeout=0.1):
+        try:
+            while self._running and self._generation == generation:
+                ret, frame = self._cap.read()  # type: ignore
+                if not ret:
+                    consecutive_failures += 1
+                    if consecutive_failures >= self._health_cfg.max_failures:
+                        # Count one connection-level failure; outer loop owns the
+                        # retry/unhealthy decision (counting per-frame failures
+                        # would skip retries entirely on a single bad reconnect).
+                        self._failure_count += 1
+                        self._last_failure_time = datetime.now().isoformat(timespec="seconds")
+                        logger.warning(
+                            "[%s] %d consecutive read failures, reconnecting",
+                            self.source_id,
+                            consecutive_failures,
+                        )
+                        break
+                    if self._stop_event.wait(0.01):
+                        break
                     continue
-                if not self._running:
-                    break
-                # Just resumed: if we were mid quiet-period, drop the span that
-                # elapsed across the pause — the paused wall-clock is not real
-                # idle time. Keep `None` as `None` (no open period to reset).
-                if static_start_wall is not None:
-                    static_start_wall = time.time()
-                    static_start_iso = now_local_str()
 
-            # Motion detection. When the gate is disabled (motion.enabled=false)
-            # every frame counts as motion — the prefilter (or, without one, the
-            # max_duration segment interval) becomes the only emit gate, and the
-            # frame-diff detector is skipped entirely to save CPU.
-            motion_detected = True if not self._motion_cfg.enabled else detector.detect(frame)
+                consecutive_failures = 0
+                self._frame_count += 1
+                self._maybe_write_snapshot(frame)
 
-            # State: enter motion
-            if motion_detected and not in_motion:
-                # Close out the preceding quiet period (if any) before the new
-                # motion. `static_start_*` is None on the very first motion
-                # (nothing to close out) — correct, we never fabricate a
-                # leading static.
-                if static_start_wall is not None:
-                    self._maybe_emit_static(static_start_wall, static_start_iso)
-                    static_start_wall = None
-                    static_start_iso = None
-                in_motion = True
-                motion_frames = 0
-                extractor.start_segment()
-                if self._prefilter:
-                    self._prefilter.reset()
-                logger.info("[%s] Motion started", self.source_id)
+                if not self._paused.is_set():
+                    # Paused: keep reading frames (maintain RTSP connection) but skip processing
+                    if not self._paused.wait(timeout=0.1):
+                        continue
+                    if not self._running or self._generation != generation:
+                        break
+                    # Just resumed: if we were mid quiet-period, drop the span that
+                    # elapsed across the pause — the paused wall-clock is not real
+                    # idle time. Keep `None` as `None` (no open period to reset).
+                    if static_start_wall is not None:
+                        static_start_wall = time.time()
+                        static_start_iso = now_local_str()
 
-            # State: in motion — record frames
-            if in_motion:
-                motion_frames += 1
-                if self._prefilter:
-                    self._prefilter.accumulate(frame, self._fps)
+                # Motion detection. When the gate is disabled (motion.enabled=false)
+                # every frame counts as motion — the prefilter (or, without one, the
+                # max_duration segment interval) becomes the only emit gate, and the
+                # frame-diff detector is skipped entirely to save CPU.
+                motion_detected = True if not self._motion_cfg.enabled else detector.detect(frame)
 
-                result = extractor.add_frame(frame)
-                if result:
-                    # Interval reached — emit segment, start next one
-                    self._maybe_emit(result)
+                # State: enter motion
+                if motion_detected and not in_motion:
+                    # Close out the preceding quiet period (if any) before the new
+                    # motion. `static_start_*` is None on the very first motion
+                    # (nothing to close out) — correct, we never fabricate a
+                    # leading static.
+                    if static_start_wall is not None:
+                        self._maybe_emit_static(static_start_wall, static_start_iso)
+                        static_start_wall = None
+                        static_start_iso = None
+                    in_motion = True
+                    motion_frames = 0
                     extractor.start_segment()
                     if self._prefilter:
+                        self._prefilter.reset()
+                    logger.info("[%s] Motion started", self.source_id)
+
+                # State: in motion — record frames
+                if in_motion:
+                    motion_frames += 1
+                    if self._prefilter:
+                        self._prefilter.accumulate(frame, self._fps)
+
+                    result = extractor.add_frame(frame)
+                    if result:
+                        # Interval reached — emit segment, start next one
+                        self._maybe_emit(result)
+                        extractor.start_segment()
+                        if self._prefilter:
+                            self._prefilter.reset_for_next_segment()
+                    elif self._prefilter and self._should_split_segment(extractor.current_duration):
+                        # Trajectory union grew past auto_split_area;
+                        # finish current segment early so the ROI crop stays tight.
+                        early = extractor.finish()
+                        if early:
+                            self._maybe_emit(early)
+                        extractor.start_segment()
                         self._prefilter.reset_for_next_segment()
-                elif self._prefilter and self._should_split_segment():
-                    # Trajectory union grew past auto_split_area;
-                    # finish current segment early so the ROI crop stays tight.
-                    early = extractor.finish()
-                    if early:
-                        self._maybe_emit(early)
-                    extractor.start_segment()
-                    self._prefilter.reset_for_next_segment()
-                    logger.debug(
-                        "[%s] Segment early-split by trajectory union",
-                        self.source_id,
-                    )
+                        logger.debug(
+                            "[%s] Segment early-split by trajectory union",
+                            self.source_id,
+                        )
 
-                # Cascaded exit check
-                if self._should_exit_motion(detector, motion_frames):
-                    tail = extractor.finish()
-                    if tail:
-                        self._maybe_emit(tail)
-                    in_motion = False
-                    # A real motion just ended → the quiet period begins now.
-                    # This is the ONLY place static_start is armed (close-out
-                    # model: static is always bracketed by two motions).
-                    static_start_wall = time.time()
-                    static_start_iso = now_local_str()
-                    logger.info("[%s] Motion ended", self.source_id)
+                    # Cascaded exit check
+                    if self._should_exit_motion(detector, motion_frames):
+                        tail = extractor.finish()
+                        if tail:
+                            self._maybe_emit(tail)
+                        in_motion = False
+                        # A real motion just ended → the quiet period begins now.
+                        # This is the ONLY place static_start is armed (close-out
+                        # model: static is always bracketed by two motions).
+                        static_start_wall = time.time()
+                        static_start_iso = now_local_str()
+                        logger.info("[%s] Motion ended", self.source_id)
 
-        # Drain remaining segment on shutdown
-        if in_motion:
-            result = extractor.finish()
-            if result:
-                self._maybe_emit(result)
-        elif static_start_wall is not None:
-            # Shut down while inside a quiet period (a motion had ended and no
-            # new motion arrived): emit the final static so state_query still
-            # sees the trailing idle span. If motion never happened at all,
-            # static_start_wall is None here and we (correctly) emit nothing.
-            self._maybe_emit_static(static_start_wall, static_start_iso)
-        extractor.close()
+        finally:
+            # Drain on shutdown AND on error exit (hence the try/finally): an
+            # exception mid-motion must not orphan the in-flight segment —
+            # finish() yields it regardless of length (only 0-frame files are
+            # removed). Guarded so a drain failure never masks the original
+            # exception.
+            try:
+                if in_motion:
+                    result = extractor.finish()
+                    if result:
+                        self._maybe_emit(result)
+                elif static_start_wall is not None:
+                    # Exiting inside a quiet period (a motion had ended and no
+                    # new motion arrived): emit the final static so state_query
+                    # still sees the trailing idle span. If motion never
+                    # happened at all, static_start_wall is None — emit nothing.
+                    self._maybe_emit_static(static_start_wall, static_start_iso)
+            except Exception as e:
+                logger.warning("[%s] Segment drain failed on exit: %s", self.source_id, e)
+            extractor.close()
 
-    def _should_split_segment(self) -> bool:
+    def _should_split_segment(self, current_duration: float) -> bool:
         """Return True when the active prefilter wants an early segment cut.
 
         Honors `pipeline.roi.auto_split_area`. With value <=0 or roi disabled,
-        never splits.
+        never splits. `min_duration` is the cut-frequency guard: a segment
+        younger than that is never split, so forced cuts can't produce short
+        fragments (motion-end tails are natural boundaries, always kept).
         """
         if self._prefilter is None:
+            return False
+        if current_duration < self._segment_cfg.min_duration:
             return False
         roi_cfg = self._roi_cfg
         if not roi_cfg.enabled or roi_cfg.auto_split_area <= 0:

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/fixtures/test_config.yaml
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/fixtures/test_config.yaml
@@ -21,7 +21,6 @@ defaults:
   recording:
     interval: 60
     fps: 15
-    retention_days: 5
   prefilter:
     enabled: true
     model_path: ""

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/integration/test_recording_to_webhook.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/integration/test_recording_to_webhook.py
@@ -35,7 +35,6 @@ class TestRecordingToWebhook:
                 "recording": {
                     "enabled": True,
                     "interval_seconds": 5,
-                    "retention_days": 1,
                 },
             },
         })

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
@@ -2,9 +2,7 @@
 
 import os
 import time
-from unittest.mock import MagicMock, patch
-from datetime import datetime, timedelta
-from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -26,7 +24,7 @@ class TestContinuousRecorderLifecycle:
         source = SourceConfig(
             source_id="test_recorder", source_url="rtsp://localhost:8554/live/test"
         )
-        cfg = RecordingConfig(interval=5, fps=15, retention_days=3)
+        cfg = RecordingConfig(interval=5, fps=15)
         return ContinuousRecorder(
             source=source,
             recording_cfg=cfg,
@@ -81,59 +79,6 @@ class TestContinuousRecorderLifecycle:
         assert os.path.isdir(expected)
 
 
-class TestContinuousRecorderCleanup:
-    @pytest.fixture
-    def mock_sink(self):
-        sink = MagicMock(spec=EventSink)
-        sink.emit.return_value = True
-        return sink
-
-    @pytest.fixture
-    def recorder(self, tmp_path, mock_sink):
-        source = SourceConfig(
-            source_id="test_cleanup", source_url="rtsp://localhost:8554/live/test"
-        )
-        cfg = RecordingConfig(interval=60, fps=15, retention_days=2)
-        r = ContinuousRecorder(
-            source=source,
-            recording_cfg=cfg,
-            data_dir=str(tmp_path),
-            sink=mock_sink,
-        )
-        return r
-
-    def test_cleanup_removes_old_directories(self, recorder):
-        base = Path(recorder._output_dir)
-
-        # Create old dir (4 days ago)
-        old_date = (datetime.now() - timedelta(days=4)).strftime("%Y-%m-%d")
-        old_dir = base / old_date
-        old_dir.mkdir(parents=True)
-        (old_dir / "segment.mp4").touch()
-
-        # Create recent dir (today)
-        today = datetime.now().strftime("%Y-%m-%d")
-        today_dir = base / today
-        today_dir.mkdir(parents=True)
-        (today_dir / "segment.mp4").touch()
-
-        recorder._cleanup_old_segments()
-
-        assert not old_dir.exists()
-        assert today_dir.exists()
-        assert (today_dir / "segment.mp4").exists()
-
-    def test_cleanup_ignores_non_date_dirs(self, recorder):
-        base = Path(recorder._output_dir)
-        misc_dir = base / "misc_data"
-        misc_dir.mkdir(parents=True)
-        (misc_dir / "file.txt").touch()
-
-        recorder._cleanup_old_segments()
-
-        assert misc_dir.exists()
-
-
 class TestContinuousRecorderWithVideo:
     @pytest.fixture
     def mock_sink(self):
@@ -147,7 +92,7 @@ class TestContinuousRecorderWithVideo:
             source_id="test_recording",
             source_url=test_video_path,
         )
-        cfg = RecordingConfig(interval=3, fps=30, retention_days=5)
+        cfg = RecordingConfig(interval=3, fps=30)
         return ContinuousRecorder(
             source=source,
             recording_cfg=cfg,

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_health_monitoring.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_health_monitoring.py
@@ -166,11 +166,12 @@ class TestHandleUnhealthy:
         pipeline._failure_count = 30
         pipeline._running = True
 
-        with patch("stream_monitor.rtsp_monitor.time.sleep") as mock_sleep:
-            pipeline._handle_unhealthy()
+        # Retry backoff waits on the interruptible stop event, not time.sleep.
+        with patch.object(pipeline._stop_event, "wait") as mock_wait:
+            pipeline._handle_unhealthy(pipeline._generation)
 
         assert pipeline._status == "unhealthy"
-        mock_sleep.assert_called_once_with(5.0)
+        mock_wait.assert_called_once_with(5.0)
 
     def test_remove_strategy_stops_and_calls_callback(self):
         callback = MagicMock()
@@ -181,7 +182,7 @@ class TestHandleUnhealthy:
         pipeline._failure_count = 30
         pipeline._running = True
 
-        pipeline._handle_unhealthy()
+        pipeline._handle_unhealthy(pipeline._generation)
 
         assert pipeline._running is False
         assert pipeline._status == "removed"
@@ -192,7 +193,7 @@ class TestHandleUnhealthy:
         pipeline._failure_count = 30
         pipeline._running = True
 
-        pipeline._handle_unhealthy()
+        pipeline._handle_unhealthy(pipeline._generation)
 
         assert pipeline._running is False
         assert pipeline._status == "removed"
@@ -208,7 +209,7 @@ class TestHandleUnhealthy:
             pipeline._paused.set()
 
         threading.Thread(target=resume_after_pause, daemon=True).start()
-        pipeline._handle_unhealthy()
+        pipeline._handle_unhealthy(pipeline._generation)
 
         assert pipeline._failure_count == 0
         assert pipeline._reconnect_count == 0
@@ -232,7 +233,7 @@ class TestHandleUnhealthy:
         pipeline._running = True
 
         with patch("stream_monitor.rtsp_monitor.time.sleep"):
-            pipeline._handle_unhealthy()
+            pipeline._handle_unhealthy(pipeline._generation)
 
         # Unhealthy (RTSP health) is not pushed to the /events webhook.
         # Internal status is set instead — MCP reads it via GET /sources/{id}/status.
@@ -253,14 +254,14 @@ class TestRunReconnectionLogic:
             pipeline._cap = MagicMock()
             pipeline._cap.isOpened.return_value = True
 
-        def fake_process_loop():
+        def fake_process_loop(_generation):
             call_count[0] += 1
             pipeline._running = False
 
         with patch.object(pipeline, "_connect", side_effect=fake_connect), \
              patch.object(pipeline, "_process_loop", side_effect=fake_process_loop), \
              patch.object(pipeline, "_emit_status"):
-            pipeline._run()
+            pipeline._run(pipeline._generation)
 
         assert pipeline._failure_count == 0
         assert pipeline._reconnect_count == 0
@@ -280,7 +281,7 @@ class TestRunReconnectionLogic:
         with patch.object(pipeline, "_connect", side_effect=fake_connect), \
              patch.object(pipeline, "_emit_status"), \
              patch("stream_monitor.rtsp_monitor.time.sleep"):
-            pipeline._run()
+            pipeline._run(pipeline._generation)
 
         assert pipeline._failure_count == 3
         assert pipeline._reconnect_count >= 2

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_full.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_full.py
@@ -94,10 +94,11 @@ class TestFullPipeline:
                 frame_count += 1
             cap.release()
             assert frame_count > 0, f"Clip has no frames: {clip_path}"
-            assert frame_count > 20, f"Clip too short ({frame_count} frames): {clip_path}"
+            # No minimum-length assertion: short motion-end/shutdown tails are
+            # kept by design (min_duration gates cut frequency, not content).
 
     def test_clip_duration_reasonable(self, pipeline, data_dir, mock_sink):
-        """Clip duration should be within min_duration to interval range."""
+        """Clip duration is bounded above by max_duration; short tails are kept."""
         pipeline.start()
         time.sleep(20)
         pipeline.stop()
@@ -120,8 +121,10 @@ class TestFullPipeline:
                 frame_count += 1
             cap.release()
             duration = frame_count / fps
-            # Fixed interval: duration should be around interval (10s) or shorter for tail segments
-            assert 1.0 <= duration <= 11.0, f"Clip duration {duration:.1f}s out of range"
+            # Cuts happen at max_duration; motion-end/shutdown tails may be any
+            # length — kept by design (min_duration is a cut-frequency guard,
+            # not a drop filter). Ceiling: max_duration + 1s tolerance.
+            assert 0 < duration <= 11.0, f"Clip duration {duration:.1f}s out of range"
 
     def test_sink_receives_no_status_events(self, pipeline, mock_sink):
         """RTSP connection status is not pushed to the sink/webhook.

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_update.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_update.py
@@ -211,7 +211,6 @@ class TestSourceManagerUpdate:
             enabled=True,
             interval_seconds=60,
             fps=15,
-            retention_days=5,
         )
 
         manager.update_pipeline_config(
@@ -224,7 +223,6 @@ class TestSourceManagerUpdate:
         assert updated.fps == 25
         assert updated.enabled is True
         assert updated.interval_seconds == 60
-        assert updated.retention_days == 5
 
 
 class TestSourceManagerRemoveCallback:

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_segment_extractor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_segment_extractor.py
@@ -113,8 +113,9 @@ class TestSegmentExtractorWithRealVideo:
         assert result is not None
         assert 4.5 <= result.duration_s <= 5.5
 
-    def test_finish_below_min_duration_returns_none(self, tmp_path, video_frames):
-        """Segment shorter than min_duration should be discarded."""
+    def test_finish_short_segment_is_kept(self, tmp_path, video_frames):
+        """min_duration is a cut-frequency guard, not a delete filter: a short
+        segment (e.g. a motion-end tail) is still returned for emission."""
         config = SegmentConfig(max_duration=60.0, min_duration=2.0)
         extractor = SegmentExtractor(
             config=config,
@@ -127,6 +128,22 @@ class TestSegmentExtractorWithRealVideo:
         # Write only 10 frames (0.33s < 2.0s min_duration)
         for frame in video_frames[:10]:
             extractor.add_frame(frame)
+        result = extractor.finish()
+        assert result is not None
+        assert os.path.exists(result.path)
+        assert 0.2 <= result.duration_s <= 0.5
+
+    def test_finish_with_zero_frames_returns_none(self, tmp_path):
+        """An empty segment (0 frames written) is removed, not emitted."""
+        config = SegmentConfig(max_duration=60.0, min_duration=2.0)
+        extractor = SegmentExtractor(
+            config=config,
+            output_dir=str(tmp_path / "motion_events"),
+            source_id="test_cam",
+            fps=30.0,
+            frame_size=(1280, 720),
+        )
+        extractor.start_segment()
         result = extractor.finish()
         assert result is None
 

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_static.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_static.py
@@ -108,7 +108,7 @@ def _run(pipeline, frames, clock):
     pipeline._fps = FPS
     pipeline._running = True
     with patch.object(rtsp_monitor.time, "time", clock.time):
-        pipeline._process_loop()
+        pipeline._process_loop(pipeline._generation)
 
 
 def _static_events(sink):


### PR DESCRIPTION
### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

  - Thread control: interruptible stops + generation guard against stale monitor threads
  - Segments: min_duration now gates forced cuts only — short tails always reach the VLM; ms filename suffix avoids collisions
  - Retention: dropped VSA-side cleanup, now owned by MCP server
  - Alerting: notification cooldown, monitor-scoped ack, stale task requeue
  - Security: SQL identifier validation in DDL; rule-override output parsed from last stdout line
  - Docker: no proxy build args; 10m healthcheck

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

