### PR TITLE
[DOCS][Metro] Enterprise Data Intelligence - publishing prep - 2026.2

### DIFF
--- a/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/get-started.md
+++ b/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/get-started.md
@@ -117,7 +117,7 @@ basic skeleton such as `gateway`, `tools.profile`, and `agents.list[main]`, so *
 - `plugins`: add the `tavily` configuration
 - `gateway`: configure `controlUi`
 
-```jsonc
+```json
 {
   "agents": {
     "defaults": {

--- a/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/get-started.md
+++ b/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/get-started.md
@@ -1,34 +1,35 @@
-<!--
-Copyright (C) 2026 Intel Corporation
-SPDX-License-Identifier: Apache-2.0
--->
+# Get Started
 
-# Enterprise Data Intelligence
-
-Demo setup steps, including OpenClaw service, EC-RAG service, Router service, compressor service, and UI service.
+This guide provides the demo setup steps for the OpenClaw service, EC-RAG service, Router
+service, Compressor service, and the UI service.
 
 ## Table of Contents
 
-- [1. Setup Router and Compressor services](#1-setup-router-and-compressor-services)
-- [2. Setup EC-RAG](#2-setup-ec-rag)
-- [3. Setup OpenClaw](#3-setup-openclaw)
-  - [3.1 Setup OpenClaw](#31-setup-openclaw)
-  - [3.2 Configure openclaw.json](#32-configure-openclawjson)
-  - [3.3 Install Repository Skills into OpenClaw Agent Directory](#33-install-repository-skills-into-openclaw-agent-directory)
+- [1. Set Up Router and Compressor Services](#1-set-up-router-and-compressor-services)
+- [2. Set Up EC-RAG](#2-set-up-ec-rag)
+- [3. Set Up OpenClaw](#3-set-up-openclaw)
+  - [3.1 Install and Onboard OpenClaw](#31-install-and-onboard-openclaw)
+  - [3.2 Configure `openclaw.json`](#32-configure-openclawjson)
+  - [3.3 Install Repository Skills into the OpenClaw Agent Directory](#33-install-repository-skills-into-the-openclaw-agent-directory)
   - [3.4 Enable the Skill in OpenClaw Configuration](#34-enable-the-skill-in-openclaw-configuration)
-- [4. Setup UI](#4-setup-ui)
+- [4. Set Up the UI](#4-set-up-the-ui)
 - [5. Test the Configuration](#5-test-the-configuration)
-- [6. How to use knowledgebase skill](#6-how-to-use-knowledgebase-skill)
+- [6. Use the Knowledgebase Skill](#6-use-the-knowledgebase-skill)
 
-## 1. Setup Router and Compressor services
+## 1. Set Up Router and Compressor Services
 
-The Router and compressor services are set up separately. See the [`inference-router`](https://github.com/open-edge-platform/edge-ai-libraries/tree/release-2026.2.0/microservices/inference-router) microservice for the full instructions on generating the config and starting both services.
+The Router and Compressor services are set up separately. See the
+[Inference Router](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/inference-router/index.html)
+microservice for the full instructions on generating the configuration and starting both
+services.
 
-## 2. Setup EC-RAG
+## 2. Set Up EC-RAG
 
-To install and launch EC-RAG, set up the EC-RAG pipeline, and build the knowledge base, follow the instructions in [`OPEA EC-RAG Setup Guide`](https://github.com/opea-project/GenAIExamples/blob/main/EdgeCraftRAG/docs/Advanced_Setup.md).
+To install and launch EC-RAG, set up the EC-RAG pipeline, and build the knowledge base, follow
+the instructions in [`OPEA EC-RAG Setup Guide`](https://github.com/opea-project/GenAIExamples/blob/main/EdgeCraftRAG/docs/Advanced_Setup.md).
 
-For latest model support, you can modify the EC-RAG vllm backend image version and config like this:
+For the latest model support, you can modify the EC-RAG vLLM backend image version and
+configuration like this:
 
 ```bash
 # clone OPEA EC-RAG repo
@@ -44,7 +45,7 @@ sed -i \
   docker_compose/intel/gpu/arc/compose.yaml
 ```
 
-below is a reference pipeline config:
+Below is a reference pipeline configuration:
 
 ```bash
 - `HOST_IP`: `<your_host_ip>`
@@ -57,17 +58,19 @@ below is a reference pipeline config:
 - `GPU_MEMORY_UTIL`: `0.65`
 ```
 
-## 3. Setup OpenClaw
+## 3. Set Up OpenClaw
 
-### 3.1 Setup OpenClaw
+### 3.1 Install and Onboard OpenClaw
 
-If you do not have OpenClaw yet, install it from the official repository: https://github.com/openclaw/openclaw, please install openclaw@2026.5.6:
+If you do not have OpenClaw yet, install it from the official repository at
+<https://github.com/openclaw/openclaw>. Install `openclaw@2026.5.6`:
 
 ```bash
 npm install -g openclaw@2026.5.6
 ```
 
-Use the following choices in the onboarding wizard. Skip all online provider/channel/skill configuration for now and configure them manually in the following sections:
+Use the following choices in the onboarding wizard. Skip all online provider/channel/skill
+configuration for now and configure them manually in the following sections:
 
 ```bash
 openclaw onboard --install-daemon
@@ -84,13 +87,14 @@ openclaw onboard --install-daemon
 | Enable hooks | **Skip for now** |
 | How do you want to hatch your bot? | **Do this later** |
 
-If you are using an internally packaged version or a preinstalled environment, make sure you can access the following:
+If you are using an internally packaged version or a preinstalled environment, make sure you
+can access the following:
 
 - OpenClaw executable
-- `openclaw.json` config file
+- `openclaw.json` configuration file
 - A usable agent workspace, for example `~/.openclaw/workspace`
 
-### 3.2 Configure openclaw.json
+### 3.2 Configure `openclaw.json`
 
 Before editing the configuration, stop the `openclaw gateway` service:
 
@@ -100,7 +104,8 @@ openclaw gateway stop
 
 Edit `~/.openclaw/openclaw.json`.
 
-The `~/.openclaw/openclaw.json` file generated by `openclaw onboard` already includes the basic skeleton such as `gateway`, `tools.profile`, and `agents.list[main]`, so **you do not need to replace the entire file**. Merge the following sections into it:
+The `~/.openclaw/openclaw.json` file generated by `openclaw onboard` already includes the
+basic skeleton such as `gateway`, `tools.profile`, and `agents.list[main]`, so **you do not need to replace the entire file**. Merge the following sections into it:
 
 - `models.providers`: add the `minimax`, `vllm`, and `proxy-101` providers
 - `tools`: append web search using `tavily`
@@ -345,11 +350,13 @@ The `~/.openclaw/openclaw.json` file generated by `openclaw onboard` already inc
 }
 ```
 
-Please remember to put `MINIMAX_API_KEY` into `${HOME}/.openclaw/.env`. Do not use `~/` in `openclaw.json`, because it is not allowed.
+Remember to put `MINIMAX_API_KEY` into `${HOME}/.openclaw/.env`. Do not use `~/` in `openclaw.json`,
+because it is not allowed.
 
-### 3.3 Install Repository Skills into OpenClaw Agent Directory
+### 3.3 Install Repository Skills into the OpenClaw Agent Directory
 
-Skill files in this repository cannot stay only in the current repo. They must be copied into the workspace of the corresponding OpenClaw agent so OpenClaw can actually load them.
+Skill files in this repository cannot remain only in the repository. They must be copied into
+the workspace of the corresponding OpenClaw agent so that OpenClaw can load them.
 
 The most common target directory is:
 
@@ -400,7 +407,7 @@ openclaw tui
 "Can you use competitive_analysis_PDF_generator?"
 ```
 
-## 4. Setup UI
+## 4. Set Up the UI
 
 Use Docker Compose to build and start the UI container:
 
@@ -442,16 +449,21 @@ After completing the setup steps above, verify the configuration as follows:
 Generate a competitive analysis report for Unitree Robotics G1 Basic and comparable products on the market.
 ```
 
-## 6. How to use knowledgebase skill
+Expected result: The UI should display a professional HTML/PDF report comparing the Unitree
+Robotics G1 Basic with other products, generated using the `competitive_analysis_PDF_generator` skill.
 
-If the LLM model is not strong enough to use knowledgebase skill automaticly , you can add below instruction in OpenClaw's AGENTS.md:
+## 6. Use the Knowledgebase Skill
+
+If the Large Language Model (LLM) is not strong enough to use the knowledgebase skill
+automatically, add the following instruction to OpenClaw's `AGENTS.md`:
 
 ```text
 For any user question, query, summarization, overview, or comparison, you must use the knowledgebase skill!
 Do not answer questions by searching for files!
 ```
 
-please insert above text into Tools chapter in $HOME/.openclaw/workspace/AGENTS.md, e.g. :
+Insert the text into the "Tools" chapter in `$HOME/.openclaw/workspace/AGENTS.md`, for example:
+
 ```md
 ## Tools
 

--- a/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/index.md
+++ b/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/index.md
@@ -1,0 +1,109 @@
+# Enterprise Data Intelligence
+
+<!--hide_directive
+<div class="component_card_widget">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/metro-ai-suite/enterprise-data-intelligence">
+     GitHub
+  </a>
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/enterprise-data-intelligence/README.md">
+     Readme
+  </a>
+</div>
+hide_directive-->
+
+An agent-native automation platform that combines a local knowledge base with autonomous
+agents to complete real enterprise tasks end-to-end. It wires together a UI service,
+retrieval-augmented generation (EC-RAG in this case), an LLM router with prompt compression,
+and an OpenClaw agent runtime — agents run reusable Skills that query the knowledge base and
+produce professional deliverables (e.g., competitive-analysis reports).
+
+## Features
+
+- **Multi-agent task automation** — OpenClaw runs a main agent that can spawn sub-agents to
+  complete multi-step enterprise tasks without manual intervention.
+- **Local knowledge base retrieval** — EC-RAG indexes uploaded documents in a Milvus vector
+  store and serves grounded answers through embedding, reranking, and vLLM-based generation.
+- **Hybrid model routing with cost savings** — The Router and compressor front local (vLLM)
+  and cloud models (for example, MiniMax), shrinking prompts before dispatch to cut token
+  usage and latency.
+- **Token consumption monitoring** — The UI shows a live dashboard of local versus cloud
+  token usage, latency, and tokens saved by compression.
+- **Reusable Skills** — Agents load self-contained Skills, such as the competitive-analysis
+  report generator, to produce professional deliverables like HTML and PDF reports.
+- **Conversational UI** — A chat interface with slash commands (for example, `/model`,
+  `/session`, `/tool`) and streaming responses for controlling agents and models
+  mid-conversation.
+- **Multi-language support** — The UI and generated reports support multiple languages,
+  including English and Chinese.
+
+## Skills
+
+| Skill | Description | Status |
+| ----- | ----------- | ------ |
+| `competitive_analysis_PDF_generator` | Competitive-analysis report generator — gathers product info from the local RAG knowledge base plus web search, then produces a professional Chinese HTML/PDF comparison report | Shipped (`SKILL.md` + `query_rag.sh`) |
+| `knowledgebase` | Generic RAG query skill — retrieves any information from the local EC-RAG knowledge base via a curl-based `ecrag` wrapper and generates structured reports, summaries, comparisons, or Q&A responses | Shipped (`SKILL.md` + `ecrag`) |
+
+See the [skills folder](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/metro-ai-suite/enterprise-data-intelligence/skills)
+for the shipped Skills and the [Get Started guide](./get-started.md) for how to install and
+enable a Skill in OpenClaw.
+
+## Architecture
+
+The platform is built around a UI service that talks to the OpenClaw agent runtime. OpenClaw
+orchestrates work through Skills. A Skill retrieves grounded facts from the EC-RAG knowledge
+base, while an LLM router (with a prompt compressor) fronts local and cloud models.
+
+```text
+                 user
+                  │
+                  ▼
+          ┌───────────────┐
+          │      UI       │  :7000
+          └───────┬───────┘
+                  │
+                  ▼
+          ┌───────────────┐        Skills (competitive_analysis_PDF_generator)
+          │   OpenClaw    │  :18789
+          │   agent       │ ◄──────────────┐
+          └───┬───────┬───┘                │ query_rag.sh
+              │       │                     ▼
+   model calls│       │            ┌────────────────┐
+              ▼       │            │  EC-RAG        │  :16011
+      ┌──────────────┐│            │  (retrieval +  │
+      │  Router +    ││            │   vLLM answer) │
+      │  compressor  ││ :8000/:8001└────────────────┘
+      └──────┬───────┘│
+             ▼        ▼
+      local vLLM   cloud models
+      :8086        (MiniMax, …)
+```
+
+### Components
+
+- **UI** — browser-based front end for sending tasks to OpenClaw and viewing generated results.
+- **Router + compressor** — LLM router that fronts local (vLLM) and cloud models, with a
+  LinguaCompressor front end that shrinks prompts before dispatch.
+- **EC-RAG** — Edge Craft RAG: embedding + reranker + vLLM answer generation over an
+  uploadable knowledge base (Milvus vector store).
+- **OpenClaw** — the agent runtime that loads Skills, calls models via the router, and
+  executes tasks (web search, RAG query, PDF generation).
+- **Skills** — reusable, self-contained task recipes under the
+  [skills folder](https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/metro-ai-suite/enterprise-data-intelligence/skills)
+  that agents load at runtime.
+
+## Additional Resources
+
+- [Inference Router microservice](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/inference-router/index.html) — the microservice that implements the Router and compressor.
+- [Get Started guide](./get-started.md) — step-by-step instructions for setting up the
+  platform and running the demo.
+- [Release Notes](./release-notes.md) — a changelog of updates and improvements to the platform.
+
+<!--hide_directive
+:::{toctree}
+:hidden:
+
+get-started.md
+Release Notes <release-notes.md>
+
+:::
+hide_directive-->

--- a/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/enterprise-data-intelligence/docs/user-guide/release-notes.md
@@ -1,14 +1,23 @@
 # Release Notes: Enterprise Data Intelligence
 
-## 2026.2.0
+## Version 2026.2.0
 
-This initial release introduces an agent-native automation platform that combines a local knowledge base with autonomous agents to complete enterprise tasks end-to-end.
+**Release Date**: September 9, 2026
 
-**New**
+This initial release introduces an agent-native automation platform that combines a local
+knowledge base with autonomous agents to complete enterprise tasks end-to-end.
 
-- **Integrated agent workflow**: connects a browser-based UI, the OpenClaw agent runtime, EC-RAG, and an LLM router with prompt compression in a unified enterprise task workflow.
-- **Grounded knowledge retrieval**: uses EC-RAG to retrieve information from an uploadable local knowledge base and generate answers grounded in enterprise data.
-- **Reusable OpenClaw Skills**: includes a generic `knowledgebase` Skill for queries, summaries, comparisons, and structured reports, plus a `competitive_analysis_PDF_generator` Skill for specialized analysis.
-- **Competitive-analysis reports**: combines information from the local knowledge base with web search to generate professional Chinese HTML and PDF comparison reports.
-- **Flexible model access**: routes agent model calls to local vLLM or cloud models and uses LinguaCompressor to reduce prompts before dispatch.
-- **Containerized UI**: provides a Docker Compose deployment for submitting tasks to OpenClaw and viewing generated results in a browser.
+**New**:
+
+- **Integrated agent workflow**: connects a browser-based UI, the OpenClaw agent runtime,
+  EC-RAG, and an LLM router with prompt compression in a unified enterprise task workflow.
+- **Grounded knowledge retrieval**: uses EC-RAG to retrieve information from an uploadable
+  local knowledge base and generate answers grounded in enterprise data.
+- **Reusable OpenClaw Skills**: includes a generic `knowledgebase` Skill for queries,
+  summaries, comparisons, and structured reports, plus a `competitive_analysis_PDF_generator` Skill for specialized analysis.
+- **Competitive-analysis reports**: combines information from the local knowledge base with
+  web search to generate professional Chinese HTML and PDF comparison reports.
+- **Flexible model access**: routes agent model calls to local vLLM or cloud models and uses
+  LinguaCompressor to reduce prompts before dispatch.
+- **Containerized UI**: provides a Docker Compose deployment for submitting tasks to OpenClaw
+  and viewing generated results in a browser.


### PR DESCRIPTION
### Description

Basic publishing readiness for the OEP docs website for Enterprise Data Intelligence.

- add `index.md` with a GH link block and a ToC structure
- content for `index.md` based on README, with the addition of a section listing Features
- adjusted links (e.g. to link to the Inference Router documentation published on the OEP docs site) 
- update the formatting in Get Started 

Port from #3887 

### How Has This Been Tested?

Docs built locally. Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.