### PR TITLE
[FedAero] Cheery-pick - Change model to Qwen3.5 and download ViPPET concurrently

### DIFF
--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/AGENTS.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/AGENTS.md
@@ -41,6 +41,7 @@ The Federal and Aerospace AI Suite Application Blueprint is defined and deployed
 | `RENDER_GID`       | `make setup` (auto-detect) | GPU device group for OpenVINO model server|
 | `GRAFANA_PASSWORD` | manual / defaults `admin`  | Grafana dashboard admin password          |
 | `CDI_XE_DEVICE_0`  | manual                     | CDI device path (CDI variant only)        |
+| `HF_TOKEN`         | optional, exported shell variable | Hugging Face token passed to OVMS and Open WebUI for authenticated, potentially faster model downloads; do not store it in `.env` or version control |
 
 Run `make setup` (idempotent) to auto-populate `.env` before any `make up` variant.
 
@@ -48,11 +49,13 @@ Run `make setup` (idempotent) to auto-populate `.env` before any `make up` varia
 
 ```bash
 make setup            # detects the render group GID and writes it into the .env file (idempotent)
-make deploy           # full one-shot deployment: sets runtime environment variables for the stack, tailors Visual Pipeline and Platform Evaluation Tool installation (metrics-manager and supported models) and brings up the stack components in the correct order
-make deploy-cdi       # full one-shot: CDI and SR-IOV variant
+make deploy           # full deployment: starts ViPPET and handheld services while their model downloads run concurrently; waits for ViPPET models to install
+make deploy-cdi       # same full deployment for CDI and SR-IOV
 make vippet-get       # does sparse-checkout of Visual Pipeline and Platform Evaluation Tool into ../vippet-fedaero (excludes docs)
 make vippet-configure # copies telegraf.conf into the Visual Pipeline and Platform Evaluation Tool and patches the tool's compose.yml file
-make vippet-up        # starts Visual Pipeline and Platform Evaluation Tool (builds images and installs models)
+make vippet-up        # starts Visual Pipeline and Platform Evaluation Tool (builds images; does not wait for model installation)
+make models-download-async # requests ViPPET model downloads in the background; logs to .work/models-download.log
+make models-status    # waits for and displays ViPPET model installation status
 make vippet-down      # stops Visual Pipeline and Platform Evaluation Tool
 make up               # starts this stack only (Visual Pipeline and Platform Evaluation Tool must already be running)
 make up-standalone    # starts without Visual Pipeline and Platform Evaluation Tool (for development or testing)

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/Makefile
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/Makefile
@@ -42,9 +42,12 @@ VIPPET_DIR := $(SELF_DIR)/../vippet-fedaero
 VIPPET_CWD := $(VIPPET_DIR)/$(VIPPET_PATH)
 
 MODELS_RETRIES  ?= 50
+MODELS_STATUS_RETRIES ?= 120
 MODELS_STATUS_INTERVAL ?= 30
 MODELS_LICENSE_FILE ?= .license-accepted
 MODELS_SUPPORTED_FILE ?= $(VIPPET_CWD)/shared/models/supported_models.yaml
+MODELS_DOWNLOAD_LOG ?= $(WORK_DIR)/models-download.log
+MODELS_DOWNLOAD_PID ?= $(WORK_DIR)/models-download.pid
 
 # ---------------------------------------------------------------------------
 # Packaging config (used by 'stage' / 'vippet' targets)
@@ -61,7 +64,7 @@ TEMPLATE_DIR := $(SELF_DIR)/templates
 	build rebuild clean health test urls build-whisper \
 	stage vippet \
 	restler-build restler-stt restler-package \
-	models-license models-download models-status
+	models-license models-download models-download-async models-status
 
 help: ## Show this help
 	@awk ' \
@@ -155,7 +158,7 @@ vippet-configure: vippet-get ## Copy telegraf config and inject env vars into vi
 	yq -i -y '.services."metrics-manager".ports = ["9090:9090"]' $(VIPPET_CWD)/compose.yml; \
 	echo "✓ vippet configured (telegraf.conf copied)"
 
-vippet-up: vippet-configure ## Start vippet (builds images, installs all models, starts stack)
+vippet-up: vippet-configure ## Start vippet (builds images and starts stack)
 	@cd $(VIPPET_CWD) && \
 	sed -i 's|^VERSION=.*|VERSION=$(VIPPET_DOCKER_TAG)|' setup_env.sh && \
 	{ [ -f .env ] || bash setup_env.sh; } && \
@@ -171,8 +174,6 @@ vippet-up: vippet-configure ## Start vippet (builds images, installs all models,
 	fi && \
 	$(MAKE) build run && \
 	echo "✓ vippet running"
-	# fedaero makefile
-	@$(MAKE) models-license models-download models-status 
 
 vippet-down: ## Stop vippet
 	@cd $(VIPPET_CWD) && docker compose down
@@ -194,13 +195,22 @@ define _wait_for_network
 	done
 endef
 
-deploy: install-deps setup vippet-up ## Full deploy: setup → start vippet → start this stack
+deploy: install-deps setup vippet-up ## Full deploy: start ViPPET and handheld stack while models download
+	@$(MAKE) --no-print-directory models-license
+	@$(MAKE) --no-print-directory models-download-async
 	$(call _wait_for_network)
 	@$(MAKE) up
+	@$(MAKE) --no-print-directory models-status
 
-deploy-cdi: install-deps setup vippet-up ## Full deploy (CDI/SR-IOV): setup → start vippet → start this stack
+deploy-cdi: install-deps setup vippet-up ## Full deploy (CDI/SR-IOV) while models download
+	@$(MAKE) --no-print-directory models-license
+	@$(MAKE) --no-print-directory models-download-async
 	$(call _wait_for_network)
 	@$(MAKE) up-cdi
+	@$(MAKE) --no-print-directory models-status
+
+deploy-standalone: install-deps setup ## Full deploy (standalone, no ViPPET)
+	@$(MAKE) up-standalone
 
 # Stack lifecycle
 
@@ -426,13 +436,23 @@ models-download:
 		esac; \
 		[ $$i -eq $(MODELS_RETRIES) ] && break; \
 		sleep 5; \
-    done; \
+	done; \
+	echo "✗ Model download request was not accepted after $(MODELS_RETRIES) attempts"; \
+	exit 1
+
+models-download-async: ## Request ViPPET model downloads in background; log at $(MODELS_DOWNLOAD_LOG)
+	@mkdir -p "$(dir $(MODELS_DOWNLOAD_LOG))"
+	@rm -f "$(MODELS_DOWNLOAD_PID)"; \
+	$(MAKE) --no-print-directory models-download >"$(MODELS_DOWNLOAD_LOG)" 2>&1 & \
+	echo $$! > "$(MODELS_DOWNLOAD_PID)"; \
+	PID=$$(cat "$(MODELS_DOWNLOAD_PID)"); \
+	echo "✓ Model download request started (PID $$PID; log: $(MODELS_DOWNLOAD_LOG))"
 
 models-status:
-	@for i in $$(seq 1 $(MODELS_RETRIES)); do \
+	@for i in $$(seq 1 $(MODELS_STATUS_RETRIES)); do \
 		STATUS=$$(curl -sf http://localhost:7860/api/v1/models | jq -c '[.[] | {display_name, install_status}]'); \
 		if [ -z "$$STATUS" ]; then \
-			echo "  [$$i/$(MODELS_RETRIES)] API not reachable yet..."; \
+			echo "  [$$i/$(MODELS_STATUS_RETRIES)] API not reachable yet..."; \
 		else \
 			echo "$$STATUS" | jq -r '.[] | "  \(.display_name)\t\(.install_status)"' | column -t -s "$$(printf '\t')"; \
 			if echo "$$STATUS" | jq -e 'length > 0 and all(.[]; .install_status == "installed")' >/dev/null; then \
@@ -440,11 +460,11 @@ models-status:
 				exit 0; \
 			fi; \
 		fi; \
-		[ $$i -eq $(MODELS_RETRIES) ] && break; \
-		echo "  [$$i/$(MODELS_RETRIES)] not all installed yet, retrying in $(MODELS_STATUS_INTERVAL)s..."; \
+		[ $$i -eq $(MODELS_STATUS_RETRIES) ] && break; \
+		echo "  [$$i/$(MODELS_STATUS_RETRIES)] not all installed yet, retrying in $(MODELS_STATUS_INTERVAL)s..."; \
 		sleep $(MODELS_STATUS_INTERVAL); \
 	done; \
-	echo "✗ Timeout: not all models installed after $$(( $(MODELS_RETRIES) * $(MODELS_STATUS_INTERVAL) ))s"; \
+	echo "✗ Timeout: not all models installed after $$(( $(MODELS_STATUS_RETRIES) * $(MODELS_STATUS_INTERVAL) ))s"; \
 	exit 1
 
 models-license:

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/README.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/README.md
@@ -50,6 +50,17 @@ All services share the `fedaero` Docker network and are defined in [`docker-comp
 
 Run `make setup` after cloning to auto-detect the `render` group GID and write the `.env`.
 
