### PR TITLE
Smart Classroom: route ASR through CapabilityRunner, drop dead audio_pipeline_lock

### DIFF
--- a/education-ai-suite/smart-classroom/api/endpoints.py
+++ b/education-ai-suite/smart-classroom/api/endpoints.py
@@ -21,7 +21,7 @@ from monitoring.monitor import start_monitoring, stop_monitoring, get_metrics
 from dto.audiosource import AudioSource
 from components.ffmpeg import audio_preprocessing
 from utils.audio_util import save_audio_file
-from utils.locks import audio_pipeline_lock, video_analytics_lock
+from utils.locks import video_analytics_lock
 from components.va.va_pipeline_service import VideoAnalyticsPipelineService, PipelineOptions
 from components.va.media_service import ensure_media_service_running
 from utils.session_manager import generate_session_id

--- a/education-ai-suite/smart-classroom/components/asr/asr_handle.py
+++ b/education-ai-suite/smart-classroom/components/asr/asr_handle.py
@@ -8,9 +8,11 @@ from typing import Optional
 from model_manager.capability.state import CapabilityState
 from model_manager.capability.runner import CapabilityRunner
 from utils.config_loader import config
-from utils.runtime_config_loader import RuntimeConfig
 
 logger = logging.getLogger(__name__)
+
+_ASR_MAX_CONCURRENCY = 1
+_ASR_QUEUE_MAX = 8
 
 
 class AsrHandler:
@@ -41,11 +43,17 @@ class AsrHandler:
         return concurrency
 
     def _concurrency_config(self) -> tuple[int, int]:
-        """Read max_concurrency and queue_max from runtime config."""
-        asr_cfg = RuntimeConfig.get_section("asr")
-        max_concurrency = asr_cfg.get("max_concurrency", 1)
-        queue_max = asr_cfg.get("queue_max", 8)
-        return max_concurrency, queue_max
+        """Read max_concurrency and queue_max from config.models.asr."""
+        try:
+            asr_cfg = getattr(config.models, "asr", None)
+            if asr_cfg is None:
+                return _ASR_MAX_CONCURRENCY, _ASR_QUEUE_MAX
+            return (
+                int(getattr(asr_cfg, "concurrency", _ASR_MAX_CONCURRENCY)),
+                int(getattr(asr_cfg, "queue_max", _ASR_QUEUE_MAX)),
+            )
+        except Exception:
+            return _ASR_MAX_CONCURRENCY, _ASR_QUEUE_MAX
 
     def _ensure_openvino_asr_model(self) -> None:
         """Download and convert ASR model to OpenVINO IR if not already cached.
@@ -164,11 +172,14 @@ class AsrHandler:
                 self._runner = None
                 raise
 
-    def transcribe(self, audio_path: str) -> dict:
+    def transcribe(self, audio_path: str, **kwargs) -> dict:
+        """Transcribe through the CapabilityRunner so concurrent callers queue
+        instead of entering the model together. Extra kwargs (e.g. temperature)
+        are forwarded to the underlying processor."""
         if not self.loaded:
             raise RuntimeError("ASR not loaded. Call load() first.")
-        
-        return self._runner.submit(audio_path)
+
+        return self._runner.submit(audio_path, **kwargs)
 
     def shutdown(self) -> None:
         """Unload the ASR model and release resources."""

--- a/education-ai-suite/smart-classroom/components/asr_component.py
+++ b/education-ai-suite/smart-classroom/components/asr_component.py
@@ -82,9 +82,6 @@ class ASRComponent(PipelineComponent):
         
         logger.info(f"ASRComponent using ModelManager ASR: provider={self.asr_handler.provider}, "
                    f"model={self.asr_handler.model_name}, device={self.asr_handler.device}")
-        
-        # Get the underlying processor for transcription
-        self.asr = self.asr_handler._processor
 
         # Resolved here so an unsupported combination fails when the pipeline is built.
         self.chunking = resolve_chunking()
@@ -175,7 +172,7 @@ class ASRComponent(PipelineComponent):
 
             for chunk_data in input_generator:
                 chunk_path = chunk_data["chunk_path"]
-                transcription = self.asr.transcribe(chunk_path, temperature=self.temperature)
+                transcription = self.asr_handler.transcribe(chunk_path, temperature=self.temperature)
 
                 ui_segments = []
                 transcribed_lines = []

--- a/education-ai-suite/smart-classroom/components/report_generator/report_generator.py
+++ b/education-ai-suite/smart-classroom/components/report_generator/report_generator.py
@@ -22,7 +22,6 @@ from utils.config_loader import config
 from utils.runtime_config_loader import RuntimeConfig
 from utils.storage_manager import StorageManager
 from utils.session_paths import SessionPaths
-from utils.locks import audio_pipeline_lock
 from components.report_generator.template_manager import (
     get_template_path,
     extract_template_structure,
@@ -139,16 +138,6 @@ class ReportGenerator:
         """
         if self.model is None:
             raise RuntimeError("ReportGenerator requires a model instance.")
