### PR TITLE
[release-2026.2.0]live-video-captioning: Pin pip version in Dockerfile to address trivy scan vuln

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-captioning-rag/app/Dockerfile
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning-rag/app/Dockerfile
@@ -12,7 +12,7 @@ RUN chmod +x /tmp/drivers/install_gpu_drivers.sh
 RUN echo "Installing GPU drivers version $INSTALL_DRIVER_VERSION" && \
     apt-get update && apt-get install -y --no-install-recommends ca-certificates libxml2 && \
     /tmp/drivers/install_gpu_drivers.sh && \
-    python -m pip install --upgrade --no-cache-dir pip && \
+    python -m pip install --upgrade --no-cache-dir pip==26.1.2 && \
     apt-get clean && rm -rf /tmp/drivers /var/lib/apt/lists/* /tmp/*
 
 # Build stage

--- a/metro-ai-suite/live-video-analysis/live-video-captioning/app/Dockerfile
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/app/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.12-slim AS base
 
 # Install system dependencies needed for building, upgrade to apply security patches
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends curl v4l-utils \
-    && python -m pip install --upgrade --no-cache-dir pip \
+    && python -m pip install --upgrade --no-cache-dir pip==26.1.2 \
     && rm -rf /var/lib/apt/lists/*
 
 # Build stage


### PR DESCRIPTION
### Description

Identified recurring Trivy findings related to msgpack (GHSA-6v7p-g79w-8964) and setuptools (CVE-2025-47273 / CVE-2026-59890). The root cause has been traced back to the latest pip release, which introduces vulnerable package attributions for both msgpack and setuptools. Pinning pip to version 26.1.2 will resolve these vulnerabilities.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

