### PR TITLE
feat(fedaero): package UAV apps into a uav.zip artifact

### DIFF
--- a/.github/workflows/fedaero.yaml
+++ b/.github/workflows/fedaero.yaml
@@ -11,7 +11,7 @@
 #   It builds zip artifacts from the `federal-and-aerospace-ai-suite/` directory:
 #     - handheld-multi-modal.zip         (one app)
 #     - deterministic-threat-detection.zip (one app)
-#     - uav.zip (two apps, one zip)
+#     - uav-mission-apps.zip (two apps, one zip)
 #
 #   Where those zips end up depends on what triggered the workflow:
 #
@@ -102,7 +102,7 @@ jobs:
     outputs:
       handheld-multi-modal: ${{ steps.force.outputs.handheld-multi-modal || steps.filter.outputs.handheld-multi-modal }}
       deterministic-threat-detection: ${{ steps.force.outputs.deterministic-threat-detection || steps.filter.outputs.deterministic-threat-detection }}
-      uav: ${{ steps.force.outputs.uav || steps.filter.outputs.uav }}
+      uav-mission-apps: ${{ steps.force.outputs.uav-mission-apps || steps.filter.outputs.uav-mission-apps }}
     steps:
       # Guard for manual dispatches: only allow runs from a release-* branch
       # or a tag. The Actions UI shows every branch in its ref dropdown, so
@@ -136,7 +136,7 @@ jobs:
         run: |
           echo "handheld-multi-modal=true"           >> "$GITHUB_OUTPUT"
           echo "deterministic-threat-detection=true" >> "$GITHUB_OUTPUT"
-          echo "uav=true"                            >> "$GITHUB_OUTPUT"
+          echo "uav-mission-apps=true"               >> "$GITHUB_OUTPUT"
 
       - id: filter
         if: github.event_name != 'workflow_dispatch'
@@ -151,7 +151,7 @@ jobs:
               - 'federal-and-aerospace-ai-suite/deterministic-threat-detection/**'
               - 'federal-and-aerospace-ai-suite/Makefile'
               - '.github/workflows/fedaero.yaml'
-            uav:
+            uav-mission-apps:
               - 'federal-and-aerospace-ai-suite/uav-mission-compute-sdk/**'
               - 'federal-and-aerospace-ai-suite/uav-vision-analytics/**'
               - 'federal-and-aerospace-ai-suite/Makefile'
@@ -202,10 +202,10 @@ jobs:
           path: federal-and-aerospace-ai-suite/dist/deterministic-threat-detection.zip
           if-no-files-found: error
 
-  uav:
-    name: Build UAV apps
+  uav-mission-apps:
+    name: Build UAV mission apps
     needs: changes
-    if: needs.changes.outputs.uav == 'true'
+    if: needs.changes.outputs.uav-mission-apps == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -213,11 +213,11 @@ jobs:
       - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
         with:
           persist-credentials: false
-      - run: make -C federal-and-aerospace-ai-suite uav
+      - run: make -C federal-and-aerospace-ai-suite uav-mission-apps
       - uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
         with:
-          name: uav
-          path: federal-and-aerospace-ai-suite/dist/uav.zip
+          name: uav-mission-apps
+          path: federal-and-aerospace-ai-suite/dist/uav-mission-apps.zip
           if-no-files-found: error
 
   release:
@@ -228,12 +228,12 @@ jobs:
       github.event_name != 'pull_request' &&
       (needs.changes.outputs.handheld-multi-modal == 'true' ||
        needs.changes.outputs.deterministic-threat-detection == 'true' ||
-       needs.changes.outputs.uav == 'true')
+       needs.changes.outputs.uav-mission-apps == 'true')
     needs:
       - changes
       - handheld-multi-modal
       - deterministic-threat-detection
-      - uav
+      - uav-mission-apps
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to create/update releases and move the tag.
@@ -256,10 +256,10 @@ jobs:
           path: assets
 
       - name: Download UAV artifact
-        if: needs.changes.outputs.uav == 'true'
+        if: needs.changes.outputs.uav-mission-apps == 'true'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: uav
+          name: uav-mission-apps
           path: assets
 
       # Sanity-check which zips landed before we touch the release.
@@ -290,7 +290,7 @@ jobs:
     needs:
       - handheld-multi-modal
       - deterministic-threat-detection
-      - uav
+      - uav-mission-apps
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to create the release and tag.
@@ -336,7 +336,7 @@ jobs:
       - name: Download UAV artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
-          name: uav
+          name: uav-mission-apps
           path: assets
 
       - name: List downloaded assets
@@ -349,6 +349,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SIV_USER_TOKEN_GH }}
           GH_REPO: ${{ github.repository }}
         run: |