+### Optional Hugging Face Token
+
+OVMS and Open WebUI download models from Hugging Face or OpenVINO Hub on first start. For authenticated or gated model access, and potentially faster Hugging Face downloads, export `HF_TOKEN` before deploying. The default public model does not require a token.
+
+```bash
+export HF_TOKEN=hf_...
+make deploy
+```
+
+Do not add the token to `.env` or commit it to version control.
+
 ## Quick Start
 
 > **Recommended — use `make deploy`.**
@@ -57,7 +68,7 @@ Run `make setup` after cloning to auto-detect the `render` group GID and write t
 > ```text
 > network visual-pipeline-and-platform-evaluation-tool_default declared as external, but could not be found
 > ```
-> `make deploy` handles everything — it fetches Visual Pipeline and Platform Evaluation Tool, starts it, waits for the network, then brings up this stack.
+> `make deploy` handles everything — it fetches and starts Visual Pipeline and Platform Evaluation Tool, requests its model downloads, waits for the shared network, then starts this stack. ViPPET and OpenVINO Model Server model downloads run concurrently; the command completes after ViPPET models are installed.
 
 ```bash
 cd handheld-multi-modal
@@ -87,8 +98,10 @@ Open WebUI, Grafana dashboard, and Whisper speech-to-text service are only acces
 ## Make Targets
 
 ```text
