### PR TITLE
[LVC] Update scheduler configuration to disable caching features

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-captioning/app/backend/services/pipeline_server.py
+++ b/metro-ai-suite/live-video-analysis/live-video-captioning/app/backend/services/pipeline_server.py
@@ -36,7 +36,7 @@ class PipelineServer:
     WEBRTC_PEER_ID_MAX_LENGTH = 8
     WEBRTC_PEER_ID_PREFIX = "s"
     DEFAULT_RESOLUTION_SUFFIX = "_Default_Resolution"
-    SCHEDULER_CONFIG = f"max_num_batched_tokens=256,cache_size={VLM_CACHE_SIZE},enable_prefix_caching=true,dynamic_split_fuse=true,use_cache_eviction=true"
+    SCHEDULER_CONFIG = f"max_num_batched_tokens=256,cache_size={VLM_CACHE_SIZE},enable_prefix_caching=false,dynamic_split_fuse=true,use_cache_eviction=false"
     HEALTHY_PIPELINE_STATES = {"running", "queued"}
 
     @staticmethod


### PR DESCRIPTION
### Description

Backport of #4190 to `main`. Disables `enable_prefix_caching` and `use_cache_eviction` together in `SCHEDULER_CONFIG` for the VLM pipeline server, since both flags control the same KV-cache blocks and combining them causes a block reference-count double-release crash after 30–60 minutes of continuous inference (confirmed against OpenVINO GenAI's `BlockAllocator`/`CacheBlock` source).

Same one-line change, applied cleanly via cherry-pick (`main` had the identical buggy line as `release-2026.2.0`).

Fixes # (issue)

N/A

### How Has This Been Tested?

Tested locally (same validation as #4190): full pytest suite passing, plus live GPU (B580) soak test showing the crash no longer occurs.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.