-          notes=$'Immutable versioned release built from `${{ github.sha }}`\n\nContains:\n- `handheld-multi-modal.zip` — handheld multi-modal app\n- `deterministic-threat-detection.zip` — deterministic threat detection app\n- `uav.zip` — UAV Mission Compute SDK + UAV Vision Analytics'
+          notes=$'Immutable versioned release built from `${{ github.sha }}`\n\nContains:\n- `handheld-multi-modal.zip` — handheld multi-modal app\n- `deterministic-threat-detection.zip` — deterministic threat detection app\n- `uav-mission-apps.zip` — UAV Mission Compute SDK + UAV Vision Analytics'
           gh release create --title "Federal and Aerospace | Edge AI Suites v${{ env.VERSION }}" \
             --notes "$notes" v${{ env.VERSION }} assets/*.zip

--- a/.github/workflows/fedaero.yaml
+++ b/.github/workflows/fedaero.yaml
@@ -8,9 +8,10 @@
 #
 # What this workflow does, in plain terms:
 #
-#   It builds two zip artifacts from the `federal-and-aerospace-ai-suite/` directory:
+#   It builds zip artifacts from the `federal-and-aerospace-ai-suite/` directory:
 #     - handheld-multi-modal.zip         (one app)
-#     - deterministic-threat-detection.zip (the other app)
+#     - deterministic-threat-detection.zip (one app)
+#     - uav.zip (two apps, one zip)
 #
 #   Where those zips end up depends on what triggered the workflow:
 #
@@ -21,11 +22,11 @@
 #        - Does not touch any release.
 #
 #   2. Push to main
-#        - Forces a rebuild of all two components (so they stay in sync).
+#        - Forces a rebuild of all components (so they stay in sync).
 #        - Uploads Actions artifacts (same as PRs).
 #        - Updates the rolling release `fedaero-latest`:
 #            * tag is force-moved to the new commit
-#            * all two zips on the release are replaced
+#            * all zips on the release are replaced
 #            * marked as a prerelease (this repo ships multiple products,
 #              so neither this release nor the versioned one claims the
 #              repo-wide "Latest release" badge).
@@ -34,7 +35,7 @@
 #        - Only allowed from `release-*` branches or any tag. Dispatching
 #          from any other ref fails fast with a clear error (the dispatch
 #          UI shows all branches; the guard step is what enforces this).
-#        - Always builds all two components (no per-component selection).
+#        - Always builds all components (no per-component selection).
 #        - Uploads Actions artifacts.
 #        - Updates `fedaero-latest`.
 #        - If `publish_versioned_release` is ticked:
@@ -101,6 +102,7 @@ jobs:
     outputs:
       handheld-multi-modal: ${{ steps.force.outputs.handheld-multi-modal || steps.filter.outputs.handheld-multi-modal }}
       deterministic-threat-detection: ${{ steps.force.outputs.deterministic-threat-detection || steps.filter.outputs.deterministic-threat-detection }}
+      uav: ${{ steps.force.outputs.uav || steps.filter.outputs.uav }}
     steps:
       # Guard for manual dispatches: only allow runs from a release-* branch
       # or a tag. The Actions UI shows every branch in its ref dropdown, so
@@ -126,7 +128,7 @@ jobs:
           persist-credentials: false
 
       # Force-build everything on main pushes (so the rolling release stays
-      # coherent) and on any manual dispatch (always all three components).
+      # coherent) and on any manual dispatch (always all components).
       - id: force
         if: >-
           (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
@@ -134,6 +136,7 @@ jobs:
         run: |
           echo "handheld-multi-modal=true"           >> "$GITHUB_OUTPUT"
           echo "deterministic-threat-detection=true" >> "$GITHUB_OUTPUT"
+          echo "uav=true"                            >> "$GITHUB_OUTPUT"
 
       - id: filter
         if: github.event_name != 'workflow_dispatch'
@@ -146,6 +149,11 @@ jobs:
               - '.github/workflows/fedaero.yaml'
             deterministic-threat-detection:
               - 'federal-and-aerospace-ai-suite/deterministic-threat-detection/**'
+              - 'federal-and-aerospace-ai-suite/Makefile'
+              - '.github/workflows/fedaero.yaml'
+            uav:
+              - 'federal-and-aerospace-ai-suite/uav-mission-compute-sdk/**'
+              - 'federal-and-aerospace-ai-suite/uav-vision-analytics/**'
               - 'federal-and-aerospace-ai-suite/Makefile'
               - '.github/workflows/fedaero.yaml'
 
@@ -194,6 +202,24 @@ jobs:
           path: federal-and-aerospace-ai-suite/dist/deterministic-threat-detection.zip
           if-no-files-found: error
 
+  uav:
+    name: Build UAV apps
+    needs: changes
+    if: needs.changes.outputs.uav == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@8edcb1bdb4e267140fa742c62e395cd74f332709
+        with:
+          persist-credentials: false
+      - run: make -C federal-and-aerospace-ai-suite uav
+      - uses: actions/upload-artifact@de65e23aa2b7e23d713bb51fbfcb6d502f8667d8
+        with:
+          name: uav
+          path: federal-and-aerospace-ai-suite/dist/uav.zip
+          if-no-files-found: error
+
   release:
     name: Publish rolling release (fedaero-latest)
     # Skip on PRs, and skip if no component was actually built this run
@@ -201,11 +227,13 @@ jobs:
     if: >-
       github.event_name != 'pull_request' &&
       (needs.changes.outputs.handheld-multi-modal == 'true' ||
-       needs.changes.outputs.deterministic-threat-detection == 'true')
+       needs.changes.outputs.deterministic-threat-detection == 'true' ||
+       needs.changes.outputs.uav == 'true')
     needs:
       - changes
       - handheld-multi-modal
       - deterministic-threat-detection
+      - uav
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to create/update releases and move the tag.
@@ -225,6 +253,13 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: deterministic-threat-detection
+          path: assets
+
+      - name: Download UAV artifact
+        if: needs.changes.outputs.uav == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: uav
           path: assets
 
       # Sanity-check which zips landed before we touch the release.
@@ -255,6 +290,7 @@ jobs:
     needs:
       - handheld-multi-modal
       - deterministic-threat-detection
+      - uav
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to create the release and tag.
@@ -283,8 +319,8 @@ jobs:
           fi
           echo "OK — $tag is free."
 
-      # Pull all three artifacts. We force all three builds when publishing
-      # a versioned release, so all three are guaranteed to exist here.
+      # Pull all artifacts. We force all builds when publishing
+      # a versioned release, so all of them are guaranteed to exist here.
       - name: Download handheld-multi-modal artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -297,6 +333,12 @@ jobs:
           name: deterministic-threat-detection
           path: assets
 
+      - name: Download UAV artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: uav
+          path: assets
+
       - name: List downloaded assets
         run: ls -la assets/
 
@@ -307,6 +349,6 @@ jobs:
           GH_TOKEN: ${{ secrets.SIV_USER_TOKEN_GH }}
           GH_REPO: ${{ github.repository }}
         run: |
-          notes=$'Immutable versioned release built from `${{ github.sha }}`\n\nContains:\n- `handheld-multi-modal.zip` — handheld multi-modal app\n- `deterministic-threat-detection.zip` — deterministic threat detection app'
+          notes=$'Immutable versioned release built from `${{ github.sha }}`\n\nContains:\n- `handheld-multi-modal.zip` — handheld multi-modal app\n- `deterministic-threat-detection.zip` — deterministic threat detection app\n- `uav.zip` — UAV Mission Compute SDK + UAV Vision Analytics'
           gh release create --title "Federal and Aerospace | Edge AI Suites v${{ env.VERSION }}" \
             --notes "$notes" v${{ env.VERSION }} assets/*.zip

--- a/federal-and-aerospace-ai-suite/Makefile
+++ b/federal-and-aerospace-ai-suite/Makefile
@@ -19,10 +19,13 @@ ROOT      := $(abspath .)
 # Source directories for each packaged component.
 HANDHELD_SRC := handheld-multi-modal
 DTD_SRC      := deterministic-threat-detection
+UAVSDK_SRC   := uav-mission-compute-sdk
+UAVVA_SRC    := uav-vision-analytics
 
 # Output archives.
 HANDHELD_ZIP := $(DIST_DIR)/handheld-multi-modal.zip
 DTD_ZIP      := $(DIST_DIR)/deterministic-threat-detection.zip
+UAV_ZIP      := $(DIST_DIR)/uav.zip
 SOLUTION_ZIP := $(DIST_DIR)/federal-and-aerospace-ai-suite.zip
 
 # Forwarded to sub-Makefiles when overridden on the command line.
@@ -32,13 +35,16 @@ override_vars := $(foreach v,VIPPET_REPO VIPPET_REF VIPPET_PATH,\
 # --- Public targets ----------------------------------------------------------
 
 .PHONY: all
-all: handheld-multi-modal deterministic-threat-detection federal-and-aerospace-ai-suite ## Build every component ZIP and the full-solution ZIP
+all: handheld-multi-modal deterministic-threat-detection uav federal-and-aerospace-ai-suite ## Build every component ZIP and the full-solution ZIP
 
 .PHONY: handheld-multi-modal
 handheld-multi-modal: $(HANDHELD_ZIP) ## Build handheld-multi-modal.zip (includes vippet)
 
 .PHONY: deterministic-threat-detection
 deterministic-threat-detection: $(DTD_ZIP) ## Build deterministic-threat-detection.zip
+
+.PHONY: uav
+uav: $(UAV_ZIP) ## Build uav.zip (uav-mission-compute-sdk + uav-vision-analytics)
 
 .PHONY: federal-and-aerospace-ai-suite
 federal-and-aerospace-ai-suite: $(SOLUTION_ZIP) ## Build federal-and-aerospace-ai-suite.zip with the entire solution
@@ -77,6 +83,12 @@ $(DTD_ZIP): $(shell find $(DTD_SRC) -type f 2>/dev/null)
 	zip -rq "$@" "$(DTD_SRC)"
 	@echo "Archive ready: $@"
 
+$(UAV_ZIP): $(shell find $(UAVSDK_SRC) $(UAVVA_SRC) -type f 2>/dev/null)
+	@mkdir -p "$(DIST_DIR)"
+	@rm -f "$@"
+	zip -rq "$@" "$(UAVSDK_SRC)" "$(UAVVA_SRC)"
+	@echo "Archive ready: $@"
+
 # --- Full solution ZIP -------------------------------------------------------
 #
 # Bundles the entire federal-and-aerospace-ai-suite tree, with handheld-multi-modal already
@@ -85,7 +97,7 @@ $(DTD_ZIP): $(shell find $(DTD_SRC) -type f 2>/dev/null)
 SOLUTION_STAGE := $(BUILD_DIR)/federal-and-aerospace-ai-suite
 
 $(SOLUTION_ZIP): $(HANDHELD_STAMP) \
-		$(shell find $(DTD_SRC) docs -type f 2>/dev/null) \
+		$(shell find $(DTD_SRC) $(UAVSDK_SRC) $(UAVVA_SRC) docs -type f 2>/dev/null) \
 		README.md
 	@echo ">> Staging federal-and-aerospace-ai-suite (full solution)"
 	@rm -rf "$(SOLUTION_STAGE)"

--- a/federal-and-aerospace-ai-suite/Makefile
+++ b/federal-and-aerospace-ai-suite/Makefile
@@ -25,7 +25,7 @@ UAVVA_SRC    := uav-vision-analytics
 # Output archives.
 HANDHELD_ZIP := $(DIST_DIR)/handheld-multi-modal.zip
 DTD_ZIP      := $(DIST_DIR)/deterministic-threat-detection.zip
-UAV_ZIP      := $(DIST_DIR)/uav.zip
+UAV_ZIP      := $(DIST_DIR)/uav-mission-apps.zip
 SOLUTION_ZIP := $(DIST_DIR)/federal-and-aerospace-ai-suite.zip
 
 # Forwarded to sub-Makefiles when overridden on the command line.
@@ -35,7 +35,7 @@ override_vars := $(foreach v,VIPPET_REPO VIPPET_REF VIPPET_PATH,\
 # --- Public targets ----------------------------------------------------------
 
 .PHONY: all
-all: handheld-multi-modal deterministic-threat-detection uav federal-and-aerospace-ai-suite ## Build every component ZIP and the full-solution ZIP
+all: handheld-multi-modal deterministic-threat-detection uav-mission-apps federal-and-aerospace-ai-suite ## Build every component ZIP
 
 .PHONY: handheld-multi-modal
 handheld-multi-modal: $(HANDHELD_ZIP) ## Build handheld-multi-modal.zip (includes vippet)
@@ -43,8 +43,8 @@ handheld-multi-modal: $(HANDHELD_ZIP) ## Build handheld-multi-modal.zip (include
 .PHONY: deterministic-threat-detection
 deterministic-threat-detection: $(DTD_ZIP) ## Build deterministic-threat-detection.zip
 
-.PHONY: uav
-uav: $(UAV_ZIP) ## Build uav.zip (uav-mission-compute-sdk + uav-vision-analytics)
+.PHONY: uav-mission-apps
+uav-mission-apps: $(UAV_ZIP) ## Build uav-mission-apps.zip (uav-mission-compute-sdk + uav-vision-analytics)
 
 .PHONY: federal-and-aerospace-ai-suite
 federal-and-aerospace-ai-suite: $(SOLUTION_ZIP) ## Build federal-and-aerospace-ai-suite.zip with the entire solution


### PR DESCRIPTION
Add a `uav-mission-apps` make target that bundles uav-mission-compute-sdk and uav-vision-analytics into a single dist/uav.zip, alongside the existing handheld-multi-modal and deterministic-threat-detection archives.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

