### PR TITLE
[smart classroom] add per-session state tracking and /sessions orchestration APIs

### DIFF
--- a/education-ai-suite/smart-classroom/api/endpoints.py
+++ b/education-ai-suite/smart-classroom/api/endpoints.py
@@ -30,6 +30,7 @@ from dto.ocr_dto import OCRExtractRequest, OCRResponse
 from components.ocr.ocr_pipeline import ocr_detect_file, ocr_extract_text
 from utils.telegram_sender import get_sender
 from utils.scp_sender import get_scp_sender
+from utils import session_store, orchestrator
 
 import logging
 logger = logging.getLogger(__name__)
@@ -45,6 +46,115 @@ def health():
     from model_manager import ModelManager
     hub = ModelManager.instance().health()
     return JSONResponse(content={"status": "ok", "hub": hub}, status_code=200)
+
+
+def _session_dir(session_id: str) -> str:
+    proj = RuntimeConfig.get_section("Project")
+    return os.path.join(proj.get("location"), proj.get("name"), session_id)
+
+
+@router.get("/sessions")
+def list_sessions():
+    sessions = []
+    for state in session_store.SessionStore.list_all():
+        sessions.append(
+            {
+                "session_id": state.get("session_id"),
+                "state": state.get("state"),
+                "current_stage": state.get("current_stage"),
+                "stages": state.get("stages"),
+                "sources": state.get("sources"),
+                "started_at": state.get("started_at"),
+                "updated_at": state.get("updated_at"),
+            }
+        )
+    return JSONResponse(content={"total": len(sessions), "sessions": sessions}, status_code=200)
+
+
+@router.post("/sessions/process")
+def process_session(payload: dict):
+    stages = payload.get("stages") or []
+    if not stages:
+        raise HTTPException(status_code=400, detail="stages required")
+    _validate_stages(stages)
+    session_id = orchestrator.start_process(payload)
+    state = session_store.SessionStore.get(session_id)
+    return JSONResponse(
+        content={
+            "session_id": session_id,
+            "stages": state.get("stages") if state else stages,
+            "output_dir": os.path.abspath(_session_dir(session_id)),
+            "started_at": state.get("started_at") if state else None,
+        },
+        status_code=200,
+    )
+
+
+@router.get("/sessions/{session_id}/status")
+def get_session_progress(session_id: str):
+    state = session_store.SessionStore.get(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    return JSONResponse(content=_status_response(state), status_code=200)
+
+
+@router.delete("/sessions/{session_id}")
+def delete_session(session_id: str):
+    import shutil
+
+    state = session_store.SessionStore.get(session_id)
+    if state is None:
+        raise HTTPException(status_code=404, detail="session not found")
+    if state.get("state") == "running":
+        raise HTTPException(
+            status_code=409,
+            detail="session is running; cannot delete until it finishes",
+        )
+
+    session_store.SessionStore.delete(session_id)
+
+    session_dir = _session_dir(session_id)
+    files_removed = False
+    if os.path.isdir(session_dir):
+        try:
+            shutil.rmtree(session_dir)
+            files_removed = True
+        except OSError as e:
+            logger.error(f"failed to remove session dir {session_dir}: {e}")
+            raise HTTPException(
+                status_code=500,
+                detail=f"record deleted but failed to remove files: {e}",
+            )
+
+    return JSONResponse(
+        content={
+            "session_id": session_id,
+            "deleted": True,
+            "files_removed": files_removed,
+        },
+        status_code=200,
+    )
+
+
+def _validate_stages(stages: list) -> None:
+    from utils.session_store import _ALL_STAGES
+    for s in stages:
+        if s not in _ALL_STAGES:
+            raise HTTPException(status_code=400, detail=f"unknown stage: {s}")
+
+
+def _status_response(state: dict) -> dict:
+    return {
+        "session_id": state.get("session_id"),
+        "state": state.get("state"),
+        "current_stage": state.get("current_stage"),
+        "stages": state.get("stages"),
+        "sources": state.get("sources"),
+        "output_dir": os.path.abspath(_session_dir(state.get("session_id"))),
+        "error": state.get("error"),
+        "started_at": state.get("started_at"),
+        "updated_at": state.get("updated_at"),
+    }
 
 
 @router.get("/features")

--- a/education-ai-suite/smart-classroom/main.py
+++ b/education-ai-suite/smart-classroom/main.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     startup(app)
+    from utils.session_store import SessionStore
+    SessionStore.recover_after_restart()
     yield
     # Shutdown: drain in-flight capability work and release device (GPU) memory.
     from model_manager import ModelManager

--- a/education-ai-suite/smart-classroom/utils/orchestrator.py
+++ b/education-ai-suite/smart-classroom/utils/orchestrator.py
@@ -1,0 +1,223 @@
+import logging
+import os
+import threading
+
+from pipeline import Pipeline
+from dto.transcription_dto import TranscriptionRequest
+from dto.audiosource import AudioSource
+from utils.config_loader import config
+from utils.runtime_config_loader import RuntimeConfig
+from utils.storage_manager import StorageManager
+from utils.session_manager import generate_session_id
+from utils import session_store
+from components.va.va_pipeline_service import VideoAnalyticsPipelineService, PipelineOptions
+
+logger = logging.getLogger(__name__)
+
+
+def _va_output_dir(session_id: str) -> str:
+    proj = RuntimeConfig.get_section("Project")
+    return os.path.join(proj.get("location"), proj.get("name"), session_id, "va")
+
+
+def start_process(request: dict) -> str:
+    session_id = generate_session_id()
+    stages = request.get("stages", [])
+    state = session_store.SessionStore.create(session_id, request, stages)
+    thread = threading.Thread(target=_run, args=(session_id, request, stages), daemon=True)
+    thread.start()
+    return session_id
+
+
+def _run(session_id: str, request: dict, stages: list) -> None:
+    session_store.SessionStore.update(session_id, state="running")
+    va_error = []
+    va_thread = None
+    try:
+        if "va" in stages:
+            va_thread = threading.Thread(
+                target=_run_va_safe,
+                args=(session_id, request, stages, va_error),
+                daemon=True,
+            )
+            va_thread.start()
+        _run_audio_chain(session_id, request, stages, va_thread, va_error)
+        if va_error:
+            raise _OrchestrationError(va_error[0])
+        session_store.SessionStore.mark_completed(session_id)
+    except _OrchestrationError as e:
+        session_store.SessionStore.mark_failed(session_id, str(e))
+    except Exception as e:
+        logger.exception(f"[orchestrator] session {session_id} unexpected failure")
+        session_store.SessionStore.mark_failed(session_id, f"unexpected error: {e}")
+
+
+def _run_va_safe(session_id: str, request: dict, stages: list, errors: list) -> None:
+    try:
+        _run_va_if_needed(session_id, request, stages)
+    except _OrchestrationError as e:
+        errors.append(str(e))
+    except Exception as e:
+        logger.exception(f"[orchestrator] session {session_id} VA thread failure")
+        errors.append(f"unexpected va error: {e}")
+
+
+def _run_audio_chain(session_id: str, request: dict, stages: list,
+                     va_thread=None, va_error=None) -> None:
+    pipeline = Pipeline(session_id)
+
+    if "transcribe" in stages:
+        session_store.SessionStore.set_stage(session_id, "transcribe", "running")
+        audio_path = request.get("audio_path")
+        if not audio_path:
+            raise _OrchestrationError("stage transcribe requires audio_path")
+        tr = TranscriptionRequest(audio_filename=audio_path, source_type=AudioSource.AUDIO_FILE)
+        _drain(pipeline.run_transcription(tr))
+        session_store.SessionStore.set_stage(session_id, "transcribe", "done")
+        _await_pending_writes()
+
+    if "summarize" in stages:
+        session_store.SessionStore.set_stage(session_id, "summarize", "running")
+        _drain(pipeline.run_summarizer())
+        session_store.SessionStore.set_stage(session_id, "summarize", "done")
+        _await_pending_writes()
+
+    if "mindmap" in stages:
+        session_store.SessionStore.set_stage(session_id, "mindmap", "running")
+        pipeline.run_mindmap()
+        session_store.SessionStore.set_stage(session_id, "mindmap", "done")
+
+    if "segmentation" in stages:
+        _join_va(va_thread, va_error)
+        session_store.SessionStore.set_stage(session_id, "segmentation", "running")
+        pipeline.run_content_segmentation()
+        session_store.SessionStore.set_stage(session_id, "segmentation", "done")
+
+    if "report" in stages:
+        session_store.SessionStore.set_stage(session_id, "report", "running")
+        _drain(pipeline.run_report_generator())
+        session_store.SessionStore.set_stage(session_id, "report", "done")
+
+
+def _join_va(va_thread, va_error) -> None:
+    if va_thread is not None:
+        va_thread.join()
+        if va_error:
+            raise _OrchestrationError(va_error[0])
+
+
+def _run_va_if_needed(session_id: str, request: dict, stages: list) -> None:
+    if "va" not in stages:
+        return
+    video_sources = request.get("video_sources") or {}
+    wanted = {k: v for k, v in video_sources.items() if v}
+    if not wanted:
+        raise _OrchestrationError("stage va requires video_sources")
+
+    session_store.SessionStore.set_stage(session_id, "va", "running")
+
+    va_out_dir = _va_output_dir(session_id)
+    os.makedirs(va_out_dir, exist_ok=True)
+
+    service = VideoAnalyticsPipelineService()
+    service.x_session_id = session_id
+
+    done = threading.Event()
+    final_status = {}
+
+    def _on_done(sid):
+        final_status.update(service.pipeline_final_status)
+        done.set()
+
+    service.on_all_pipelines_done = _on_done
+
+    options = PipelineOptions(
+        output_dir=va_out_dir,
+        output_rtsp=config.va_pipeline.output_rtsp_url,
+        threshold=config.models.va.threshold,
+        record=False,
+    )
+
+    launched = 0
+    failures = []
+    for name, source in wanted.items():
+        try:
+            ok = service.launch_pipeline(name, source, options)
+        except Exception as e:
+            failures.append(f"{name}: {e}")
+            logger.warning(f"[orchestrator] VA pipeline {name} launch raised: {e}")
+            continue
+        if not ok:
+            failures.append(f"{name}: launch returned false")
+            logger.warning(f"[orchestrator] VA pipeline {name} failed to launch")
+        else:
+            launched += 1
+
+    if launched == 0:
+        raise _OrchestrationError(f"all va pipelines failed to launch: {'; '.join(failures)}")
+
+    _start_board_ocr_if_enabled(session_id, wanted)
+
+    if not done.wait(timeout=3600):
+        raise _OrchestrationError("va timed out")
+
+    _stop_board_ocr_if_enabled(session_id, final_status)
+
+    if not _any_success(final_status, wanted):
+        raise _OrchestrationError("all va pipelines failed")
+
+    session_store.SessionStore.set_stage(session_id, "va", "done")
+
+
+def _board_ocr_enabled() -> bool:
+    features = getattr(config, "features", None)
+    bo = getattr(features, "board_ocr", None) if features else None
+    return bool(getattr(bo, "enabled", False)) if bo else False
+
+
+def _start_board_ocr_if_enabled(session_id: str, wanted: dict) -> None:
+    content_source = wanted.get("content")
+    if not content_source or not _board_ocr_enabled():
+        return
+    try:
+        from components.board_ocr.board_ocr_pipeline import start_board_ocr
+        start_board_ocr(session_id, content_source)
+        logger.info(f"[orchestrator] board OCR started for session {session_id}")
+    except Exception as e:
+        logger.error(f"[orchestrator] failed to start board OCR: {e}", exc_info=True)
+
+
+def _stop_board_ocr_if_enabled(session_id: str, final_status: dict) -> None:
+    if not _board_ocr_enabled():
+        return
+    # Leave board OCR running if the content pipeline failed (it reads the source
+    # directly); otherwise stop it. Mirrors the UI behavior.
+    if final_status.get("content") == "failed":
+        logger.info("[orchestrator] content pipeline failed; leaving board OCR running")
+        return
+    try:
+        from components.board_ocr.board_ocr_pipeline import stop_board_ocr
+        stop_board_ocr(session_id)
+        logger.info(f"[orchestrator] board OCR stopped for session {session_id}")
+    except Exception as e:
+        logger.error(f"[orchestrator] failed to stop board OCR: {e}", exc_info=True)
+
+
+def _any_success(final_status: dict, wanted: dict) -> bool:
+    for name in wanted:
+        if final_status.get(name) == "eos":
+            return True
+    return False
+
+
+def _drain(gen) -> None:
+    for _ in gen:
+        pass
+
+
+def _await_pending_writes(timeout: float = 30.0) -> None:
+    StorageManager.wait_idle(timeout)
+
+
+class _OrchestrationError(Exception):
+    pass

--- a/education-ai-suite/smart-classroom/utils/session_store.py
+++ b/education-ai-suite/smart-classroom/utils/session_store.py
@@ -1,0 +1,232 @@
+import os
+import json
+import sqlite3
+from datetime import datetime, timezone
+from threading import Lock
+
+from utils.runtime_config_loader import RuntimeConfig
+
+_ALL_STAGES = ("transcribe", "summarize", "mindmap", "va", "segmentation", "report")
+
+_DB_FILE = "sessions.db"
+
+
+class SessionStore:
+    _states = {}
+    _lock = Lock()
+
+    @classmethod
+    def _db_path(cls) -> str:
+        proj = RuntimeConfig.get_section("Project")
+        base = os.path.join(proj.get("location"), proj.get("name"))
+        os.makedirs(base, exist_ok=True)
+        return os.path.join(base, _DB_FILE)
+
+    @classmethod
+    def _conn(cls) -> sqlite3.Connection:
+        conn = sqlite3.connect(cls._db_path(), check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    @classmethod
+    def _init_table(cls) -> None:
+        conn = cls._conn()
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sessions (
+                    session_id    TEXT PRIMARY KEY,
+                    state         TEXT,
+                    current_stage TEXT,
+                    stages        TEXT,
+                    sources       TEXT,
+                    error         TEXT,
+                    started_at    TEXT,
+                    updated_at    TEXT,
+                    request       TEXT
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @classmethod
+    def create(cls, session_id: str, request: dict, stages: list) -> dict:
+        with cls._lock:
+            cls._init_table()
+            now = _now_iso()
+            state = {
+                "session_id": session_id,
+                "state": "pending",
+                "stages": {s: "pending" for s in _ALL_STAGES},
+                "current_stage": None,
+                "sources": _extract_sources(request),
+                "error": None,
+                "started_at": now,
+                "updated_at": now,
+                "request": request,
+            }
+            for s in stages:
+                state["stages"][s] = "pending"
+            for s in set(_ALL_STAGES) - set(stages):
+                state["stages"][s] = "skipped"
+            cls._states[session_id] = state
+            cls._upsert(state)
+            return dict(state)
+
+    @classmethod
+    def get(cls, session_id: str) -> dict | None:
+        with cls._lock:
+            state = cls._states.get(session_id)
+            if state:
+                return dict(state)
+            row = cls._select(session_id)
+            if row:
+                state = _row_to_dict(row)
+                cls._states[session_id] = state
+                return dict(state)
+            return None
+
+    @classmethod
+    def update(cls, session_id: str, **fields) -> dict | None:
+        with cls._lock:
+            state = cls._states.get(session_id)
+            if state is None:
+                return None
+            state.update(fields)
+            state["updated_at"] = _now_iso()
+            cls._upsert(state)
+            return dict(state)
+
+    @classmethod
+    def set_stage(cls, session_id: str, stage: str, status: str) -> dict | None:
+        with cls._lock:
+            state = cls._states.get(session_id)
+            if state is None:
+                return None
+            if stage in state["stages"]:
+                state["stages"][stage] = status
+            if status in ("running", "done", "failed"):
+                state["current_stage"] = stage
+            state["updated_at"] = _now_iso()
+            cls._upsert(state)
+            return dict(state)
+
+    @classmethod
+    def mark_completed(cls, session_id: str) -> dict | None:
+        return cls.update(session_id, state="completed")
+
+    @classmethod
+    def mark_failed(cls, session_id: str, error: str) -> dict | None:
+        return cls.update(session_id, state="failed", error=error)
+
+    @classmethod
+    def list_all(cls) -> list:
+        with cls._lock:
+            cls._init_table()
+            conn = cls._conn()
+            try:
+                rows = conn.execute("SELECT * FROM sessions ORDER BY started_at").fetchall()
+                return [_row_to_dict(r) for r in rows]
+            finally:
+                conn.close()
+
+    @classmethod
+    def delete(cls, session_id: str) -> bool:
+        with cls._lock:
+            cls._init_table()
+            conn = cls._conn()
+            try:
+                cur = conn.execute(
+                    "DELETE FROM sessions WHERE session_id = ?", (session_id,)
+                )
+                conn.commit()
+                deleted = cur.rowcount > 0
+            finally:
+                conn.close()
+            cls._states.pop(session_id, None)
+            return deleted
+
+    @classmethod
+    def recover_after_restart(cls) -> None:
+        with cls._lock:
+            cls._init_table()
+            conn = cls._conn()
+            try:
+                rows = conn.execute("SELECT * FROM sessions WHERE state = 'running'").fetchall()
+                for row in rows:
+                    state = _row_to_dict(row)
+                    state["state"] = "failed"
+                    state["error"] = "process interrupted (restart)"
+                    state["updated_at"] = _now_iso()
+                    cls._states[state["session_id"]] = state
+                    cls._upsert(state)
+            finally:
+                conn.close()
+
+    @classmethod
+    def _upsert(cls, state: dict) -> None:
+        conn = cls._conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO sessions
+                (session_id, state, current_stage, stages, sources, error, started_at, updated_at, request)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    state["session_id"],
+                    state.get("state"),
+                    state.get("current_stage"),
+                    json.dumps(state.get("stages"), ensure_ascii=False),
+                    json.dumps(state.get("sources"), ensure_ascii=False),
+                    state.get("error"),
+                    state.get("started_at"),
+                    state.get("updated_at"),
+                    json.dumps(state.get("request"), ensure_ascii=False),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @classmethod
+    def _select(cls, session_id: str) -> sqlite3.Row | None:
+        conn = cls._conn()
+        try:
+            return conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+
+def _row_to_dict(row) -> dict:
+    return {
+        "session_id": row["session_id"],
+        "state": row["state"],
+        "current_stage": row["current_stage"],
+        "stages": json.loads(row["stages"] or "{}"),
+        "sources": json.loads(row["sources"] or "{}"),
+        "error": row["error"],
+        "started_at": row["started_at"],
+        "updated_at": row["updated_at"],
+        "request": json.loads(row["request"] or "{}"),
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _extract_sources(request: dict) -> dict:
+    sources = {}
+    audio = request.get("audio_path")
+    if audio:
+        sources["audio"] = os.path.basename(audio)
+    video = request.get("video_sources") or {}
+    video_files = {k: v for k, v in video.items() if v}
+    if video_files:
+        sources["video"] = {k: os.path.basename(v) for k, v in video_files.items()}
+    return sources

--- a/education-ai-suite/smart-classroom/utils/storage_manager.py
+++ b/education-ai-suite/smart-classroom/utils/storage_manager.py
@@ -1,11 +1,16 @@
 import os
 import json, csv
-from threading import Thread
+import time
+from threading import Thread, Lock
 from typing import Union, List, Dict, Tuple
 from pathlib import Path
 import logging
 
 logger = logging.getLogger(__name__)
+
+_inflight_lock = Lock()
+_inflight = 0
+
 
 class StorageManager:
     @staticmethod
@@ -46,8 +51,38 @@ class StorageManager:
 
     @staticmethod
     def save_async(path: str, data: Union[str, dict], append: bool = False):
-        Thread(target=StorageManager._write, args=(path, data, append)).start()
-        
+        global _inflight
+        with _inflight_lock:
+            _inflight += 1
+
+        def _run():
+            global _inflight
+            try:
+                StorageManager._write(path, data, append)
+            finally:
+                with _inflight_lock:
+                    _inflight -= 1
+
+        Thread(target=_run).start()
+
+    @staticmethod
+    def wait_idle(timeout: float = 30.0) -> bool:
+        """Block until all async writes have flushed, or timeout elapses.
+
+        Returns True if writes drained, False on timeout. Used to barrier
+        between pipeline stages so a stage never reads a file the previous
+        stage is still writing.
+        """
+        waited = 0.0
+        while waited < timeout:
+            with _inflight_lock:
+                if _inflight == 0:
+                    return True
+            time.sleep(0.1)
+            waited += 0.1
+        return False
+
+
     @staticmethod
     def save_csv(path: str, data: dict, headers: List[str], append: bool = True):
         StorageManager._ensure_dir(path)


### PR DESCRIPTION
### Description

Persist per-session pipeline state to SQLite (SessionStore) and add a background orchestrator that chains transcribe/summarize/mindmap/va/segmentation/report stages. Expose list/create/status/delete via /sessions endpoints. Add an in-flight write counter + StorageManager.wait_idle to barrier between stages, and mark interrupted sessions failed on restart.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