-make deploy           # full one-shot deployment: sets runtime environment variables for the stack, tailors Visual Pipeline and Platform Evaluation Tool installation (metrics-manager and supported models) and brings up the stack components in the correct order
-make deploy-cdi        The same for CDI and SR-IOV environments
+make deploy           # full deployment: starts ViPPET and handheld services while their model downloads run concurrently; waits for ViPPET models to install
+make deploy-cdi       # same full deployment for CDI and SR-IOV
+make models-download-async  # request ViPPET models in the background; view .work/models-download.log for request diagnostics
+make models-status     # wait for and show ViPPET model installation progress
 make up                Start this stack (standard, requires Visual Pipeline and Platform Evaluation Tool network)
 make up-cdi            Start this stack (CDI, requires Visual Pipeline and Platform Evaluation Tool network)
 make up-standalone     Start this stack without Visual Pipeline and Platform Evaluation Tool (development or testing only)

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/LLM-OpenWebUI/README.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/LLM-OpenWebUI/README.md
@@ -55,6 +55,7 @@ downloading or loading, and inference requests will fail.
 
 | Model | Size | Notes |
 |-------|------|-------|
+| `OpenVINO/Qwen3.5-4B-int8-ov` | ~4 GB | Default deployment model; supports reasoning |
 | `OpenVINO/Phi-3.5-mini-instruct-int8-ov` | ~4 GB | Balanced quality and speed |
 | `OpenVINO/llama-3.2-3b-instruct-int8-ov` | ~3 GB | Good accuracy |
 | `OpenVINO/mistral-7b-instruct-v0.3-int8-ov` | ~7 GB | High quality, needs more VRAM |

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/LLM-OpenWebUI/README.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/LLM-OpenWebUI/README.md
@@ -45,7 +45,7 @@ downloading or loading, and inference requests will fail.
 
 | Model | Size | Notes |
 |-------|------|-------|
