### PR TITLE
[DOCS] Simplify git clone commands and add explicit branch checkout

### DIFF
--- a/education-ai-suite/ai-teaching-assistant/README.md
+++ b/education-ai-suite/ai-teaching-assistant/README.md
@@ -34,7 +34,7 @@ See [docs/user-guide/get-started.md](docs/user-guide/get-started.md) for the com
 At a high level:
 
 ```powershell
-git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git
+git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git -b main
 cd edge-ai-suites
 git sparse-checkout set education-ai-suite/ai-teaching-assistant
 cd education-ai-suite/ai-teaching-assistant

--- a/education-ai-suite/ai-teaching-assistant/docs/user-guide/get-started.md
+++ b/education-ai-suite/ai-teaching-assistant/docs/user-guide/get-started.md
@@ -18,7 +18,7 @@ Confirm your machine meets the [System Requirements](./get-started/system-requir
 Open PowerShell and run:
 
 ```powershell
-git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git `
+git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git -b main `
 ; cd edge-ai-suites `
 ; git sparse-checkout set education-ai-suite/ai-teaching-assistant `
 ; cd education-ai-suite/ai-teaching-assistant

--- a/education-ai-suite/ai-teaching-assistant/docs/user-guide/index.md
+++ b/education-ai-suite/ai-teaching-assistant/docs/user-guide/index.md
@@ -37,7 +37,7 @@ Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 High-level flow:
 
 ```powershell
-git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git;
+git clone --filter=blob:none --sparse https://github.com/open-edge-platform/edge-ai-suites.git -b main;
 cd edge-ai-suites;
 git sparse-checkout set education-ai-suite/ai-teaching-assistant;
 cd education-ai-suite/ai-teaching-assistant;

--- a/education-ai-suite/teacher-assistant-claw-demo/docs/openclaw-setup.md
+++ b/education-ai-suite/teacher-assistant-claw-demo/docs/openclaw-setup.md
@@ -76,8 +76,8 @@ Perform the following steps to setup OpenClaw agent for the Teacher Assistant de
 
 Clone the repository and navigate to the Teacher Assistant demo directory. All subsequent commands assume you are in this directory.
 
-``` bash
-git clone https://github.com/open-edge-platform/edge-ai-suites.git
+```bash
+git clone https://github.com/open-edge-platform/edge-ai-suites.git -b main
 cd edge-ai-suites/education-ai-suite/teacher-assistant-claw-demo
 ```
 

--- a/education-ai-suite/utils/flutter/README.md
+++ b/education-ai-suite/utils/flutter/README.md
@@ -239,13 +239,13 @@ The Flutter application uses a **dedicated configuration file** at `utils/flutte
 content_search:
   host_addr: "127.0.0.1"
   port: 9011
-  
+
   vlm:
     model_name: "Qwen/Qwen3-VL-8B-Instruct"
     host_addr: "127.0.0.1"
     port: 8000  # Main backend VLM service
     device: "GPU"
-    
+
   qa:
     max_context: 5          # Top chunks for RAG
     max_tokens: 1024        # Max answer length
@@ -272,7 +272,7 @@ content_search:
 
 ```powershell
 # 1. Clone the repository (if not already done)
-git clone https://github.com/open-edge-platform/edge-ai-suites.git
+git clone https://github.com/open-edge-platform/edge-ai-suites.git -b main
 cd edge-ai-suites/education-ai-suite
 
 # 2. Run setup (one-time)

--- a/metro-ai-suite/live-video-analysis/live-video-captioning-rag/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning-rag/docs/user-guide/get-started/deploy-with-helm.md
@@ -123,10 +123,8 @@ To set up the integrated deployment, obtain the chart and install it with your e
 1. Clone the repository.
 
 	 ```bash
-	 # Clone latest mainline
+	 # Clone the mainline branch
 	 git clone https://github.com/open-edge-platform/edge-ai-suites.git edge-ai-suites -b main
-	 # Or clone a specific release branch
-	 git clone https://github.com/open-edge-platform/edge-ai-suites.git edge-ai-suites -b <release-tag>
 	 ```
 
 2. Navigate to the chart directory.