-
-        if audio_pipeline_lock.locked():
-            busy_msg = (
-                "当前音频处理正在进行中，请等待转录/摘要完成后再生成报告。"
-                if self.language == "zh"
-                else "Audio processing is in progress. Please wait for transcription/summary to complete."
-            )
-            logger.warning("[ReportGenerator] audio_pipeline_lock is held, refusing to start.")
-            yield {"type": "token", "content": busy_msg}
-            return
 
         start = time.perf_counter()
 

--- a/education-ai-suite/smart-classroom/config.yaml
+++ b/education-ai-suite/smart-classroom/config.yaml
@@ -37,6 +37,8 @@ models:
     min_duration_sec: 0.25
     min_words: 2
     max_chars_per_segment: 0  # cap characters per merged transcript segment; set to 0 or Null to disable merging entirely
+    concurrency: 1    # CapabilityRunner max_concurrency (single warm pipe)
+    queue_max: 8      # CapabilityRunner queue depth before 503 backpressure
   
   diarization: #Only applicable when diarization is set to True for ASR
     backend: pyannote  # pyannote, or campplus for funasr/paraformer-zh

--- a/education-ai-suite/smart-classroom/model_manager/features/asr_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/asr_feature.py
@@ -12,7 +12,6 @@ from dto.transcription_dto import TranscriptionRequest
 from pipeline import Pipeline
 from utils.audio_util import save_audio_file
 from utils.config_loader import config
-from utils.locks import audio_pipeline_lock
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +21,6 @@ router = APIRouter()
 @router.post("/upload-audio")
 def upload_audio(file: UploadFile = File(...)):
     status_code = status.HTTP_201_CREATED
-
-    if audio_pipeline_lock.locked():
-        raise HTTPException(status_code=429, detail="Session Active, Try Later")
 
     try:
         filename, filepath = save_audio_file(file)
@@ -55,9 +51,6 @@ def transcribe_audio(
     request: TranscriptionRequest,
     x_session_id: Optional[str] = Header(None)
 ):
-    if audio_pipeline_lock.locked():
-        raise HTTPException(status_code=429, detail="Session Active, Try Later")
-
     pipeline = Pipeline(x_session_id)
 
     def stream_transcription():

--- a/education-ai-suite/smart-classroom/model_manager/features/segmentation_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/segmentation_feature.py
@@ -7,7 +7,6 @@ from fastapi.responses import JSONResponse
 
 from dto.summarizer_dto import SummaryRequest
 from pipeline import Pipeline
-from utils.locks import audio_pipeline_lock
 from utils.runtime_config_loader import RuntimeConfig
 from utils.scp_sender import get_scp_sender
 from utils.session_state_manager import SessionState
@@ -20,9 +19,6 @@ router = APIRouter()
 
 @router.post("/content-segmentation")
 def content_segmentation(request: SummaryRequest):
-
-    if audio_pipeline_lock.locked():
-        raise HTTPException(status_code=429, detail="Session Active, Try Later")
 
     pipeline = Pipeline(request.session_id)
 

--- a/education-ai-suite/smart-classroom/model_manager/features/summary_feature.py
+++ b/education-ai-suite/smart-classroom/model_manager/features/summary_feature.py
@@ -3,13 +3,12 @@ import json
 import logging
 from typing import Dict, List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from dto.summarizer_dto import SummaryRequest
 from pipeline import Pipeline
 from utils.config_loader import config