-| `OpenVINO/Phi-3.5-mini-instruct-int4-ov` | ~2 GB | Default, very fast |
+| `OpenVINO/Phi-3.5-mini-instruct-int4-ov` | ~2 GB | Very fast |
 | `OpenVINO/llama-3.2-3b-instruct-int4-ov` | ~2 GB | Good general use |
 | `OpenVINO/mistral-7b-instruct-v0.3-int4-ov` | ~4 GB | Better quality |
 | `OpenVINO/DeepSeek-R1-Distill-Qwen-1.5B-int4-ov` | ~1 GB | Tiny, fastest |

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/grafana/provisioning/dashboards/panther-lake-live.json
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/apps/grafana/provisioning/dashboards/panther-lake-live.json
@@ -1933,7 +1933,7 @@
                       "include": {
                         "names": [
                           "time",
-                          "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Phi-3.5-mini-instruct-int4-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
+                          "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Qwen3.5-4B-int8-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
                         ]
                       }
                     }
@@ -1984,7 +1984,7 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Phi-3.5-mini-instruct-int4-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
+                      "options": "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Qwen3.5-4B-int8-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
                     },
                     "properties": [
                       {
@@ -2118,7 +2118,7 @@
                       "include": {
                         "names": [
                           "time",
-                          "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Phi-3.5-mini-instruct-int4-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
+                          "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Qwen3.5-4B-int8-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
                         ]
                       }
                     }
@@ -2203,7 +2203,7 @@
                   {
                     "matcher": {
                       "id": "byName",
-                      "options": "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Phi-3.5-mini-instruct-int4-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
+                      "options": "counter {api=\"V3\", host=\"ptl\", interface=\"REST\", method=\"Stream\", name=\"OpenVINO/Qwen3.5-4B-int8-ov\", url=\"http://ovms.fedaero.intel.com:8000/metrics\"}"
                     },
                     "properties": [
                       {

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose-cdi.yml
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose-cdi.yml
@@ -74,22 +74,24 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: "${no_proxy},fedaero.intel.com"
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
       - ./data/ovms-models:/models
     command: >
       --rest_port 8000
-      --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov
+      --source_model OpenVINO/Qwen3.5-4B-int8-ov
       --model_repository_path /models
       --task text_generation
       --target_device GPU
       --metrics_enable
+      --reasoning_parser qwen3
       --plugin_config '{"GPU_ENABLE_SDPA_OPTIMIZATION":"NO","KV_CACHE_PRECISION":"f16","ENABLE_MMAP":"NO"}'
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Phi-3.5-mini-instruct-int4-ov'"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Qwen3.5-4B-int8-ov'"]
       interval: 15s
       timeout: 5s
       retries: 20
-      start_period: 5m
+      start_period: 30m
 
   # OpenWebUI - LLM Chat Interface
   open-webui:
@@ -108,10 +110,15 @@ services:
       - WHISPER_MODEL=base
       - WHISPER_COMPUTE_TYPE=float32
       - WEBUI_AUTH=False
+      - HF_TOKEN=${HF_TOKEN:-}
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
       - no_proxy=${no_proxy},fedaero.intel.com
-      - DEFAULT_MODEL_PARAMS={"max_tokens":1024}
+      - DEFAULT_MODEL_PARAMS={"max_tokens":2048, "custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      - TASK_MODEL_PARAMS={"max_tokens":1000,"custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      # Stops the model from generating follow-up questions and tags after answering a user query. Limits model usage.
+      - ENABLE_FOLLOW_UP_GENERATION=false
+      - ENABLE_TAGS_GENERATION=false
       # ONLY NEEDED IF OFFLINE MODE IS DESIRED
       # - OFFLINE_MODE=true
       # - HF_HUB_OFFLINE=1

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose-standalone.yml
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose-standalone.yml
@@ -75,22 +75,24 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: "${no_proxy},fedaero.intel.com"
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
       - ./data/ovms-models:/models
     command: >
       --rest_port 8000
-      --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov
+      --source_model OpenVINO/Qwen3.5-4B-int8-ov
       --model_repository_path /models
       --task text_generation
       --target_device GPU
       --metrics_enable
+      --reasoning_parser qwen3
       --plugin_config '{"GPU_ENABLE_SDPA_OPTIMIZATION":"NO","KV_CACHE_PRECISION":"f16","ENABLE_MMAP":"NO"}'
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Phi-3.5-mini-instruct-int4-ov'"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Qwen3.5-4B-int8-ov'"]
       interval: 15s
       timeout: 5s
       retries: 20
-      start_period: 5m
+      start_period: 30m
 
   # OpenWebUI - LLM Chat Interface
   open-webui:
@@ -109,10 +111,15 @@ services:
       - WHISPER_MODEL=base
       - WHISPER_COMPUTE_TYPE=float32
       - WEBUI_AUTH=False
+      - HF_TOKEN=${HF_TOKEN:-}
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
       - no_proxy=${no_proxy},fedaero.intel.com
-      - DEFAULT_MODEL_PARAMS={"max_tokens":1024}
+      - DEFAULT_MODEL_PARAMS={"max_tokens":2048, "custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      - TASK_MODEL_PARAMS={"max_tokens":1000,"custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      # Stops the model from generating follow-up questions and tags after answering a user query. Limits model usage.
+      - ENABLE_FOLLOW_UP_GENERATION=false
+      - ENABLE_TAGS_GENERATION=false
       # ONLY NEEDED IF OFFLINE MODE IS DESIRED
       # - OFFLINE_MODE=true
       # - HF_HUB_OFFLINE=1

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose.yml
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docker-compose.yml
@@ -71,22 +71,24 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       no_proxy: "${no_proxy},fedaero.intel.com"
+      HF_TOKEN: ${HF_TOKEN:-}
     volumes:
       - ./data/ovms-models:/models
     command: >
       --rest_port 8000
-      --source_model OpenVINO/Phi-3.5-mini-instruct-int4-ov
+      --source_model OpenVINO/Qwen3.5-4B-int8-ov
       --model_repository_path /models
       --task text_generation
       --target_device GPU
       --metrics_enable
+      --reasoning_parser qwen3
       --plugin_config '{"GPU_ENABLE_SDPA_OPTIMIZATION":"NO","KV_CACHE_PRECISION":"f16","ENABLE_MMAP":"NO"}'
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Phi-3.5-mini-instruct-int4-ov'"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/v1/config | grep -q 'Qwen3.5-4B-int8-ov'"]
       interval: 15s
       timeout: 5s
       retries: 20
-      start_period: 5m
+      start_period: 30m
 
   # OpenWebUI - LLM Chat Interface
   open-webui:
@@ -105,10 +107,15 @@ services:
       - WHISPER_MODEL=base
       - WHISPER_COMPUTE_TYPE=float32
       - WEBUI_AUTH=False
+      - HF_TOKEN=${HF_TOKEN:-}
       - http_proxy=${http_proxy}
       - https_proxy=${https_proxy}
       - no_proxy=${no_proxy},fedaero.intel.com
-      - DEFAULT_MODEL_PARAMS={"max_tokens":1024}
+      - DEFAULT_MODEL_PARAMS={"max_tokens":2048, "custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      - TASK_MODEL_PARAMS={"max_tokens":1000,"custom_params":{"chat_template_kwargs":{"enable_thinking":false}}}
+      # Stops the model from generating follow-up questions and tags after answering a user query. Limits model usage.
+      - ENABLE_FOLLOW_UP_GENERATION=false
+      - ENABLE_TAGS_GENERATION=false
       # ONLY NEEDED IF OFFLINE MODE IS DESIRED
       # - OFFLINE_MODE=true
       # - HF_HUB_OFFLINE=1

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
@@ -91,6 +91,12 @@ cd handheld-multi-modal
 ./run.sh up
 ```
 
+To deploy without Visual Pipeline and Platform Evaluation Tool, run:
+
+```bash
+./run.sh standalone
+```
+
 ## Verifying the installation
 
 After the script finishes, verify that the containers are running (sample output below):

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/templates/README.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/templates/README.md
@@ -8,7 +8,7 @@ This package contains:
 
 - `handheld-multi-modal/` — Federal and Aerospace AI Suite's Handheld Multi-Modal application (Docker Compose stack).
 - `vippet-fedaero/`       — Visual Pipeline and Platform Evaluation Tool, pre-checked-out at the pinned revision.
-- `run.sh`                — Convenience wrapper around `make deploy` and `make down`.
+- `run.sh`                — Convenience wrapper around the deployment and shutdown targets.
 
 ## Prerequisites
 
@@ -19,6 +19,7 @@ This package contains:
 
 ```bash
 ./run.sh up      # Deploy Visual Pipeline and Platform Evaluation Tool and HandHeld Multi-Modal stack (default)
+./run.sh standalone # Deploy HandHeld Multi-Modal without Visual Pipeline and Platform Evaluation Tool
 ./run.sh down    # Stop both stacks
 ./run.sh logs    # Tail logs from the HandHeld Multi-Modal stack
 ```
@@ -29,6 +30,7 @@ Or invoke `make` directly:
 cd handheld-multi-modal
 make deploy        # standard GPU
 make deploy-cdi    # CDI and SR-IOV
+make deploy-standalone # standalone deployment without Visual Pipeline and Platform Evaluation Tool
 make down          # stop everything
 ```
 

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/templates/run.sh
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/templates/run.sh
@@ -5,7 +5,7 @@
 # Convenience wrapper for the Federal Aerospace handheld multi-modal stack.
 # vippet is included in this package; make deploy handles the full deployment.
 #
-# Usage: ./run.sh [up|down|logs]
+# Usage: ./run.sh [up|standalone|down|logs]
 
 set -euo pipefail
 
@@ -18,6 +18,9 @@ case "${action}" in
   up)
     make -C "${APP_DIR}" deploy
     ;;
+  standalone)
+    make -C "${APP_DIR}" deploy-standalone
+    ;;
   down)
     make -C "${APP_DIR}" down
     ;;
@@ -25,7 +28,7 @@ case "${action}" in
     docker compose -f "${APP_DIR}/docker-compose.yml" logs -f --tail=100
     ;;
   *)
-    echo "usage: $0 [up|down|logs]" >&2
+    echo "usage: $0 [up|standalone|down|logs]" >&2
     exit 2
     ;;
 esac

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/third-party-components.spdx
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/third-party-components.spdx
@@ -81,7 +81,7 @@ PackageHomePage: https://github.com/openvinotoolkit/model_server
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: <text>Copyright (C) Intel Corporation</text>
-PackageSummary: <text>OpenVINO Model Server (OVMS) serving the Phi-3.5-mini-instruct INT4 LLM over an OpenAI-compatible REST API, executed on Intel GPU via the OpenVINO runtime.</text>
+PackageSummary: <text>OpenVINO Model Server (OVMS) serving the Qwen3.5-4B-int8 LLM over an OpenAI-compatible REST API, executed on Intel GPU via the OpenVINO runtime.</text>
 ExternalRef: PACKAGE-MANAGER purl pkg:docker/openvino/model_server@latest-gpu
 FilesAnalyzed: false
 


### PR DESCRIPTION

### Description

Improve Handheld Multi-Modal model startup and download workflow

- Switch the OVMS LLM from Phi-3.5 Mini to Qwen 3.5 4B INT8 and enable the Qwen reasoning parser.
- Align OVMS health checks with the new model and extend the startup grace period from 5 to 30 minutes for initial model download and loading.
- Pass an optional HF_TOKEN into OVMS and Open WebUI to support authenticated, gated, and potentially faster Hugging Face downloads.
- Tune Open WebUI generation defaults:
    - Increase regular response tokens to 2048.
    - Set task generation tokens to 1000.
    - Disable automatic follow-up-question and tag generation to reduce unnecessary model usage.
- Start ViPPET and Handheld Multi-Modal model downloads concurrently during make deploy and make deploy-cdi.
- Add background ViPPET model-download handling with request logs and PID tracking.
- Extend ViPPET model-installation status waiting to 60 minutes while preserving the shorter request-retry timeout.

- Add ./run.sh standalone for deploying without ViPPET, and document the option in the deployment guide.

Fixes # (issue)

ITEP-95868

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

