### PR TITLE
LVC [fix] Bump OVMS_RELEASE_TAG default placeholder to v2026.1.0

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-captioning-rag/model_download_scripts/download_models.sh
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning-rag/model_download_scripts/download_models.sh
@@ -44,7 +44,7 @@ EPHEMERAL_SCRIPT_URL="${MODEL_DOWNLOAD_EPHEMERAL_SCRIPT_URL:-https://raw.githubu
 # application image TAG (used by compose.yaml) to avoid pinning the app release
 # tag onto the model-download image, which has its own tag stream.
 IMAGE_TAG="${MODEL_DOWNLOAD_IMAGE_TAG:-latest}"
-OVMS_RELEASE_TAG="${OVMS_RELEASE_TAG:-v2026.0}"
+OVMS_RELEASE_TAG="${OVMS_RELEASE_TAG:-v2026.1.0}"
 EPHEMERAL_CONTAINER_NAME="${MODEL_DOWNLOAD_EPHEMERAL_CONTAINER_NAME:-model-download-ephemeral}"
 
 ensure_model_base_dir_for_current_user() {

--- a/metro-ai-suite/live-video-analysis/live-video-captioning/model_download_scripts/download_models.sh
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/model_download_scripts/download_models.sh
@@ -43,7 +43,7 @@ EPHEMERAL_SCRIPT_URL="${MODEL_DOWNLOAD_EPHEMERAL_SCRIPT_URL:-https://raw.githubu
 # application image TAG (used by compose.yaml) to avoid pinning the app release
 # tag onto the model-download image, which has its own tag stream.
 IMAGE_TAG="${MODEL_DOWNLOAD_IMAGE_TAG:-latest}"
-OVMS_RELEASE_TAG="${OVMS_RELEASE_TAG:-v2026.0}"
+OVMS_RELEASE_TAG="${OVMS_RELEASE_TAG:-v2026.1.0}"
 EPHEMERAL_CONTAINER_NAME="${MODEL_DOWNLOAD_EPHEMERAL_CONTAINER_NAME:-model-download-ephemeral}"
 
 ensure_model_base_dir_for_current_user() {


### PR DESCRIPTION

### Description

The previous default OVMS_RELEASE_TAG=v2026.0 pinned openvino-tokenizers==2026.0.0rc3, which has been rotated out of pre-release/nightly wheel storage and is no longer installable. This caused `uv pip install` to silently fall back to the base (near-empty) openvino venv, resulting in missing jinja2/transformers dependencies and a runtime failure during model conversion: ModuleNotFoundError: No module named 'jinja2'

Update the default tag to v2026.1.0 in both live-video-captioning and live-video-captioning-rag model download scripts to resolve the broken dependency chain.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

