### PR TITLE
[DOCS] DLS release 2026.2 tag references

### DIFF
--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/infrastructure/build-dlstreamer-pipelines.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/infrastructure/build-dlstreamer-pipelines.md
@@ -289,8 +289,8 @@ See the [DL Streamer Coding Agent Guide](./use-dlstreamer-coding-agent.md) for u
 
 - [DL Streamer Repository](https://github.com/open-edge-platform/dlstreamer)
 - [DL Streamer Docker Hub](https://hub.docker.com/r/intel/dlstreamer)
-- [DL Streamer Elements Reference](https://github.com/open-edge-platform/dlstreamer/blob/main/docs/user-guide/elements/elements.md)
-- [DL Streamer Samples](https://github.com/open-edge-platform/dlstreamer/tree/main/samples)
+- [DL Streamer Elements Reference](https://github.com/open-edge-platform/dlstreamer/blob/v2026.2.0/docs/user-guide/elements/elements.md)
+- [DL Streamer Samples](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/samples)
 - [Container Device Interface Guide](./configure-cdi.md) — CDI setup for GPU/NPU access
 
 <!--hide_directive

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/install-oep-sdks.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/install-oep-sdks.md
@@ -38,7 +38,7 @@ Expected: `card0`/`renderD128` under `/dev/dri`, `accel0` under `/dev/accel`, an
 Run the official OEP Vision AI SDK installer on the target. It configures Docker, pulls the DL Streamer image, and installs the OpenVINO tooling and sample content:
 
 ```bash
-curl https://raw.githubusercontent.com/open-edge-platform/edge-ai-suites/refs/heads/main/metro-ai-suite/metro-sdk-manager/scripts/oep-vision-ai-sdk.sh | bash
+curl https://raw.githubusercontent.com/open-edge-platform/edge-ai-suites/refs/heads/release-2026.2.0/metro-ai-suite/metro-sdk-manager/scripts/oep-vision-ai-sdk.sh | bash
 ```
 
 The installer sets up:
@@ -76,7 +76,7 @@ wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-
   "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin?raw=true"
 
 wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/pedestrian-and-vehicle-detector-adas-0001.json" \
-  "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/pedestrian-and-vehicle-detector-adas-0001.json"
+  "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/pedestrian-and-vehicle-detector-adas-0001.json"
 ```
 
 Start the DL Streamer container with display forwarding:

--- a/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/get-started/install-oep-sdks.md
+++ b/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/get-started/install-oep-sdks.md
@@ -39,7 +39,7 @@ Expected: `card0`/`renderD128` under `/dev/dri`, `accel0` under `/dev/accel`, an
 Run the official UAV Mission Compute SDK installer on the target. It configures Docker, pulls the SDK images, and builds the full simulation stack:
 
 ```bash
-curl -fsS https://raw.githubusercontent.com/open-edge-platform/edge-ai-suites/refs/heads/main/metro-ai-suite/metro-sdk-manager/scripts/uav-mission-compute-sdk.sh | bash
+curl -fsS https://raw.githubusercontent.com/open-edge-platform/edge-ai-suites/refs/heads/release-2026.2.0/metro-ai-suite/metro-sdk-manager/scripts/uav-mission-compute-sdk.sh | bash
 ```
 
 The installer sets up:
@@ -129,9 +129,9 @@ make down
 
 ## Next Steps
 
-- Review the upstream [UAV Mission Compute SDK Get Started](https://github.com/open-edge-platform/edge-ai-suites/blob/main/federal-and-aerospace-ai-suite/uav-mission-compute-sdk/docs/user-guide/get-started.md) for USB camera setup and advanced configuration.
+- Review the upstream [UAV Mission Compute SDK Get Started](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/uav-mission-compute-sdk/docs/user-guide/get-started.md) for USB camera setup and advanced configuration.
 
-- Review the [UAV Mission Compute SDK Benchmarking Guide](https://github.com/open-edge-platform/edge-ai-suites/blob/main/federal-and-aerospace-ai-suite/uav-mission-compute-sdk/docs/user-guide/benchmarking.md) for telemetry and bridge performance benchmarking.
+- Review the [UAV Mission Compute SDK Benchmarking Guide](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/uav-mission-compute-sdk/docs/user-guide/benchmarking.md) for telemetry and bridge performance benchmarking.
 
 - Refer to [Get Started — UAV Mission Compute SDK Mode](./get-started-uavsdk.md) for application deployment and running the vision analytics stack against the live UAV SDK services.
 

--- a/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/infrastructure/build-dlstreamer-pipelines.md
+++ b/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/infrastructure/build-dlstreamer-pipelines.md
@@ -289,8 +289,8 @@ See the [DL Streamer Coding Agent Guide](./use-dlstreamer-coding-agent.md) for u
 
 - [DL Streamer Repository](https://github.com/open-edge-platform/dlstreamer)
 - [DL Streamer Docker Hub](https://hub.docker.com/r/intel/dlstreamer)
-- [DL Streamer Elements Reference](https://github.com/open-edge-platform/dlstreamer/blob/main/docs/user-guide/elements/elements.md)
-- [DL Streamer Samples](https://github.com/open-edge-platform/dlstreamer/tree/main/samples)
+- [DL Streamer Elements Reference](https://github.com/open-edge-platform/dlstreamer/blob/v2026.2.0/docs/user-guide/elements/elements.md)
+- [DL Streamer Samples](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/samples)
 - [Container Device Interface Guide](./configure-cdi.md) — CDI setup for GPU/NPU access
 
 <!--hide_directive

--- a/health-and-life-sciences-ai-suite/surgical-instrument/docs/user-guide/index.md
+++ b/health-and-life-sciences-ai-suite/surgical-instrument/docs/user-guide/index.md
@@ -3,10 +3,10 @@
 <!--hide_directive
 ::::{container} component_header_row
 <div class="component_card_widget">
-  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/main/health-and-life-sciences-ai-suite/surgical_instrument">
+  <a class="icon_github" href="https://github.com/open-edge-platform/edge-ai-suites/tree/release-2026.2.0/health-and-life-sciences-ai-suite/surgical_instrument">
      GitHub
   </a>
-  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/main/health-and-life-sciences-ai-suite/surgical_instrument/README.md">
+  <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/health-and-life-sciences-ai-suite/surgical_instrument/README.md">
      Readme
   </a>
 </div>

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/get-started.md
@@ -139,7 +139,7 @@ $env:MEDIAMTX_PATH = "<mediamtx_dir>\mediamtx.exe"
 
 ### Download a Model
 
-If you want to download YOLO models, you can refer to the [DL Streamer download scripts](https://github.com/open-edge-platform/dlstreamer/tree/main/scripts/download_models).
+If you want to download YOLO models, you can refer to the [DL Streamer download scripts](https://github.com/open-edge-platform/dlstreamer/tree/v2026.2.0/scripts/download_models).
 
 ```powershell
 pip install ultralytics

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/how-it-works.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/how-it-works.md
@@ -43,4 +43,4 @@ This document provides an overview of the architecture and components of Win Vis
 
 - [DL Streamer Documentation](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/index.html)
   - [DL Streamer Supported Models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/supported_models.html)
-  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/main/scripts/download_models/README.md)
+  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/v2026.2.0/scripts/download_models/README.md)

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/index.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/docs/user-guide/win-vision-ai/index.md
@@ -34,7 +34,7 @@ outputs, see [How It Works](./how-it-works.md).
 
 - [DL Streamer Documentation](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/index.html)
   - [DL Streamer Supported Models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/supported_models.html)
-  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/main/scripts/download_models/README.md)
+  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/v2026.2.0/scripts/download_models/README.md)
 
 <!--hide_directive
 :::{toctree}

--- a/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/README.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-vision/win-vision-ai/README.md
@@ -53,4 +53,4 @@ control.
 - [How It Works](../docs/user-guide/win-vision-ai/how-it-works.md) - detailed architecture and component descriptions.
 - [DL Streamer Documentation](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/index.html)
   - [DL Streamer Supported Models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/dlstreamer/supported_models.html)
-  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/main/scripts/download_models/README.md)
+  - [DL Streamer Model Conversion Scripts README](https://github.com/open-edge-platform/dlstreamer/blob/v2026.2.0/scripts/download_models/README.md)

--- a/metro-ai-suite/agentic-smart-community/docs/user-guide/get-started.md
+++ b/metro-ai-suite/agentic-smart-community/docs/user-guide/get-started.md
@@ -300,7 +300,7 @@ docker pull intel/smart-community-mcp-server:2026.2.0
 docker pull intel/videostream-analytics:2026.2.0
 ```
 
-> **Note:** `setup_docker.sh` resolves each image as `${REGISTRY_URL}<service>:${TAG}`, which with the defaults in [docker/set_env.sh](https://github.com/open-edge-platform/edge-ai-suites/blob/main/metro-ai-suite/agentic-smart-community/docker/set_env.sh). Export `TAG` before sourcing `docker/set_env.sh` so it matches the tag you pulled or built.
+> **Note:** `setup_docker.sh` resolves each image as `${REGISTRY_URL}<service>:${TAG}`, which with the defaults in [docker/set_env.sh](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/agentic-smart-community/docker/set_env.sh). Export `TAG` before sourcing `docker/set_env.sh` so it matches the tag you pulled or built.
 
 ## Data directory
 

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-vision-ai-sdk/get-started.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-vision-ai-sdk/get-started.md
@@ -60,7 +60,7 @@ wget -O sample.mp4 https://github.com/intel-iot-devkit/sample-videos/raw/master/
 mkdir -p models/intel/pedestrian-and-vehicle-detector-adas-0001/FP32/
 wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml" "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.xml?raw=true"
 wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin" "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/pedestrian-and-vehicle-detector-adas-0001/FP32/pedestrian-and-vehicle-detector-adas-0001.bin?raw=true"
-wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/pedestrian-and-vehicle-detector-adas-0001.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/pedestrian-and-vehicle-detector-adas-0001.json"
+wget -O "models/intel/pedestrian-and-vehicle-detector-adas-0001/pedestrian-and-vehicle-detector-adas-0001.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/pedestrian-and-vehicle-detector-adas-0001.json"
 ```
 
 ### Step 3: Pipeline Execution

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-vision-ai-sdk/tutorial-4.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-vision-ai-sdk/tutorial-4.md
@@ -77,7 +77,7 @@ wget -O models/intel/human-pose-estimation-0001/FP32/human-pose-estimation-0001.
   "https://storage.openvinotoolkit.org/repositories/open_model_zoo/2023.0/models_bin/1/human-pose-estimation-0001/FP32/human-pose-estimation-0001.bin"
 
 wget -O models/intel/human-pose-estimation-0001/human-pose-estimation-0001.json \
-  "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/main/samples/gstreamer/model_proc/intel/human-pose-estimation-0001.json"
+  "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/human-pose-estimation-0001.json"
 ```
 
 ### Step 2: Understand Human Pose Estimation Model

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/visual-ai-demo-kit/tutorial-1.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/visual-ai-demo-kit/tutorial-1.md
@@ -99,12 +99,12 @@ python3 -m pip install --break-system-packages openvino-dev[onnx,tensorflow2]
 
 omz_downloader --name license-plate-recognition-barrier-0007 -o /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
 omz_converter --name license-plate-recognition-barrier-0007  -o /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/ -d /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
-curl -Lo "/home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/license-plate-recognition-barrier-0007.json"
+curl -Lo "/home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/license-plate-recognition-barrier-0007.json"
 
 
 omz_downloader --name vehicle-attributes-recognition-barrier-0039 -o /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
 omz_converter --name  vehicle-attributes-recognition-barrier-0039 -o /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/ -d /home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
-curl -Lo "/home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/intel/vehicle-attributes-recognition-barrier-0039/vehicle-attributes-recognition-barrier-0039.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/vehicle-attributes-recognition-barrier-0039.json"
+curl -Lo "/home/dlstreamer/oep-suite/ai-tolling/src/dlstreamer-pipeline-server/models/intel/vehicle-attributes-recognition-barrier-0039/vehicle-attributes-recognition-barrier-0039.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/vehicle-attributes-recognition-barrier-0039.json"
 
 echo "Fix ownership..."
 chown -R "$(id -u):$(id -g)" ai-tolling/src/dlstreamer-pipeline-server/models ai-tolling/src/dlstreamer-pipeline-server/videos 2>/dev/null || true

--- a/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/tutorial-1.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/docs/user-guide/tutorial-1.md
@@ -93,12 +93,12 @@ python3 -m pip install openvino-dev[onnx,tensorflow2]
 
 omz_downloader --name license-plate-recognition-barrier-0007 -o /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
 omz_converter --name license-plate-recognition-barrier-0007  -o /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/ -d /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
-wget -O "/home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/license-plate-recognition-barrier-0007.json"
+wget -O "/home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/public/license-plate-recognition-barrier-0007/license-plate-recognition-barrier-0007.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/license-plate-recognition-barrier-0007.json"
 
 
 omz_downloader --name vehicle-attributes-recognition-barrier-0039 -o /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
 omz_converter --name  vehicle-attributes-recognition-barrier-0039 -o /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/ -d /home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/
-wget -O "/home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/intel/vehicle-attributes-recognition-barrier-0039/vehicle-attributes-recognition-barrier-0039.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/refs/heads/main/samples/gstreamer/model_proc/intel/vehicle-attributes-recognition-barrier-0039.json"
+wget -O "/home/dlstreamer/metro-suite/ai-tolling/src/dlstreamer-pipeline-server/models/intel/vehicle-attributes-recognition-barrier-0039/vehicle-attributes-recognition-barrier-0039.json" "https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.2.0/samples/gstreamer/model_proc/intel/vehicle-attributes-recognition-barrier-0039.json"
 
 echo "Fix ownership..."
 chown -R "$(id -u):$(id -g)" ai-tolling/src/dlstreamer-pipeline-server/models ai-tolling/src/dlstreamer-pipeline-server/videos 2>/dev/null || true


### PR DESCRIPTION
### Description

- Update DL Streamer GH references with the `v2026.2.0` tag.
- re-align some other 2026.2 references

### How Has This Been Tested?

Links checked.

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.