### PR TITLE
[Onboarding-Validation] Make self-test contract check CRLF-agnostic (cherry-pick #3649)

### DIFF
--- a/.github/skills/onboarding-validation/scripts/self-test.sh
+++ b/.github/skills/onboarding-validation/scripts/self-test.sh
@@ -132,9 +132,12 @@ check_skeleton_matches_rules() {
 # -----------------------------------------------------------------------------
 check_contract_not_drifted() {
   echo "[4/5] Format contract in the script matches references/report-format.md..."
-  awk '/^# CONTRACT-BEGIN/{f=1;next} /^# CONTRACT-END/{f=0} f && /^[A-Z_]+=/ { print }' \
+  # CR is stripped from both sides: a CRLF checkout (git core.autocrlf=true on Windows) would
+  # otherwise make every line differ by a trailing \r and report a drift that does not exist.
+  awk '{ sub(/\r$/, "") }
+       /^# CONTRACT-BEGIN/{f=1;next} /^# CONTRACT-END/{f=0} f && /^[A-Z_]+=/ { print }' \
     "$CHECKER" | sort > "$WORK/contract-script.txt"
-  grep -E '^[A-Z_]+=' "$FORMAT_FILE" | sort > "$WORK/contract-doc.txt"
+  awk '{ sub(/\r$/, "") } /^[A-Z_]+=/ { print }' "$FORMAT_FILE" | sort > "$WORK/contract-doc.txt"
 
   [[ -s "$WORK/contract-script.txt" ]] || fail "No contract constants found in $CHECKER."
 


### PR DESCRIPTION
### Description

Step 4 of self-test.sh compared contract constants byte-for-byte between `scripts/reconcile-report.sh` (LF) and `references/report-format.md` (CRLF-committed), causing all 32 constants to appear different on Linux/CI while being invisible on Windows due to core.autocrlf. The fix strips trailing CR on both sides before diffing. 
Test-only change — no contract constants, runtime scripts or agent-facing behaviour modified.

### Any Newly Introduced Dependencies

None. The change is five lines of shell in `scripts/self-test.sh`, using only `awk`, which the script already uses. No new packages, binaries or manifest changes.

### How Has This Been Tested?

The self-test passes all five steps on Windows (Git for Windows bash 5.2) and on Ubuntu 24.04 LTS (bash 5.2.21), and the CR-stripping works under both gawk 5.2.1 and mawk 1.3.4.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

