### PR TITLE
fix(multi-modal-patient-monitoring): document 2026.2.0 in release notes

### DIFF
--- a/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/release-notes.md
+++ b/health-and-life-sciences-ai-suite/multi_modal_patient_monitoring/docs/user-guide/release-notes.md
@@ -1,8 +1,8 @@
 # Release Notes: Multi-Modal Patient Monitoring
 
-## Version 1.0.0
+## Version 2026.2.0
 
-**Release Date**: March 25, 2026
+**Release Date**: August 18, 2026
 
 This is the initial release of the application, therefore, it is considered a preview version.
 


### PR DESCRIPTION
The release notes documented only 'Version 1.0.0' (March 25, 2026) from the previous semantic-versioning scheme, while the Makefile ships TAG 2026.2.0. Relabel the entry to the current 2026.2.0 release (Aug 18, 2026) so the docs match the shipped version, consistent with the surgical-instrument sibling's format.

Fixes ITEP-96035

