### PR TITLE
Smart Building Digital Twin: update image tags to 2026.2.0

### DIFF
--- a/metro-ai-suite/smart-building-digital-twin/.env.example
+++ b/metro-ai-suite/smart-building-digital-twin/.env.example
@@ -5,10 +5,10 @@
 # GST plugin scripts are fetched via sparse git clone (no manual build step needed).
 
 # Scenescape image tag
-SCENESCAPE_IMAGE_TAG=2026.2.0-rc3
+SCENESCAPE_IMAGE_TAG=2026.2.0
 
 # Git branch or tag to sparse-clone the DLStreamer GST plugin scripts from the Scenescape repo
-SCENESCAPE_PLUGINS_REF=2026.2.0-rc3
+SCENESCAPE_PLUGINS_REF=2026.2.0
 
 # Primary scene to run (auto-detected from scenes/)
 PRIMARY_SCENE=Showcase  

--- a/metro-ai-suite/smart-building-digital-twin/.github/copilot-instructions.md
+++ b/metro-ai-suite/smart-building-digital-twin/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This repo layers analytics and setup automation on top of a Scenescape deploymen
 - For loopback API access, bypass host proxy settings so local `curl` traffic does not tunnel through `HTTP_PROXY` or `HTTPS_PROXY`.
 
 ## Images And Runtime
-- All Scenescape images (`intel/scenescape-*:2026.2.0-rc3`) are pulled from Docker Hub — do not add build steps for them. The DLStreamer GST plugin scripts are sparse-cloned by `setup.sh` into `generated/scenescape-plugins/` (no full repo clone, no build). `scene-narrator` uses `python:3.12-slim` directly with pip dependencies installed at container start; there is no Dockerfile for it.
+- All Scenescape images (`intel/scenescape-*:2026.2.0`) are pulled from Docker Hub — do not add build steps for them. The DLStreamer GST plugin scripts are sparse-cloned by `setup.sh` into `generated/scenescape-plugins/` (no full repo clone, no build). `scene-narrator` uses `python:3.12-slim` directly with pip dependencies installed at container start; there is no Dockerfile for it.
 
 ## Setup And Runtime
 When working on setup, preserve these behaviors unless the task explicitly requires a change.

--- a/metro-ai-suite/smart-building-digital-twin/README.md
+++ b/metro-ai-suite/smart-building-digital-twin/README.md
@@ -110,11 +110,11 @@ Scenescape images are pulled automatically from Docker Hub by `./setup.sh` — n
 
 | Image | Tag |
 |---|---|
-| `intel/scenescape-manager` | `2026.2.0-rc3` |
-| `intel/scenescape-controller` | `2026.2.0-rc3` |
-| `intel/scenescape-autocalibration` | `2026.2.0-rc3` |
-| `intel/scenescape-analytics` | `2026.2.0-rc3` |
-| `intel/dlstreamer-pipeline-server` | `2026.2.0-ubuntu24-rc3` |
+| `intel/scenescape-manager` | `2026.2.0` |
+| `intel/scenescape-controller` | `2026.2.0` |
+| `intel/scenescape-autocalibration` | `2026.2.0` |
+| `intel/scenescape-analytics` | `2026.2.0` |
+| `intel/dlstreamer-pipeline-server` | `2026.2.0-ubuntu24` |
 
 `setup.sh` automatically downloads the GStreamer plugin scripts (`gstplugins/`) used by the Deep Learning Streamer (DL Streamer), from the Scenescape repository using a sparse shallow clone. Only the `gstplugins/` directory is downloaded; a full repository clone and local image build are not required.
 
@@ -191,7 +191,7 @@ Key variables in the `.env` file:
 | `DASHBOARD_URL` | `http://$PUBLIC_HOSTNAME:$DASHBOARD_PORT` | Browser URL for the analytics dashboard |
 | `SNAPSHOT_INTERVAL` | `10` | Seconds between narrator snapshots |
 | `DASHBOARD_PORT` | `7000` | Host port for the analytics dashboard |
-| `SCENESCAPE_IMAGE_TAG` | `2026.2.0-rc3` | Scenescape image tag pulled from Docker Hub |
+| `SCENESCAPE_IMAGE_TAG` | `2026.2.0` | Scenescape image tag pulled from Docker Hub |
 | `MODEL_NAME` | `smartbuilding-int8` | Detection model variant; set to `smartbuilding-fp16` for FP16 |
 
 ## Adding a New Scene

--- a/metro-ai-suite/smart-building-digital-twin/docker-compose.yml
+++ b/metro-ai-suite/smart-building-digital-twin/docker-compose.yml
@@ -80,7 +80,7 @@ services:
 
   # Scenescape Web UI
   web:
-    image: intel/scenescape-manager:${SCENESCAPE_IMAGE_TAG:-2026.2.0-rc3}
+    image: intel/scenescape-manager:${SCENESCAPE_IMAGE_TAG:-2026.2.0}
     init: true
     networks:
       scenescape:
