### PR TITLE
[smart-traffic-intersection-agent] Disable Metrics Manager service account token automount #95419

### DIFF
--- a/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/metrics-manager/templates/deployment.yaml
+++ b/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/metrics-manager/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
     spec:
       hostPID: {{ .Values.pod.hostPID }}
       hostNetwork: {{ .Values.pod.hostNetwork }}
+      # Metrics Manager does not use the Kubernetes API, and its token folder cannot be created under read-only /run.
+      automountServiceAccountToken: false
       {{- $dnsPolicy := .Values.pod.dnsPolicy }}
       {{- if not $dnsPolicy }}
         {{- if .Values.pod.hostNetwork }}


### PR DESCRIPTION
### Description

Disables the unused Kubernetes service-account token automount for the Metrics Manager pod. This prevents startup failures when Kubernetes cannot create the token mount directory under the read-only /run  host mount.

### How Has This Been Tested?

Deployed the updated STIA Helm chart with Metrics Manager pinned to a node, where the service-account directory was absent. Confirmed the new pod started successfully with /run read-only, automountServiceAccountToken: false.