### PR TITLE
Smart Classroom: Enhance download with resumable support and error handling

### DIFF
--- a/education-ai-suite/smart-classroom/utils/convert_classification_models.py
+++ b/education-ai-suite/smart-classroom/utils/convert_classification_models.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 import urllib.request
+import urllib.error
+import http.client
+import socket
+import time
 import torch
 import torch.nn as nn
 import torchvision.models as models
@@ -12,7 +16,6 @@ import os
 import tarfile
 import ssl
 import certifi
-import urllib.request
 
 
 # Model URLs
@@ -28,23 +31,92 @@ DATASET_CLASSES = 10
 
 SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
+CHUNK_SIZE = 1024 * 1024
+DOWNLOAD_TIMEOUT = 60
+DOWNLOAD_RETRIES = 8
+
+# Errors that mean "the transfer broke, but retrying/resuming may work".
+TRANSIENT_ERRORS = (
+    http.client.IncompleteRead,
+    http.client.HTTPException,
+    urllib.error.URLError,
+    ConnectionError,
+    socket.timeout,
+    TimeoutError,
+    ssl.SSLError,
+)
+
 
 def download(url, filename, output_dir):
-    """Download model weights if not already present."""
+    """Download a file if not already present, resuming interrupted transfers."""
     filepath = output_dir / filename
 
     if filepath.exists():
         return filepath
 
     print(f"Downloading {filename}...")
-
-    ssl_context = ssl.create_default_context(cafile=certifi.where())
-
-    with urllib.request.urlopen(url, context=ssl_context) as response:
-        with open(filepath, "wb") as f:
-            f.write(response.read())
+    _download_resumable(url, filepath)
 
     return filepath
+
+
+def _download_resumable(url, filepath):
+    """Stream `url` into `filepath`, retrying with HTTP range resume on failure.
+
+    Write to a `.part` file in chunks so a broken connection only costs the
+    remaining bytes, and only publish the final file once the expected number
+    of bytes has actually arrived.
+    """
+    part_path = filepath.with_suffix(filepath.suffix + ".part")
+    last_error = None
+
+    for attempt in range(1, DOWNLOAD_RETRIES + 1):
+        downloaded = part_path.stat().st_size if part_path.exists() else 0
+
+        request = urllib.request.Request(url)
+        if downloaded:
+            request.add_header("Range", f"bytes={downloaded}-")
+
+        try:
+            with urllib.request.urlopen(request, context=SSL_CONTEXT, timeout=DOWNLOAD_TIMEOUT) as response:
+                # Server ignored the range request, so start over from zero.
+                resuming = response.status == 206
+                if downloaded and not resuming:
+                    downloaded = 0
+
+                remaining = response.headers.get("Content-Length")
+                total = downloaded + int(remaining) if remaining is not None else None
+
+                with open(part_path, "ab" if downloaded else "wb") as f:
+                    while True:
+                        chunk = response.read(CHUNK_SIZE)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        downloaded += len(chunk)
+                        if total:
+                            print(f"\r  {downloaded * 100 // total}% "
+                                  f"({downloaded / 1048576:.1f}/{total / 1048576:.1f} MB)", end="")
+
+            if total:
+                print()
+
+            if total is not None and downloaded < total:
+                raise http.client.IncompleteRead(b"", total - downloaded)
+
+            os.replace(part_path, filepath)
+            return filepath
+
+        except TRANSIENT_ERRORS as e:
+            last_error = e
+            if attempt == DOWNLOAD_RETRIES:
+                break
+            backoff = min(2 ** attempt, 30)
+            print(f"\n  Download interrupted ({type(e).__name__}: {e}); "
+                  f"retrying in {backoff}s [attempt {attempt + 1}/{DOWNLOAD_RETRIES}]...")
+            time.sleep(backoff)
+
+    raise RuntimeError(f"Failed to download {url} after {DOWNLOAD_RETRIES} attempts: {last_error}") from last_error
 
 def download_labels():
     """Extract labels from model metadata."""
@@ -76,13 +148,15 @@ def download_dataset(url, dataset_path):
 
     if not (dataset_path / "imagenette2-320/val").exists():
         print(f"Downloading dataset from {url}...")
+        _download_resumable(url, archive_path)
 
-        with urllib.request.urlopen(url, context=SSL_CONTEXT) as response:
-            with open(archive_path, "wb") as f:
-                f.write(response.read())
-
-        with tarfile.open(archive_path, "r:*") as tar:
-            safe_extract(tar, dataset_path)
+        try:
+            with tarfile.open(archive_path, "r:*") as tar:
+                safe_extract(tar, dataset_path)
+        except tarfile.ReadError as e:
+            # A corrupt archive can never extract; drop it so the next run refetches.
+            os.remove(archive_path)
+            raise RuntimeError(f"Dataset archive from {url} is corrupt, please re-run: {e}") from e
 
         os.remove(archive_path)
 


### PR DESCRIPTION

### Description

- New _download_resumable() streams into a .part file in 1 MB chunks with a 60 s socket timeout, and prints %/MB progress.
- On a transient failure (IncompleteRead, HTTPException, URLError, connection/timeout/SSL errors) it retries up to 8 times with exponential backoff capped at 30 s, sending Range: bytes=<n>- so it picks up where it stopped instead of restarting 340 MB. If the server ignores the range (no 206), it falls back to starting over.
- The final file is only os.replace'd into place after the full Content-Length has arrived, so a truncated body can never masquerade as a complete download. Short reads that don't raise are caught explicitly and re-raised as IncompleteRead to trigger a retry.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