@@ -145,7 +145,7 @@ services:
       - vol-datasets:/data/datasets
 
   autocalibration:
-    image: intel/scenescape-autocalibration:${SCENESCAPE_IMAGE_TAG:-2026.2.0-rc3}
+    image: intel/scenescape-autocalibration:${SCENESCAPE_IMAGE_TAG:-2026.2.0}
     init: true
     networks:
       scenescape:
@@ -199,7 +199,7 @@ services:
 
   # Scenescape Controller
   scene:
-    image: intel/scenescape-controller:${SCENESCAPE_IMAGE_TAG:-2026.2.0-rc3}
+    image: intel/scenescape-controller:${SCENESCAPE_IMAGE_TAG:-2026.2.0}
     init: true
     networks:
       scenescape:
@@ -238,7 +238,7 @@ services:
 
   # Sensor Replay (primary scene)
   sensor-replay-showcase:
-    image: intel/scenescape-controller:${SCENESCAPE_IMAGE_TAG:-2026.2.0-rc3}
+    image: intel/scenescape-controller:${SCENESCAPE_IMAGE_TAG:-2026.2.0}
     networks:
       scenescape:
     depends_on:
@@ -316,7 +316,7 @@ services:
 
   # DL-Streamer Cameras
   showcase-cameras:
-    image: docker.io/intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24-rc3
+    image: docker.io/intel/dlstreamer-pipeline-server:2026.2.0-ubuntu24
     networks:
       scenescape:
     tty: true
@@ -374,7 +374,7 @@ services:
 
   # Scenescape Analytics — region/tripwire/sensor analytics (decoupled from the controller)
   analytics:
-    image: intel/scenescape-analytics:${SCENESCAPE_IMAGE_TAG:-2026.2.0-rc3}
+    image: intel/scenescape-analytics:${SCENESCAPE_IMAGE_TAG:-2026.2.0}
     init: true
     user: "${UID:-1000}:${GID:-1000}"
     networks:

--- a/metro-ai-suite/smart-building-digital-twin/setup.sh
+++ b/metro-ai-suite/smart-building-digital-twin/setup.sh
@@ -338,7 +338,7 @@ info "Locating DLStreamer GST plugins..."
 SCENESCAPE_PLUGINS_DIR="$SCRIPT_DIR/generated/scenescape-plugins"
 # SCENESCAPE_PLUGINS_REF selects the branch or tag for the gstplugins sparse clone independently of the image SCENESCAPE_IMAGE_TAG
 SCENESCAPE_PLUGINS_REF="${SCENESCAPE_PLUGINS_REF:-$(grep -E '^SCENESCAPE_PLUGINS_REF=' .env 2>/dev/null | head -n1 | cut -d'=' -f2-)}"
-SCENESCAPE_PLUGINS_REF="${SCENESCAPE_PLUGINS_REF:-2026.2.0-rc3}"
+SCENESCAPE_PLUGINS_REF="${SCENESCAPE_PLUGINS_REF:-2026.2.0}"
 
 scenescape_valid() {
     [ -d "$1/dlstreamer-pipeline-server/user_scripts/gstplugins" ]
@@ -608,7 +608,7 @@ delete_env_var "INTERNAL_BROKER_HOST"
 delete_env_var "INTERNAL_WEB_HOST"
 delete_env_var "INTERNAL_AUTOCALIBRATION_HOST"
 upsert_env_var "DATABASE_PASSWORD" "$CURRENT_DATABASE_PASSWORD"
-upsert_env_var "SCENESCAPE_IMAGE_TAG" "2026.2.0-rc3"
+upsert_env_var "SCENESCAPE_IMAGE_TAG" "2026.2.0"
 upsert_env_var "SCENESCAPE_DIR" "$SCENESCAPE_DIR_INPUT"
 upsert_env_var "PRIMARY_SCENE" "${SCENES[0]}"
 upsert_env_var "PRIMARY_DATASET" "$PRIMARY_DATASET"
@@ -654,7 +654,7 @@ success "Docker images ready"
 # Verify Scenescape images are available (pulled from Docker Hub)
 info "Verifying Scenescape images are available..."
 REQUIRED_IMAGE_VERSION="${SCENESCAPE_IMAGE_TAG:-$(read_env_var "SCENESCAPE_IMAGE_TAG")}"
-REQUIRED_IMAGE_VERSION="${REQUIRED_IMAGE_VERSION:-2026.2.0-rc3}"
+REQUIRED_IMAGE_VERSION="${REQUIRED_IMAGE_VERSION:-2026.2.0}"
 missing_images=()
 for img in scenescape-manager scenescape-controller scenescape-autocalibration scenescape-analytics; do
     if ! docker image inspect "intel/${img}:${REQUIRED_IMAGE_VERSION}" >/dev/null 2>&1; then


### PR DESCRIPTION
### Description

Smart Building Digital Twin: update image tags to 2026.2.0

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

