### PR TITLE
[Agentic-Smart-Community] VSA: record via ffmpeg codec copy, drop decode/re-encode path

### DIFF
--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/Dockerfile
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/docker/Dockerfile
@@ -119,18 +119,42 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y \
     && rm -rf /var/lib/apt/lists/*
 
 # --enable-libx264: the app re-encodes clips to browser-compatible H.264
-# (roi_processor.py / roi.py). --disable-network: only file:// I/O is used
-# (RTSP ingest goes through OpenCV's bundled ffmpeg). Static libav* -> single
-# binary; only runtime dependency is libx264-164.
+# (roi_processor.py / roi.py).
+# --enable-network: REQUIRED by the continuous recorder's default "copy"
+# backend, which pulls RTSP itself (`ffmpeg -rtsp_transport tcp -c copy -f
+# segment`) instead of decoding through OpenCV — see stream_monitor/
+# continuous_recorder.py. Without it the rtsp demuxer is compiled out
+# entirely and every recording session dies with "Protocol not found".
+# No TLS library is linked, so https/rtmps stay unavailable; a protocol
+# whitelist is deliberately NOT used because configure's
+# rtsp_demuxer_select pulls http_protocol back in regardless.
+# --disable-ffprobe: nothing shells out to ffprobe (the recorder reads
+# durations from ffmpeg's own segment list). Static libav* -> single binary;
+# only runtime dependency is libx264-164.
 RUN cd "/src/ffmpeg/ffmpeg-${FFMPEG_VERSION}" \
     && ./configure \
-        --disable-doc --disable-debug --disable-network \
+        --disable-doc --disable-debug --enable-network \
         --disable-ffplay --disable-ffprobe \
         --enable-pic --enable-static --disable-shared \
         --enable-gpl --enable-libx264 \
         --extra-libs=-lpthread --extra-libs=-lm \
     && make -j"$(nproc)" ffmpeg \
     && install -m 755 ffmpeg /usr/local/bin/ffmpeg
+
+# Build-time capability assertion: a network-less ffmpeg still builds and runs
+# fine, it just fails at the first recording session in production. Fail the
+# BUILD instead (same intent as the gst engine's gst-inspect assertions).
+RUN set -eu; \
+    ff=/usr/local/bin/ffmpeg; \
+    "$ff" -hide_banner -formats 2>/dev/null | grep -qE '^ *D[E ]? *rtsp( |$)' \
+        || { echo "MISSING: ffmpeg rtsp demuxer (--enable-network?)"; exit 1; }; \
+    for proto in file pipe tcp rtp; do \
+        "$ff" -hide_banner -protocols 2>/dev/null | grep -qE "^ *${proto}\$" \
+            || { echo "MISSING: ffmpeg protocol ${proto}"; exit 1; }; \
+    done; \
+    "$ff" -hide_banner -h encoder=libx264 2>/dev/null | grep -q '^Encoder libx264' \
+        || { echo "MISSING: ffmpeg libx264 encoder"; exit 1; }; \
+    echo "ffmpeg capabilities OK (rtsp demuxer + file/pipe/tcp/rtp + libx264)"
 
 # ---------------------------------------------------------------------------
 FROM python-base AS runtime

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/shared/config.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/shared/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional, TypeVar
+from typing import Literal, Optional, TypeVar
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
@@ -59,6 +59,13 @@ class RecordingConfig(BaseModel):
     a legacy alias accepted on input but written as `interval_seconds`.
     Recordings on disk are pruned by the MCP server (storage.retention_days);
     VSA does not do its own retention cleanup.
+
+    `backend` selects how segments are produced:
+      - "copy" (default): an ffmpeg subprocess pulls the stream and cuts
+        segments with `-c copy` — no decode, no encode, original codec/bitrate
+        preserved. Requires ffmpeg on PATH.
+      - "x264" (rollback): cv2 decode + libx264 re-encode via H264SegmentWriter.
+        Kept as an escape hatch; `fps` is only used by this backend.
     """
 
     model_config = ConfigDict(populate_by_name=True)
@@ -66,6 +73,7 @@ class RecordingConfig(BaseModel):
     enabled: bool = True
     interval_seconds: int = Field(default=60, alias="interval")
     fps: int = 15
+    backend: Literal["copy", "x264"] = "copy"
 
 
 class RoiConfig(BaseModel):

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
@@ -15,6 +15,7 @@ Two backends (RecordingConfig.backend):
 from __future__ import annotations
 
 import glob
+import itertools
 import logging
 import os
 import shutil
@@ -70,6 +71,10 @@ class ContinuousRecorder(BaseMonitor):
         # mismatch at its next loop check and exits instead of resurrecting.
         self._generation = 0
         self._status = "stopped"
+        # Copy backend: one token per ffmpeg session, embedded in the segment
+        # names it writes. `itertools.count.__next__` is atomic, so a superseded
+        # generation's thread racing a fresh one still gets a distinct value.
+        self._session_seq = itertools.count(1)
 
     @property
     def status(self) -> str:
@@ -186,12 +191,22 @@ class ContinuousRecorder(BaseMonitor):
             raise ConnectionError("ffmpeg not found on PATH; cannot record (copy backend)")
 
         self._ensure_date_dirs()
+        # Per-session token. ffmpeg's -strftime has no sub-second specifier and
+        # -y overwrites silently, so two segments named in the same wall-clock
+        # second would destroy each other's file AND collapse into one event
+        # (_drain_segment_list dedupes by name). Within one session that cannot
+        # happen (segments are >=1s apart), but across sessions it can — a
+        # sub-second pause/resume flap, or a reconnect landing on the same
+        # second. The token makes cross-session names disjoint; the pid keeps it
+        # true across process restarts. Starts with a letter so
+        # _segment_start_from_path can never mistake it for HHMMSS.
+        session_tag = f"s{os.getpid():x}x{next(self._session_seq):x}"
         list_path = os.path.join(
-            self._output_dir, f".segments_{os.getpid()}_{generation}.csv"
+            self._output_dir, f".segments_{os.getpid()}_{generation}_{session_tag}.csv"
         )
         self._cleanup_stale_lists(keep=os.path.basename(list_path))
         pattern = os.path.join(
-            self._output_dir, "%Y-%m-%d", f"{self.source_id}_%H%M%S.mp4"
+            self._output_dir, "%Y-%m-%d", f"{self.source_id}_%H%M%S_{session_tag}.mp4"
         )
 
         args = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y"]
@@ -359,14 +374,24 @@ class ContinuousRecorder(BaseMonitor):
         logger.debug("[%s] Segment: %.1fs, %s", self.source_id, duration, path)
 
     def _segment_start_from_path(self, path: str) -> datetime | None:
-        """Recover segment wall-clock start from `<date>/<source_id>_<HHMMSS>.mp4`."""
-        try:
-            date_dir = os.path.basename(os.path.dirname(path))
-            stem = os.path.splitext(os.path.basename(path))[0]
-            hms = stem.rsplit("_", 1)[1]
-            return datetime.strptime(f"{date_dir} {hms}", "%Y-%m-%d %H%M%S")
-        except (ValueError, IndexError):
-            return None
+        """Recover segment wall-clock start from `<date>/<source_id>_<HHMMSS>[_<suffix>].mp4`.
+
+        The HHMMSS field is found by scanning underscore-separated fields from
+        the right for the first all-digit 6-char one, so this handles the copy
+        backend's `_<session_tag>` suffix (never all digits — it starts with
+        "s") and the x264 backend's `_<ms>` suffix (3 digits) without needing to
+        know which wrote the file. A `source_id` that itself ends in 6 digits is
+        safe for the same reason: the scan stops at the rightmost match.
+        """
+        date_dir = os.path.basename(os.path.dirname(path))
+        stem = os.path.splitext(os.path.basename(path))[0]
+        for field in reversed(stem.split("_")):
+            if len(field) == 6 and field.isdigit():
+                try:
+                    return datetime.strptime(f"{date_dir} {field}", "%Y-%m-%d %H%M%S")
+                except ValueError:
+                    return None
+        return None
 
     def _ensure_date_dirs(self) -> None:
         """Pre-create today + tomorrow date dirs (ffmpeg won't mkdir at rollover)."""

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/continuous_recorder.py
@@ -1,16 +1,27 @@
 """Continuous recorder — fixed-interval segment recording independent of motion detection.
 
-Runs in its own thread with its own VideoCapture, parallel to the motion pipeline.
-Produces time-based segments (default 60s) and optionally emits recording events via sink.
-Old segments are pruned by the MCP server (storage.retention_days).
+Runs in its own thread, parallel to the motion pipeline, and emits recording
+events via sink. Old segments are pruned by the MCP server (storage.retention_days).
+
+Two backends (RecordingConfig.backend):
+  - "copy" (default): one ffmpeg subprocess per session pulls the stream and
+    cuts segments with `-c copy` — no decode, no encode, original codec and
+    bitrate preserved, near-zero CPU. Segment boundaries align to the source
+    GOP (ffmpeg cuts at the first keyframe at/after segment_time).
+  - "x264": own cv2.VideoCapture (a second RTSP session per source), decode +
+    libx264 re-encode via H264SegmentWriter. Kept as a rollback escape hatch.
 """
 
 from __future__ import annotations
 
+import glob
 import logging
 import os
+import shutil
+import signal
+import subprocess
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import cv2
 
@@ -22,6 +33,10 @@ from stream_monitor.base_monitor import BaseMonitor
 from stream_monitor.h264_writer import H264SegmentWriter
 
 logger = logging.getLogger(__name__)
+
+# Socket I/O stall tolerance for the copy backend (rtsp demuxer `-timeout`,
+# microseconds — only meaningful with TCP transport).
+_RW_TIMEOUT_US = 15_000_000
 
 
 class ContinuousRecorder(BaseMonitor):
@@ -110,21 +125,24 @@ class ContinuousRecorder(BaseMonitor):
         logger.info("[%s] Continuous recorder resumed", self.source_id)
 
     def _run(self, generation: int):
-        """Main loop: connect, record segments, reconnect on failure."""
+        """Main loop: record segments, reconnect on failure."""
         while self._running and self._generation == generation:
             cap = None
             try:
-                cap = cv2.VideoCapture(self.rtsp_url, cv2.CAP_FFMPEG)
-                if not cap.isOpened():
-                    raise ConnectionError(f"Cannot open RTSP: {self.rtsp_url}")
+                if self._cfg.backend == "copy":
+                    self._record_loop_copy(generation)
+                else:
+                    cap = cv2.VideoCapture(self.rtsp_url, cv2.CAP_FFMPEG)
+                    if not cap.isOpened():
+                        raise ConnectionError(f"Cannot open RTSP: {self.rtsp_url}")
 
-                fps = cap.get(cv2.CAP_PROP_FPS) or self._cfg.fps
-                w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 640
-                h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 480
+                    fps = cap.get(cv2.CAP_PROP_FPS) or self._cfg.fps
+                    w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 640
+                    h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 480
 
-                self._status = "recording"
-                logger.info("[%s] Recording: %dx%d @ %.1f fps", self.source_id, w, h, fps)
-                self._record_loop(cap, fps, w, h, generation)
+                    self._status = "recording"
+                    logger.info("[%s] Recording: %dx%d @ %.1f fps", self.source_id, w, h, fps)
+                    self._record_loop(cap, fps, w, h, generation)
 
             except Exception as e:
                 logger.error("[%s] Recorder error: %s", self.source_id, e)
@@ -138,6 +156,248 @@ class ContinuousRecorder(BaseMonitor):
                 logger.info("[%s] Recorder reconnecting in 10s...", self.source_id)
                 if self._stop_event.wait(10):
                     break
+
+    # ------------------------------------------------------------------
+    # "copy" backend: ffmpeg -c copy segmenting, no decode/encode.
+    # ------------------------------------------------------------------
+
+    def _record_loop_copy(self, generation: int):
+        """Run ffmpeg segmenting sessions until paused/stopped/failed."""
+        while self._running and self._generation == generation:
+            if not self._paused.is_set():
+                if not self._paused.wait(timeout=1.0):
+                    continue
+                if not self._running or self._generation != generation:
+                    return
+
+            # ffmpeg exited on its own (stream error / EOF) → back to _run's
+            # reconnect backoff; interrupted by pause/stop → loop here (park or exit).
+            if not self._run_copy_session(generation):
+                return
+
+    def _run_copy_session(self, generation: int) -> bool:
+        """Run one ffmpeg segmenting session.
+
+        Returns True when the session was interrupted by pause/stop (caller
+        loops back to the pause park), False when ffmpeg exited on its own
+        (caller reconnects).
+        """
+        if shutil.which("ffmpeg") is None:
+            raise ConnectionError("ffmpeg not found on PATH; cannot record (copy backend)")
+
+        self._ensure_date_dirs()
+        list_path = os.path.join(
+            self._output_dir, f".segments_{os.getpid()}_{generation}.csv"
+        )
+        self._cleanup_stale_lists(keep=os.path.basename(list_path))
+        pattern = os.path.join(
+            self._output_dir, "%Y-%m-%d", f"{self.source_id}_%H%M%S.mp4"
+        )
+
+        args = ["ffmpeg", "-hide_banner", "-loglevel", "error", "-y"]
+        if self.rtsp_url.startswith("rtsp://"):
+            args += ["-rtsp_transport", "tcp", "-timeout", str(_RW_TIMEOUT_US)]
+        else:
+            # File/test inputs: pace reads like a live source so segment timing
+            # (and strftime naming) behaves as it would for RTSP.
+            args += ["-re"]
+        args += [
+            "-i", self.rtsp_url,
+            "-map", "0:v:0", "-c", "copy", "-an",
+            "-avoid_negative_ts", "make_zero",
+            "-f", "segment",
+            "-segment_time", str(self._cfg.interval_seconds),
+            "-reset_timestamps", "1",
+            # moov up front per segment, so the dashboard can seek with one
+            # range request (same contract as the x264 backend's +faststart).
+            "-segment_format_options", "movflags=+faststart",
+            "-segment_list", list_path, "-segment_list_type", "csv",
+            "-strftime", "1",
+            pattern,
+        ]
+
+        log_file = open(list_path + ".log", "wb")
+        try:
+            proc = subprocess.Popen(
+                args, stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+                stderr=log_file,
+            )
+        except OSError as exc:
+            log_file.close()
+            raise ConnectionError(f"Cannot start ffmpeg: {exc}") from exc
+
+        self._status = "recording"
+        logger.info(
+            "[%s] Recording (copy): %ds segments from %s",
+            self.source_id, self._cfg.interval_seconds, self.rtsp_url,
+        )
+
+        emitted: set[str] = set()
+        interrupted = False
+        try:
+            interrupted = self._watch_copy_session(proc, generation, list_path, emitted)
+            return interrupted
+        finally:
+            rc = proc.poll()
+            # ffmpeg exits 255 on SIGINT — only log when it died on its own.
+            if rc and not interrupted:
+                tail = self._read_log_tail(list_path)
+                if tail:
+                    logger.error("[%s] ffmpeg exited %s: %s", self.source_id, rc, tail)
+            log_file.close()
+            try:
+                os.remove(list_path)
+                os.remove(list_path + ".log")
+            except OSError:
+                pass
+
+    def _watch_copy_session(
+        self, proc: subprocess.Popen, generation: int, list_path: str, emitted: set[str]
+    ) -> bool:
+        """Poll a running ffmpeg; drain completed segments; interrupt on pause/stop."""
+        while True:
+            rc = proc.poll()
+            self._drain_segment_list(list_path, emitted)
+            if rc is not None:
+                return False
+            if not self._running or self._generation != generation or not self._paused.is_set():
+                self._finalize_ffmpeg(proc)
+                # SIGINT flushed the in-progress segment's entry — drain once more.
+                self._drain_segment_list(list_path, emitted)
+                return True
+            self._stop_event.wait(0.2)
+
+    @staticmethod
+    def _finalize_ffmpeg(proc: subprocess.Popen) -> None:
+        """SIGINT so ffmpeg writes the moov + final segment-list entry; kill on stall."""
+        try:
+            proc.send_signal(signal.SIGINT)
+        except OSError:
+            return
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("ffmpeg did not exit on SIGINT; killing")
+            proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+    def _drain_segment_list(self, list_path: str, emitted: set[str]) -> None:
+        """Emit events for newly completed segments from ffmpeg's csv list.
+
+        The segment muxer appends `name,start,end` when a segment file is
+        finalized, so every entry seen here is a complete, playable file.
+        Duration comes from the list (start/end are on the continuous input
+        timeline), segment wall-clock start from the strftime filename — no
+        ffprobe needed (the production image builds ffmpeg without it).
+        """
+        self._ensure_date_dirs()
+        try:
+            with open(list_path, "r", encoding="utf-8") as f:
+                lines = f.read().splitlines()
+        except OSError:
+            return
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            # `name,start,end` — split from the right so a comma in source_id
+            # (and thus in name) can't break parsing.
+            parts = line.rsplit(",", 2)
+            if len(parts) != 3:
+                continue
+            name, start_s, end_s = parts
+            name = name.strip()
+            if not name or name in emitted:
+                continue
+            try:
+                duration = float(end_s) - float(start_s)
+            except ValueError:
+                continue
+            if duration <= 0:
+                continue
+            path = self._resolve_segment_path(name)
+            if path is None:
+                continue
+            emitted.add(name)
+            self._emit_copy_segment(path, duration)
+
+    def _resolve_segment_path(self, name: str) -> str | None:
+        """Resolve a segment-list entry to the actual file path.
+
+        ffmpeg writes just the basename into the list even when the output
+        pattern contains directories, so search the date dirs (only a couple
+        exist at any time thanks to MCP retention).
+        """
+        if os.path.dirname(name):
+            return name if os.path.exists(name) else None
+        matches = glob.glob(os.path.join(self._output_dir, "*", name))
+        if not matches:
+            return None
+        matches.sort(key=os.path.getmtime)
+        return matches[-1]
+
+    def _emit_copy_segment(self, path: str, duration: float) -> None:
+        """Emit one completed copy-backend segment with the standard payload."""
+        start_time = self._segment_start_from_path(path) or datetime.now()
+        end_time = start_time + timedelta(seconds=duration)
+        payload: dict[str, Any] = {
+            "recording_path": path,
+            "recording_start": start_time.isoformat(timespec="seconds"),
+            "recording_end": end_time.isoformat(timespec="seconds"),
+            "duration_seconds": round(duration, 1),
+            "file_size_bytes": os.path.getsize(path) if os.path.exists(path) else 0,
+        }
+        self._sink.emit({
+            "sourceId": self.source_id,
+            "type": "recording",
+            "timestamp": payload["recording_end"],
+            "payload": payload,
+        })
+        logger.debug("[%s] Segment: %.1fs, %s", self.source_id, duration, path)
+
+    def _segment_start_from_path(self, path: str) -> datetime | None:
+        """Recover segment wall-clock start from `<date>/<source_id>_<HHMMSS>.mp4`."""
+        try:
+            date_dir = os.path.basename(os.path.dirname(path))
+            stem = os.path.splitext(os.path.basename(path))[0]
+            hms = stem.rsplit("_", 1)[1]
+            return datetime.strptime(f"{date_dir} {hms}", "%Y-%m-%d %H%M%S")
+        except (ValueError, IndexError):
+            return None
+
+    def _ensure_date_dirs(self) -> None:
+        """Pre-create today + tomorrow date dirs (ffmpeg won't mkdir at rollover)."""
+        today = datetime.now().date()
+        for day in (today, today + timedelta(days=1)):
+            os.makedirs(
+                os.path.join(self._output_dir, day.strftime("%Y-%m-%d")), exist_ok=True
+            )
+
+    def _cleanup_stale_lists(self, keep: str = "") -> None:
+        """Remove segment-list files left behind by crashed sessions."""
+        try:
+            for name in os.listdir(self._output_dir):
+                if name.startswith(".segments_") and not name.startswith(keep):
+                    try:
+                        os.remove(os.path.join(self._output_dir, name))
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    @staticmethod
+    def _read_log_tail(list_path: str, limit: int = 500) -> str:
+        try:
+            with open(list_path + ".log", "rb") as f:
+                f.seek(0, os.SEEK_END)
+                size = f.tell()
+                f.seek(max(0, size - 4096))
+                return f.read().decode("utf-8", "replace")[-limit:].strip()
+        except OSError:
+            return ""
 
     def _record_loop(self, cap: cv2.VideoCapture, fps: float, w: int, h: int, generation: int):
         """Record frames in fixed-interval segments."""

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/segment_extractor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/pipeline/segment_extractor.py
@@ -3,10 +3,16 @@
 Segment length is bounded by `max_duration`. Nothing recorded is dropped for
 being short — `min_duration` only gates forced cuts upstream (see the
 early-split logic in rtsp_monitor), so motion-end tails always reach the VLM.
+
+Segments are written as browser-playable H.264 directly (H264SegmentWriter
+pipes frames to ffmpeg/libx264). The previous mp4v intermediate + post-hoc
+`transcode_h264_in_place` pass cost a decode + a re-encode per segment in the
+pipeline thread; the direct writer replaces both with a single encode.
 """
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import datetime
 from pathlib import Path
@@ -16,6 +22,9 @@ import cv2
 
 from shared.config import SegmentConfig
 from shared.time_utils import now_local_str
+from stream_monitor.h264_writer import H264SegmentWriter
+
+logger = logging.getLogger(__name__)
 
 
 class SegmentResult:
@@ -42,10 +51,13 @@ class SegmentExtractor:
         self.fps = fps
         self.frame_size = frame_size
 
-        self._writer: Optional[cv2.VideoWriter] = None
+        self._writer: Optional[H264SegmentWriter] = None
         self._current_path: Optional[str] = None
         self._frame_count = 0
         self._start_time: Optional[str] = None
+        # Latch: writer open failure disables writing (not retries-per-frame)
+        # until the next explicit start_segment.
+        self._write_failed = False
 
         os.makedirs(output_dir, exist_ok=True)
 
@@ -76,14 +88,28 @@ class SegmentExtractor:
         self._start_time = now_local_str()
         self._frame_count = 0
 
-        fourcc = cv2.VideoWriter.fourcc(*"mp4v")
-        self._writer = cv2.VideoWriter(
-            self._current_path, fourcc, self.fps, self.frame_size
-        )
+        writer = H264SegmentWriter(self._current_path, self.fps, *self.frame_size)
+        if not writer.isOpened():
+            logger.error(
+                "[%s] Cannot open segment writer (ffmpeg on PATH?): %s",
+                self.source_id, self._current_path,
+            )
+            self._write_failed = True
+            self._writer = None
+            return
+        self._write_failed = False
+        self._writer = writer
 
     def add_frame(self, frame: cv2.typing.MatLike) -> Optional[SegmentResult]:
         """Add a frame. Returns SegmentResult when interval reached."""
         if self._writer is None:
+            if self._write_failed:
+                # Writer unavailable: keep counting so duration/exit logic and
+                # the next segment rotation keep working, just drop the pixels.
+                self._frame_count += 1
+                if self._frame_count / self.fps >= self.max_duration:
+                    self.finish()
+                return None
             self.start_segment()
 
         self._writer.write(frame)  # type: ignore
@@ -98,24 +124,36 @@ class SegmentExtractor:
         """Finalize the current segment and return it for emission.
 
         Recorded content is never dropped for being short — a short tail at
-        motion end still reaches the VLM. The only discarded file is an empty
-        one (0 frames written — nothing to analyze).
+        motion end still reaches the VLM. Discarded files: empty (0 frames) or
+        broken (writer died mid-segment — an mp4 without its moov is useless
+        to the VLM and the dashboard).
         """
-        if self._writer is None or self._current_path is None:
+        if self._current_path is None:
             return None
 
-        self._writer.release()
-        self._writer = None
+        writer, self._writer = self._writer, None
+        if writer is not None:
+            # Capture before release: a mid-segment pipe death means the file
+            # was never finalized.
+            writer_alive = writer.isOpened()
+            writer.release()
+        else:
+            writer_alive = False
 
         duration = self._frame_count / self.fps
         end_time = now_local_str()
 
-        if self._frame_count == 0:
+        if self._frame_count == 0 or self._write_failed or not writer_alive:
+            if self._frame_count > 0 and not self._write_failed:
+                logger.warning(
+                    "[%s] Segment writer died mid-segment, discarding %s",
+                    self.source_id, self._current_path,
+                )
             try:
                 os.unlink(self._current_path)
             except OSError:
                 pass
-            self._current_path = None
+            self._reset()
             return None
 
         result = SegmentResult(
@@ -124,17 +162,20 @@ class SegmentExtractor:
             start_time=self._start_time or end_time,
             end_time=end_time,
         )
+        self._reset()
+        return result
+
+    def _reset(self):
         self._current_path = None
         self._start_time = None
         self._frame_count = 0
-        return result
+        self._write_failed = False
 
     def close(self) -> Optional[SegmentResult]:
         """Release the writer, finalizing the open segment.
 
         Delegates to finish(): the segment is returned for the caller to emit
-        (only 0-frame files are removed). Never leaves an un-finalized file
-        behind — the previous implementation could keep a file on disk without
-        handing it to anyone.
+        (only 0-frame/broken files are removed). Never leaves an un-finalized
+        file behind.
         """
         return self.finish()

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/rtsp_monitor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/stream_monitor/rtsp_monitor.py
@@ -38,7 +38,7 @@ from stream_monitor.base_monitor import BaseMonitor
 from stream_monitor.pipeline.motion_detector import MotionDetector
 from stream_monitor.pipeline.segment_extractor import SegmentExtractor
 from stream_monitor.pipeline.prefilter_yolo import YoloPrefilter, FramePrefilter
-from stream_monitor.pipeline.roi_processor import prepare_roi_segment, transcode_h264_in_place
+from stream_monitor.pipeline.roi_processor import prepare_roi_segment
 
 logger = logging.getLogger(__name__)
 
@@ -576,7 +576,9 @@ class StreamPipeline(BaseMonitor):
             if os.path.exists(crop_path):
                 summary_clip_input = crop_path
 
-        transcode_h264_in_place(clip_path)
+        # No transcode pass here: SegmentExtractor writes browser-playable
+        # H.264 directly via H264SegmentWriter (ROI variants transcode their
+        # own output inside prepare_roi_segment).
 
         payload: dict[str, Any] = {
             "event_file_path": clip_path,

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
@@ -1,15 +1,44 @@
 """Tests for ContinuousRecorder."""
 
 import os
+import subprocess
 import time
 from unittest.mock import MagicMock
 
 import pytest
 
-from shared.config import RecordingConfig, SourceConfig
+from shared.config import RecordingConfig, SourceConfig, merge_config
 from stream_monitor.continuous_recorder import ContinuousRecorder
 from stream_monitor.base_monitor import BaseMonitor
 from sinks import EventSink
+
+
+def make_recorder(tmp_path, sink, backend="copy", interval=5, fps=15, source_id="test_recorder", source_url="rtsp://localhost:8554/live/test"):
+    source = SourceConfig(source_id=source_id, source_url=source_url)
+    cfg = RecordingConfig(interval=interval, fps=fps, backend=backend)
+    return ContinuousRecorder(
+        source=source,
+        recording_cfg=cfg,
+        data_dir=str(tmp_path),
+        sink=sink,
+    )
+
+
+class TestRecordingConfigBackend:
+    def test_default_backend_is_copy(self):
+        assert RecordingConfig().backend == "copy"
+
+    def test_x264_backend_accepted(self):
+        assert RecordingConfig(backend="x264").backend == "x264"
+
+    def test_invalid_backend_rejected(self):
+        with pytest.raises(Exception):
+            RecordingConfig(backend="bogus")
+
+    def test_merge_config_keeps_default_backend(self):
+        merged = merge_config(RecordingConfig(), RecordingConfig(interval=30))
+        assert merged.backend == "copy"
+        assert merged.interval_seconds == 30
 
 
 class TestContinuousRecorderLifecycle:
@@ -21,16 +50,7 @@ class TestContinuousRecorderLifecycle:
 
     @pytest.fixture
     def recorder(self, tmp_path, mock_sink):
-        source = SourceConfig(
-            source_id="test_recorder", source_url="rtsp://localhost:8554/live/test"
-        )
-        cfg = RecordingConfig(interval=5, fps=15)
-        return ContinuousRecorder(
-            source=source,
-            recording_cfg=cfg,
-            data_dir=str(tmp_path),
-            sink=mock_sink,
-        )
+        return make_recorder(tmp_path, mock_sink)
 
     def test_inherits_base_monitor(self, recorder):
         assert isinstance(recorder, BaseMonitor)
@@ -79,6 +99,28 @@ class TestContinuousRecorderLifecycle:
         assert os.path.isdir(expected)
 
 
+def recording_events(sink):
+    return [
+        call.args[0] for call in sink.emit.call_args_list
+        if call.args[0].get("type") == "recording"
+    ]
+
+
+def assert_recording_event_contract(event, source_id):
+    assert event["sourceId"] == source_id
+    payload = event["payload"]
+    assert payload["duration_seconds"] > 0
+    assert payload["recording_path"].endswith(".mp4")
+    assert os.path.exists(payload["recording_path"])
+    assert "recording_start" in payload
+    assert "recording_end" in payload
+    assert "file_size_bytes" in payload
+    # recordings must stay under <data_dir>/recordings/<YYYY-MM-DD>/ —
+    # MCP storage-cleaner prunes by that date-dir layout.
+    assert os.path.basename(os.path.dirname(payload["recording_path"])).count("-") == 2
+
+
+@pytest.mark.parametrize("backend", ["copy", "x264"])
 class TestContinuousRecorderWithVideo:
     @pytest.fixture
     def mock_sink(self):
@@ -87,20 +129,13 @@ class TestContinuousRecorderWithVideo:
         return sink
 
     @pytest.fixture
-    def recorder(self, test_video_path, tmp_path, mock_sink):
-        source = SourceConfig(
-            source_id="test_recording",
-            source_url=test_video_path,
-        )
-        cfg = RecordingConfig(interval=3, fps=30)
-        return ContinuousRecorder(
-            source=source,
-            recording_cfg=cfg,
-            data_dir=str(tmp_path),
-            sink=mock_sink,
+    def recorder(self, test_video_path, tmp_path, mock_sink, backend):
+        return make_recorder(
+            tmp_path, mock_sink, backend=backend, interval=2, fps=30,
+            source_id="test_recording", source_url=test_video_path,
         )
 
-    def test_recorder_produces_segments(self, recorder, mock_sink, tmp_path):
+    def test_recorder_produces_segments(self, recorder, mock_sink, backend):
         """Recorder should produce at least 1 segment from a real video.
 
         Events use the nested envelope `{sourceId, type, timestamp, payload}`;
@@ -110,18 +145,118 @@ class TestContinuousRecorderWithVideo:
         time.sleep(8)
         recorder.stop()
 
-        recording_events = [
-            call.args[0] for call in mock_sink.emit.call_args_list
-            if call.args[0].get("type") == "recording"
-        ]
-        assert len(recording_events) >= 1
+        events = recording_events(mock_sink)
+        assert len(events) >= 1
+        assert_recording_event_contract(events[0], "test_recording")
 
-        event = recording_events[0]
-        assert event["sourceId"] == "test_recording"
-        payload = event["payload"]
-        assert payload["duration_seconds"] > 0
-        assert payload["recording_path"].endswith(".mp4")
-        assert os.path.exists(payload["recording_path"])
-        assert "recording_start" in payload
-        assert "recording_end" in payload
-        assert "file_size_bytes" in payload
+        payload = events[0]["payload"]
+        # copy backend: duration comes from ffmpeg's segment list (packet
+        # timeline), so a full segment ≈ the configured interval.
+        if backend == "copy":
+            assert 1.5 <= payload["duration_seconds"] <= 3.5
+
+
+class TestCopyBackend:
+    @pytest.fixture
+    def mock_sink(self):
+        sink = MagicMock(spec=EventSink)
+        sink.emit.return_value = True
+        return sink
+
+    def test_pause_mid_segment_emits_partial(self, test_video_path, tmp_path, mock_sink):
+        """Pausing mid-segment SIGINTs ffmpeg; the partial segment is finalized
+        and emitted (same contract as the x264 backend's paused cut)."""
+        recorder = make_recorder(
+            tmp_path, mock_sink, interval=30,
+            source_id="test_pause", source_url=test_video_path,
+        )
+        recorder.start()
+        time.sleep(4)
+        recorder.pause()
+        # pause -> finalize -> emit happens in the recorder thread; give it a moment
+        time.sleep(1)
+        try:
+            assert recorder.status == "paused"
+            events = recording_events(mock_sink)
+            assert len(events) == 1
+            payload = events[0]["payload"]
+            assert 2.0 <= payload["duration_seconds"] <= 8.0
+            assert_recording_event_contract(events[0], "test_pause")
+        finally:
+            recorder.stop()
+
+    def test_stop_mid_segment_emits_partial(self, test_video_path, tmp_path, mock_sink):
+        recorder = make_recorder(
+            tmp_path, mock_sink, interval=30,
+            source_id="test_stop", source_url=test_video_path,
+        )
+        recorder.start()
+        time.sleep(4)
+        recorder.stop()
+
+        assert recorder.status == "stopped"
+        events = recording_events(mock_sink)
+        assert len(events) == 1
+        payload = events[0]["payload"]
+        assert 2.0 <= payload["duration_seconds"] <= 8.0
+
+    def test_no_list_files_left_behind(self, test_video_path, tmp_path, mock_sink):
+        recorder = make_recorder(
+            tmp_path, mock_sink, interval=2,
+            source_id="test_clean", source_url=test_video_path,
+        )
+        recorder.start()
+        time.sleep(5)
+        recorder.stop()
+
+        leftovers = [
+            n for n in os.listdir(os.path.join(str(tmp_path), "recordings"))
+            if n.startswith(".segments_")
+        ]
+        assert leftovers == []
+
+    def test_segment_start_from_path(self, tmp_path, mock_sink):
+        recorder = make_recorder(tmp_path, mock_sink)
+        path = "/data/recordings/2026-08-17/cam1_132045.mp4"
+        dt = recorder._segment_start_from_path(path)
+        assert dt is not None
+        assert (dt.year, dt.month, dt.day) == (2026, 8, 17)
+        assert (dt.hour, dt.minute, dt.second) == (13, 20, 45)
+
+    def test_segment_start_from_path_bad_input(self, tmp_path, mock_sink):
+        recorder = make_recorder(tmp_path, mock_sink)
+        assert recorder._segment_start_from_path("/data/recordings/cam1.mp4") is None
+
+    def test_drain_skips_malformed_lines(self, tmp_path, mock_sink):
+        recorder = make_recorder(tmp_path, mock_sink)
+        list_path = os.path.join(str(tmp_path), "recordings", ".list.csv")
+        with open(list_path, "w") as f:
+            f.write("garbage\n")
+            f.write("no-floats,here,please\n")
+            f.write("missing.mp4,0.000000,4.000000\n")  # file doesn't exist
+        emitted = set()
+        recorder._drain_segment_list(list_path, emitted)
+        mock_sink.emit.assert_not_called()
+        assert emitted == set()
+
+    def test_finalize_ffmpeg_interrupts_long_process(self, tmp_path, mock_sink):
+        recorder = make_recorder(tmp_path, mock_sink)
+        proc = subprocess.Popen(["sleep", "60"])
+        start = time.monotonic()
+        recorder._finalize_ffmpeg(proc)
+        elapsed = time.monotonic() - start
+        assert proc.poll() is not None
+        assert elapsed < 10
+
+    def test_connection_error_reconnects_and_stops(self, mock_sink, tmp_path):
+        """Unreachable source: copy session fails fast, _run backs off, stop() exits."""
+        recorder = make_recorder(
+            tmp_path, mock_sink, interval=2,
+            source_id="test_down", source_url="rtsp://127.0.0.1:1/none",
+        )
+        recorder.start()
+        time.sleep(3)
+        recorder.stop()
+        assert recorder.status == "stopped"
+        # no recording events for a dead source
+        assert recording_events(mock_sink) == []

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_continuous_recorder.py
@@ -200,6 +200,33 @@ class TestCopyBackend:
         payload = events[0]["payload"]
         assert 2.0 <= payload["duration_seconds"] <= 8.0
 
+    def test_every_segment_keeps_its_own_file(self, test_video_path, tmp_path, mock_sink):
+        """One emitted event per segment file, every file still on disk.
+
+        Guards the -y overwrite trap: ffmpeg's -strftime has no sub-second
+        specifier, so if two segments ever resolve to the same name the second
+        one destroys the first and only one event survives the name-keyed dedupe.
+        """
+        recorder = make_recorder(
+            tmp_path, mock_sink, interval=2,
+            source_id="test_unique", source_url=test_video_path,
+        )
+        recorder.start()
+        time.sleep(9)
+        recorder.stop()
+
+        events = recording_events(mock_sink)
+        assert len(events) >= 3, f"expected several segments, got {len(events)}"
+        paths = [e["payload"]["recording_path"] for e in events]
+        assert len(set(paths)) == len(paths), f"duplicate segment names: {paths}"
+        for path in paths:
+            assert os.path.exists(path), f"segment overwritten/removed: {path}"
+        # Every name carries the per-session tag, and start recovery still works.
+        for path in paths:
+            stem = os.path.splitext(os.path.basename(path))[0]
+            assert stem.rsplit("_", 1)[1].startswith("s"), stem
+            assert recorder._segment_start_from_path(path) is not None, path
+
     def test_no_list_files_left_behind(self, test_video_path, tmp_path, mock_sink):
         recorder = make_recorder(
             tmp_path, mock_sink, interval=2,
@@ -215,17 +242,44 @@ class TestCopyBackend:
         ]
         assert leftovers == []
 
-    def test_segment_start_from_path(self, tmp_path, mock_sink):
+    @pytest.mark.parametrize("name", [
+        "cam1_132045.mp4",                # legacy copy naming (no suffix)
+        "cam1_132045_s3f9x2.mp4",         # copy backend session tag
+        "cam1_132045_007.mp4",            # x264 backend millisecond suffix
+        "cam_2_132045_s1x1.mp4",          # underscore inside source_id
+        "cam999999_132045_s1x1.mp4",      # source_id ending in 6 digits
+        "cam_999999_132045_s1x1.mp4",     # ...as its own trailing field
+    ])
+    def test_segment_start_from_path(self, tmp_path, mock_sink, name):
         recorder = make_recorder(tmp_path, mock_sink)
-        path = "/data/recordings/2026-08-17/cam1_132045.mp4"
-        dt = recorder._segment_start_from_path(path)
-        assert dt is not None
+        dt = recorder._segment_start_from_path(f"/data/recordings/2026-08-17/{name}")
+        assert dt is not None, name
         assert (dt.year, dt.month, dt.day) == (2026, 8, 17)
         assert (dt.hour, dt.minute, dt.second) == (13, 20, 45)
 
-    def test_segment_start_from_path_bad_input(self, tmp_path, mock_sink):
+    @pytest.mark.parametrize("name", [
+        "cam1.mp4",                       # no time field at all
+        "cam1_9999.mp4",                  # wrong width
+        "cam1_995099_s1x1.mp4",           # 6 digits but not a valid time
+    ])
+    def test_segment_start_from_path_bad_input(self, tmp_path, mock_sink, name):
         recorder = make_recorder(tmp_path, mock_sink)
-        assert recorder._segment_start_from_path("/data/recordings/cam1.mp4") is None
+        assert recorder._segment_start_from_path(
+            f"/data/recordings/2026-08-17/{name}"
+        ) is None
+
+    def test_session_tag_makes_segment_names_disjoint(self, tmp_path, mock_sink):
+        """Two sessions of the same recorder must never pick the same segment
+        name: -y would silently overwrite the file and _drain_segment_list would
+        dedupe the second event away."""
+        recorder = make_recorder(tmp_path, mock_sink)
+        tags = {
+            f"s{os.getpid():x}x{next(recorder._session_seq):x}" for _ in range(5)
+        }
+        assert len(tags) == 5
+        # A tag must never parse as HHMMSS (that would break start recovery).
+        for tag in tags:
+            assert not (len(tag) == 6 and tag.isdigit())
 
     def test_drain_skips_malformed_lines(self, tmp_path, mock_sink):
         recorder = make_recorder(tmp_path, mock_sink)

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_full.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_pipeline_full.py
@@ -162,7 +162,9 @@ class TestFullPipeline:
         assert isinstance(payload["start_time"], str)
         assert isinstance(payload["end_time"], str)
 
-    def test_non_roi_clip_is_transcoded_before_emit(self, pipeline, tmp_path, mock_sink):
+    def test_non_roi_clip_is_emitted_as_written(self, pipeline, tmp_path, mock_sink):
+        """Clips are H.264 by construction (SegmentExtractor writes H.264
+        directly): emit passes the path through, no transcode step."""
         clip_path = str(tmp_path / "motion.mp4")
         result = MagicMock(
             path=clip_path,
@@ -171,10 +173,8 @@ class TestFullPipeline:
             duration_s=4.0,
         )
 
-        with patch("stream_monitor.rtsp_monitor.transcode_h264_in_place") as transcode:
-            pipeline._emit_segment(result)
+        pipeline._emit_segment(result)
 
-        transcode.assert_called_once_with(clip_path)
         payload = mock_sink.emit.call_args.args[0]["payload"]
         assert payload["event_file_path"] == clip_path
         assert payload["summary_clip_input"] == clip_path

--- a/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_segment_extractor.py
+++ b/metro-ai-suite/agentic-smart-community/videostream-analytics/tests/unit/test_segment_extractor.py
@@ -174,3 +174,74 @@ class TestSegmentExtractorWithRealVideo:
             extractor.add_frame(frame)
         extractor.close()
         assert extractor.is_recording is False
+
+    def test_output_codec_is_h264(self, extractor, video_frames):
+        """Segments are browser-playable H.264 by construction — no post-hoc
+        transcode pass exists anymore (rtsp_monitor emits the file as-is)."""
+        extractor.start_segment()
+        for frame in video_frames[:90]:
+            extractor.add_frame(frame)
+        result = extractor.finish()
+        assert result is not None
+
+        # stsd sample-entry fourcc: avc1 = H.264-in-mp4 (mp4v would be "mp4v").
+        # Byte-probe instead of ffprobe — the production image ships none.
+        with open(result.path, "rb") as f:
+            data = f.read(64 * 1024)
+        assert b"avc1" in data, "segment is not H.264 (no avc1 sample entry)"
+
+    def test_output_has_faststart_moov(self, extractor, video_frames):
+        """moov precedes mdat so the dashboard can seek with one range request."""
+        extractor.start_segment()
+        for frame in video_frames[:90]:
+            extractor.add_frame(frame)
+        result = extractor.finish()
+        assert result is not None
+
+        with open(result.path, "rb") as f:
+            data = f.read()
+        moov, mdat = data.find(b"moov"), data.find(b"mdat")
+        assert 0 < moov < mdat, "moov must precede mdat (faststart)"
+
+    def test_writer_open_failure_latches_and_recovers(self, tmp_path, video_frames, monkeypatch):
+        """ffmpeg missing: segment is dropped with an error log, frames are
+        counted (duration logic intact), and the NEXT segment retries."""
+        from stream_monitor.pipeline import segment_extractor as se
+
+        class DeadWriter:
+            def __init__(self, *a, **k): pass
+            def isOpened(self): return False
+            def write(self, frame): pass
+            def release(self): pass
+
+        monkeypatch.setattr(se, "H264SegmentWriter", DeadWriter)
+        extractor = SegmentExtractor(
+            config=SegmentConfig(max_duration=5.0, min_duration=0.5),
+            output_dir=str(tmp_path / "motion_events"),
+            source_id="test_cam", fps=30.0, frame_size=(1280, 720),
+        )
+        extractor.start_segment()
+        assert extractor.is_recording is False
+        for frame in video_frames[:30]:
+            assert extractor.add_frame(frame) is None
+        assert extractor.finish() is None
+        # Latch cleared by finish: next segment retries the writer.
+        extractor.start_segment()
+        assert extractor._write_failed is True  # DeadWriter still fails
+
+    def test_writer_mid_segment_death_discards_segment(self, tmp_path, video_frames):
+        """If the ffmpeg pipe dies mid-segment the mp4 has no moov — discard
+        instead of emitting an unreadable file."""
+        extractor = SegmentExtractor(
+            config=SegmentConfig(max_duration=5.0, min_duration=0.5),
+            output_dir=str(tmp_path / "motion_events"),
+            source_id="test_cam", fps=30.0, frame_size=(1280, 720),
+        )
+        extractor.start_segment()
+        for frame in video_frames[:30]:
+            extractor.add_frame(frame)
+        # Simulate ffmpeg dying mid-segment (broken pipe path in the writer).
+        extractor._writer._proc = None
+        result = extractor.finish()
+        assert result is None
+        assert extractor.is_recording is False


### PR DESCRIPTION
### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)
  - Add a codec-copy recording backend (ffmpeg `-c copy`, no decode/re-encode) as the default; keep x264 as fallback via `RecordingConfig.backend`
  - Enable ffmpeg network support in the Docker image with build-time capability assertions
  - Add per-session token to segment file names to prevent same-second overwrite
### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

