### PR TITLE
[DOCS][Education][Manufacturing] Fix links - 26.2

### DIFF
--- a/education-ai-suite/smart-classroom/setup-smart-classroom.ps1
+++ b/education-ai-suite/smart-classroom/setup-smart-classroom.ps1
@@ -1440,7 +1440,7 @@ if ($appChecksFailed) {
         Write-Host "    Download and run the installer" -ForegroundColor Gray
         Write-Host ""
         Write-Host "  Installation Guide:" -ForegroundColor White
-        Write-Host "    https://github.com/open-edge-platform/dlstreamer/blob/main/docs/user-guide/get_started/install/install_guide_windows.md" -ForegroundColor Cyan
+        Write-Host "    https://github.com/open-edge-platform/dlstreamer/blob/docs-release/2026.2/docs/user-guide/install/install_guide_windows.md" -ForegroundColor Cyan
         Write-Host ""
     }
 

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/install-balluff-sdk-on-host.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/pallet-defect-detection/how-to-guides/install-balluff-sdk-on-host.md
@@ -98,4 +98,4 @@ GDK_BACKEND=x11 ./ImpactControlCenter
 ```
 
 **Reference:**
-[Balluff Impact Acquire Quick Start Guide](https://assets.balluff.com/documents/DRF_957345_AA_000/mvBC_page_quickstart.html)
+[Balluff Impact Acquire Quick Start Guide](https://assets.balluff.com/documents/DRF_957346_AA_000/Quickstart_FrameworkInstallation.html)


### PR DESCRIPTION
### Description

- Fix link to DL Streamer Windows Installation documentation (adjusted to the DLS 2026.2 documentation branch, i.e., `docs-release/2026.2`)
- Fix external link to Balluff documentation assets

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.