-from utils.locks import audio_pipeline_lock
 
 logger = logging.getLogger(__name__)
 
@@ -18,9 +17,6 @@ router = APIRouter()
 
 @router.post("/summarize")
 async def summarize_audio(request: SummaryRequest):
-    if audio_pipeline_lock.locked():
-        raise HTTPException(status_code=429, detail="Session Active, Try Later")
-
     pipeline = Pipeline(request.session_id)
 
     async def event_stream():

--- a/education-ai-suite/smart-classroom/model_manager/test/test_model_manager.py
+++ b/education-ai-suite/smart-classroom/model_manager/test/test_model_manager.py
@@ -1,4 +1,5 @@
 import threading
+import time
 import sys
 import os
 
@@ -223,6 +224,81 @@ def test_asr_handler_reads_concurrency_from_config():
     assert handler._runner._queue_max == 16
 
     handler.shutdown()
+
+
+def test_asr_transcribe_forwards_kwargs_to_processor():
+    """temperature (and any other kwarg) reaches the underlying processor."""
+    from unittest.mock import MagicMock, patch
+    handler = AsrHandler()
+    mock_processor = MagicMock()
+    mock_processor.transcribe.return_value = {"segments": []}
+
+    with patch.object(handler, "_build_processor", return_value=mock_processor):
+        handler.load()
+
+    result = handler.transcribe("chunk.wav", temperature=0.3)
+
+    assert result == {"segments": []}
+    mock_processor.transcribe.assert_called_once_with("chunk.wav", temperature=0.3)
+
+    handler.shutdown()
+
+
+def test_asr_transcribe_requires_load():
+    handler = AsrHandler()
+    try:
+        handler.transcribe("chunk.wav")
+        assert False, "expected RuntimeError"
+    except RuntimeError:
+        pass
+
+
+def test_asr_transcribe_serializes_under_max_concurrency_one():
+    """Concurrent transcribe() calls queue on the CapabilityRunner instead of
+    entering the model together. Guards against callers reaching around the
+    handler to the raw processor."""
+    from unittest.mock import patch
+    handler = AsrHandler()
+
+    inflight = []
+    peak = []
+
+    class SlowProcessor:
+        def transcribe(self, audio_path, temperature=0.0):
+            inflight.append(1)
+            peak.append(len(inflight))
+            time.sleep(0.05)
+            inflight.pop()
+            return {"segments": []}
+
+    with patch.object(handler, "_build_processor", return_value=SlowProcessor()):
+        with patch.object(handler, "_concurrency_config", return_value=(1, 8)):
+            handler.load()
+
+    threads = [
+        threading.Thread(target=handler.transcribe, args=(f"chunk{i}.wav",))
+        for i in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert max(peak) == 1, f"expected serialized ASR calls, saw {max(peak)} concurrent"
+
+    handler.shutdown()
+
+
+def test_asr_component_does_not_bypass_the_runner():
+    """ASRComponent must call AsrHandler.transcribe(), not reach into
+    _processor — otherwise the CapabilityRunner is silently skipped.
+    Source-level check so the test stays free of torch/model imports."""
+    path = os.path.join(_SC_ROOT, "components", "asr_component.py")
+    with open(path, encoding="utf-8") as f:
+        source = f.read()
+
+    assert "_processor" not in source
+    assert "self.asr_handler.transcribe(" in source
 
 
 def test_health_reports_asr_state_without_loading():

--- a/education-ai-suite/smart-classroom/utils/locks.py
+++ b/education-ai-suite/smart-classroom/utils/locks.py
@@ -1,4 +1,3 @@
 import threading 
 
-audio_pipeline_lock = threading.Lock()
 video_analytics_lock = threading.Lock()


### PR DESCRIPTION
### Description

ASRComponent grabbed AsrHandler._processor directly, bypassing the runner — concurrent sessions entered the model unprotected. Also removes audio_pipeline_lock, whose holders were deleted in 58bfb7c12, leaving 5 unreachable .locked() guards.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the APACHE-2.0 license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