--- a/metro-ai-suite/live-video-analysis/live-video-captioning/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/docs/user-guide/get-started/deploy-with-helm.md
@@ -101,10 +101,8 @@ cd live-video-captioning
 Clone the repository containing the charts files:
 
 ```bash
-# Clone the latest on mainline
+# Clone the mainline branch
 git clone https://github.com/open-edge-platform/edge-ai-suites.git edge-ai-suites -b main
-# Alternatively, clone a specific release branch
-git clone https://github.com/open-edge-platform/edge-ai-suites.git edge-ai-suites -b <release-tag>
 ```
 
 ##### Step 2: Navigate to the chart directory

--- a/metro-ai-suite/metro-sdk-manager/docs/oep-sdk-manager-files/config.js
+++ b/metro-ai-suite/metro-sdk-manager/docs/oep-sdk-manager-files/config.js
@@ -258,8 +258,6 @@ const CONFIG = {
             "Document Ingestion (pgvector)",
             "Multimodal Embedding Serving",
             "Visual Data Preparation For Retrieval",
-            "VLM OpenVINO Serving",
-            "Chat Q&A",
             "Chat Q&A Core",
             "Edge AI Libraries - Repo",
             "Edge AI Suites - Repo"
@@ -746,9 +744,7 @@ const CONFIG = {
             { text: "Audio Analyzer", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/audio-analyzer/index.html" },
             { text: "Document Ingestion - pgvector", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/pgvector/index.html" },
             { text: "Multimodal Embedding Serving", url: "https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/multimodal-embedding-serving/index.html" },
-            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/visual-data-preparation-for-retrieval/vdms/docs/user-guide/Overview.md" },
-            { text: "VLM OpenVINO Serving", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/vlm-openvino-serving/docs/user-guide/Overview.md" },
-            { text: "Chat Q&A", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/chat-question-and-answer/index.html" },
+            { text: "Visual Data Preparation For Retrieval", url: "https://github.com/open-edge-platform/edge-ai-libraries/blob/main/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/Overview.md" },
             { text: "Chat Q&A Core", url: "http://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/chat-question-and-answer-core/index.html" },
             { text: "Edge AI Libraries", url: "https://docs.openedgeplatform.intel.com/dev/ai-libraries.html"},
             { text: "Edge AI Suites", url: "https://docs.openedgeplatform.intel.com/dev/ai-suite-metro.html"}

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/conftest.py
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: LicenseRef-Intel-Edge-Software
 # This file is licensed under the Limited Edge Software Distribution License Agreement.
 
@@ -47,13 +47,13 @@ INFLUX_DB_ADMIN_PASSWORD = os.getenv("INFLUX_DB_ADMIN_PASSWORD", get_password_fr
 NODE_RED_URL = os.getenv("NODE_RED_URL", "http://localhost:1880")
 NODE_RED_REMOTE_URL = os.getenv("NODE_RED_REMOTE_URL")
 
-PROJECT_GITHUB_URL = os.getenv("PROJECT_GITHUB_URL", "https://github.com/open-edge-platform/edge-ai-suites/blob/main/metro-ai-suite/smart-intersection")
+PROJECT_GITHUB_URL = os.getenv("PROJECT_GITHUB_URL", "https://github.com/open-edge-platform/edge-ai-suites/tree/main/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection")
 
 
 def start_remote_port_forwarding(service_name, remote_host, local_port, remote_port, namespace="smart-intersection"):
   """Start remote port forwarding for a service and return the process."""
   pod_name = get_pod_name(service_name, namespace)
-  
+
   # Use sudo with password for privileged ports (<1024)
   if local_port < 1024:
     sudo_password = os.environ.get('SUDO_PASSWORD')
@@ -64,7 +64,7 @@ def start_remote_port_forwarding(service_name, remote_host, local_port, remote_p
     cmd = f'echo "{sudo_password}" | sudo -S -E kubectl -n {namespace} port-forward {pod_name} {local_port}:{remote_port} --address {remote_host}'
   else:
     cmd = f"kubectl -n {namespace} port-forward {pod_name} {local_port}:{remote_port} --address {remote_host}"
-    
+
   logger.info(f"Starting remote port forwarding for {service_name}: {remote_host}:{local_port}")
   return subprocess.Popen(cmd, shell=True)
 
@@ -107,7 +107,7 @@ def wait_for_services_readiness(services_urls, timeout=120, interval=2):
 @pytest.fixture(scope="session", autouse=True)
 def setup_environment(request):
   """Set up Docker or Kubernetes environment for testing."""
-  
+
   if "kubernetes" in request.config.getoption("markexpr"):
     logger.info("Deploying Kubernetes environment...")
     out, err, code = run_command(
@@ -121,7 +121,7 @@ def setup_environment(request):
 
     # Wait for all pods to be ready
     wait_for_pods_ready("smart-intersection")
-    
+
     # Get dynamic NodePort
     web_node_port = get_node_port("smart-intersection-web", "smart-intersection")
 
@@ -139,27 +139,27 @@ def setup_environment(request):
       NODE_RED_URL
     ]
     wait_for_services_readiness(localhost_services_urls)
-    
-    if are_remote_urls_configured():        
+
+    if are_remote_urls_configured():
       # Start remote port forwarding for each configured service
       if SCENESCAPE_REMOTE_URL:
         parsed = urllib.parse.urlparse(SCENESCAPE_REMOTE_URL)
         logger.info(f"SCENESCAPE_REMOTE_URL: {SCENESCAPE_REMOTE_URL}")
         logger.info(f"parsed.hostname: {parsed.hostname}, parsed.port: {parsed.port}")
         start_remote_port_forwarding("smart-intersection-web", parsed.hostname, 443, 443)
-        
+
       if GRAFANA_REMOTE_URL:
         parsed = urllib.parse.urlparse(GRAFANA_REMOTE_URL)
         logger.info(f"GRAFANA_REMOTE_URL: {GRAFANA_REMOTE_URL}")
         logger.info(f"parsed.hostname: {parsed.hostname}, parsed.port: {parsed.port}")
         start_remote_port_forwarding("smart-intersection-grafana", parsed.hostname, parsed.port, 3000)
-        
+
       if INFLUX_REMOTE_DB_URL:
         parsed = urllib.parse.urlparse(INFLUX_REMOTE_DB_URL)
         logger.info(f"INFLUX_REMOTE_DB_URL: {INFLUX_REMOTE_DB_URL}")
         logger.info(f"parsed.hostname: {parsed.hostname}, parsed.port: {parsed.port}")
         start_remote_port_forwarding("smart-intersection-influxdb", parsed.hostname, parsed.port, 8086)
-        
+
       if NODE_RED_REMOTE_URL:
         parsed = urllib.parse.urlparse(NODE_RED_REMOTE_URL)
         logger.info(f"NODE_RED_REMOTE_URL: {NODE_RED_REMOTE_URL}")
@@ -178,11 +178,11 @@ def setup_environment(request):
     wait_for_services_readiness(services_urls)
 
   yield
-  
+
   # Cleanup - this ALWAYS runs regardless of success/failure
   if "kubernetes" in request.config.getoption("markexpr"):
     logger.info("Tearing down Kubernetes environment...")
-    
+
     # Cleanup: kill all kubectl port-forward processes for namespace smart-intersection
     try:
       logger.info("Killing kubectl port-forward processes for namespace smart-intersection...")
@@ -190,8 +190,8 @@ def setup_environment(request):
       logger.info("Port forwarding stopped.")
     except Exception as e:
       logger.error(f"Error killing kubectl port-forward processes for smart-intersection: {e}")
-    
-    # Clean up Kubernetes resources  
+
+    # Clean up Kubernetes resources
     run_command("helm uninstall smart-intersection -n smart-intersection")
     run_command("kubectl delete namespace smart-intersection")
     logger.info("Kubernetes environment removed.")

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/test_admin.py
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/test_admin.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2025-2026 Intel Corporation
 # SPDX-License-Identifier: LicenseRef-Intel-Edge-Software
 # This file is licensed under the Limited Edge Software Distribution License Agreement.
 
@@ -35,7 +35,7 @@ def web_options_availability_check(waiter, scenescape_url):
     scenescape_url + "/cam/list/",  # Cameras
     scenescape_url + "/singleton_sensor/list/",  # Sensors
     scenescape_url + "/asset/list/",  # Object Library
-    "https://docs.openedgeplatform.intel.com/scenescape/dev/index.html",  # Documentation
+    "https://docs.openedgeplatform.intel.com/dev/scenescape/index.html",  # Documentation
     scenescape_url + "/admin"  # Admin
   ]
 

--- a/metro-ai-suite/smart-traffic-intersection-agent/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/smart-traffic-intersection-agent/docs/user-guide/get-started/deploy-with-helm.md
@@ -67,10 +67,8 @@ Edit the `values.yaml` file to set the necessary environment variables. Refer to
 Clone the repository containing the Helm chart:
 
 ```bash
-# Clone the latest on mainline
+# Clone the mainline branch
 git clone https://github.com/open-edge-platform/edge-ai-suites.git -b main
-# Alternatively, clone a specific release branch
-git clone https://github.com/open-edge-platform/edge-ai-suites.git -b <release-tag>
 ```
 
 #### Step 2: Change to the Chart Directory

--- a/metro-ai-suite/smart-traffic-intersection-agent/docs/user-guide/get-started/deploy-with-trusted-compute-helm.md
+++ b/metro-ai-suite/smart-traffic-intersection-agent/docs/user-guide/get-started/deploy-with-trusted-compute-helm.md
@@ -78,10 +78,8 @@ Edit the `values.yaml` file to set the necessary environment variables. Refer to
 Clone the repository containing the Helm chart:
 
 ```bash
-# Clone the latest on mainline
+# Clone the mainline branch
 git clone https://github.com/open-edge-platform/edge-ai-suites.git -b main
-# Alternatively, clone a specific release branch
-git clone https://github.com/open-edge-platform/edge-ai-suites.git -b <release-tag>
 ```
 
 #### Step 2: Change to the Chart Directory

--- a/robotics-ai-suite/components/its-planner/collab_slam/README.md
+++ b/robotics-ai-suite/components/its-planner/collab_slam/README.md
@@ -12,7 +12,7 @@ Here are the instructions on how to enable Collaborative Visual SLAM Framework o
 
 1. Get the Collaborative Visual SLAM code
 
-    `git clone --recursive https://github.com/open-edge-platform/edge-ai-suites`
+    `git clone --recursive https://github.com/open-edge-platform/edge-ai-suites -b main`
 
 2. Build the collaborative VSLAM, nav2_bringup and the ITS planner
 

--- a/robotics-ai-suite/components/ros-kpi/setup_ros2_env.sh
+++ b/robotics-ai-suite/components/ros-kpi/setup_ros2_env.sh
@@ -19,7 +19,7 @@ elif [ -f "/opt/ros/jazzy/setup.bash" ]; then
 else
     echo "⚠️  ROS2 not found in /opt/ros/"
     echo "Please follow the Intel Robotics AI Suite getting started guide:"
-    echo "  https://docs.openedgeplatform.intel.com/2025.2/edge-ai-suites/robotics-ai-suite/robotics/gsg_robot/index.html"
+    echo "  https://docs.openedgeplatform.intel.com/dev/edge-ai-suites/robotics-ai-suite/robotics/gsg_robot/index.html"
     exit 1
 fi
 

--- a/robotics-ai-suite/pipelines/openclaw-agenticros-demo/README.md
+++ b/robotics-ai-suite/pipelines/openclaw-agenticros-demo/README.md
@@ -55,7 +55,7 @@ First, clone this deployment folder with all submodules:
 ```bash
 # Clone the edge-ai-suites repository (if not already done)
 cd ~
-git clone https://github.com/open-edge-platform/edge-ai-suites.git
+git clone https://github.com/open-edge-platform/edge-ai-suites.git -b main
 
 # Navigate to the deployment folder
 cd ~/edge-ai-suites/robotics-ai-suite/pipelines/openclaw-agenticros-demo


### PR DESCRIPTION
### Description

- fix some paths to `metro-vision-ai-recipe` docs
- simplify git clone commands where they offered two paths to a single path
- add explicit branch checkout to git clone commands, where it was missing
- update `config.js` for Metro SDK Manager (remove stale references to Chat Q&A/VLM Serving on main, update refs to Visual Data Prep)

Partial backport from #3835 (with references adjusted for `main`).

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.