### PR TITLE
[LVS] Update image tags and chart version for release 2026.2.0

### DIFF
--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/Chart.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: live-video-search
 description: Umbrella Helm chart for Live Video Search (VSS Search + Smart NVR)
 type: application
-version: 2026.2.0-rc1-helm
+version: 2026.2.0-helm
 appVersion: "1.0.0"
 dependencies:
   - name: shared

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/metrics-manager/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/metrics-manager/values.yaml
@@ -9,7 +9,7 @@ global:
 
 image:
   repository: intel/metrics-manager
-  tag: "2026.2.0-rc1"
+  tag: "2026.2.0"
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/multimodal-dataprep/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/multimodal-dataprep/values.yaml
@@ -52,7 +52,7 @@ global:
     httpsProxy: ''
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
 images:

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/multimodal-embedding-serving/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/multimodal-embedding-serving/values.yaml
@@ -28,7 +28,7 @@ global:
     httpsProxy: ''
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
 images:

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/nvr-event-router/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/nvr-event-router/values.yaml
@@ -2,7 +2,7 @@ global:
   proxy:
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   smartNvrStackTag: ''
   pullPolicy: ''
 

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/pipeline-manager/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/pipeline-manager/values.yaml
@@ -13,7 +13,7 @@ global:
     httpsProxy: ''
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
 images:

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/vector-retriever/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/vector-retriever/values.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 global:
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
   vectordbBackend: vdms

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/video-search/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/video-search/values.yaml
@@ -18,7 +18,7 @@ global:
     httpsProxy: ''
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
 images:

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/vss-ui/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/subchart/vss-ui/values.yaml
@@ -10,7 +10,7 @@ global:
     httpsProxy: ''
     noProxy: localhost,127.0.0.1,.svc.cluster.local
   registry: ''
-  tag: 2026.2.0-rc1
+  tag: 2026.2.0
   vssStackTag: ''
   pullPolicy: ''
 

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/user_values_override.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/user_values_override.yaml
@@ -4,7 +4,7 @@
 global:
   # Image registry and tags
   registry: ''
-  tag: '2026.2.0-rc1'
+  tag: '2026.2.0'
   vssStackTag: ''
   smartNvrStackTag: ''
   # Single pull-policy override for the LVS, VSS, and Smart NVR application

--- a/metro-ai-suite/live-video-analysis/live-video-search/chart/values.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/chart/values.yaml
@@ -1,6 +1,6 @@
 global:
   registry: "intel"
-  tag: "2026.2.0-rc1"
+  tag: "2026.2.0"
   vssStackTag: ""
   smartNvrStackTag: ""
   pullPolicy: ""
@@ -464,7 +464,7 @@ metrics-manager:
   coLocateWithDataPrep: true
   image:
     repository: intel/metrics-manager
-    tag: "2026.2.0-rc1"
+    tag: "2026.2.0"
     pullPolicy: IfNotPresent
 
 vdms-vector-db:

--- a/metro-ai-suite/live-video-analysis/live-video-search/docker/compose.metrics-manager.yaml
+++ b/metro-ai-suite/live-video-analysis/live-video-search/docker/compose.metrics-manager.yaml
@@ -3,7 +3,7 @@
 
 services:
   metrics-manager:
-    image: intel/metrics-manager:2026.2.0-rc1
+    image: intel/metrics-manager:2026.2.0
     container_name: metrics-manager
     ports:
       - "${METRICS_MANAGER_HOST_PORT:-9090}:9090"

--- a/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started.md
+++ b/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started.md
@@ -37,10 +37,10 @@ Before running the application, you need to set several environment variables:
 
     ```bash
     export REGISTRY_URL=intel
-    export TAG=2026.2.0-rc1
+    export TAG=2026.2.0
     ```
 
-    Use `TAG=2026.2.0-rc1` for this release workflow.
+    Use `TAG=2026.2.0` for this release workflow.
 
     **Override tags per stack (recommended for mixed release cycles):**
 
@@ -51,9 +51,9 @@ Before running the application, you need to set several environment variables:
     Use stack-specific tag overrides when you need different image versions for each stack:
 
      ```bash
-     export TAG=2026.2.0-rc1
-     export VSS_STACK_TAG=2026.2.0-rc1
-     export SMART_NVR_STACK_TAG=2026.2.0-rc1
+     export TAG=2026.2.0
+     export VSS_STACK_TAG=2026.2.0
+     export SMART_NVR_STACK_TAG=2026.2.0
      ```
 
     Why this is needed: a single shared `TAG` forces both stacks to use the same version, which does not match independent VSS and Smart NVR release cycles.

--- a/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started/deploy-with-helm.md
+++ b/metro-ai-suite/live-video-analysis/live-video-search/docs/user-guide/get-started/deploy-with-helm.md
@@ -29,17 +29,17 @@ There are 2 options to get the charts in your workspace:
 Use the following command to pull the Helm chart from Docker Hub:
 
 ```bash
-helm pull oci://registry-1.docker.io/intel/live-video-search --version 2026.2.0-rc1-helm
+helm pull oci://registry-1.docker.io/intel/live-video-search --version 2026.2.0-helm
 ```
 
-Use chart version `2026.2.0-rc1-helm` for this release workflow.
+Use chart version `2026.2.0-helm` for this release workflow.
 
 ##### Step 2: Extract the `.tgz` file
 
 After pulling the chart, extract the `.tgz` file:
 
 ```bash
-tar -xvf live-video-search-2026.2.0-rc1-helm.tgz
+tar -xvf live-video-search-2026.2.0-helm.tgz
 ```
 
 This creates a directory named `live-video-search` containing chart files. Navigate to the extracted directory:
@@ -83,14 +83,14 @@ Common optional values:
 | Key | Description | Example Value |
 | --- | ----------- | ------------- |
 | `global.registry` | Optional image registry override | `intel` |
-| `global.tag` | Shared image tag | `2026.2.0-rc1` |
-| `global.vssStackTag` | Override tag for VSS stack services | `2026.2.0-rc1` |
-| `global.smartNvrStackTag` | Override tag for Smart NVR services | `2026.2.0-rc1` |
+| `global.tag` | Shared image tag | `2026.2.0` |
+| `global.vssStackTag` | Override tag for VSS stack services | `2026.2.0` |
+| `global.smartNvrStackTag` | Override tag for Smart NVR services | `2026.2.0` |
 | `global.pullPolicy` | Pull-policy override for application images selected by the shared or stack-specific tags | `Always`, `IfNotPresent`, or `Never` |
 | `global.vectordbBackend` | Vector database used by Multimodal DataPrep and Vector Retriever | `vdms` (default) or `milvus` |
 | `global.metricsManager.enabled` | Deploy Metrics Manager and enable live system/DataPrep metrics | `true` (default) or `false` |
 | `metrics-manager.image.repository` | Metrics Manager image repository | `intel/metrics-manager` |
-| `metrics-manager.image.tag` | Metrics Manager image tag | `2026.2.0-rc1` |
+| `metrics-manager.image.tag` | Metrics Manager image tag | `2026.2.0` |
 | `global.proxy.httpProxy` | HTTP proxy | `http://proxy-example.com:000` |
 | `global.proxy.httpsProxy` | HTTPS proxy | `http://proxy-example.com:000` |
 | `global.usePvc` | Use PVC-backed storage paths for MME/DataPrep | `true` or `false` |


### PR DESCRIPTION
Moves Live Video Search from the `2026.2.0-rc1` pre-release tags to the final `2026.2.0` tags.

- Helm chart, `user_values_override.yaml` and 8 subchart `values.yaml` image tags
- `chart/Chart.yaml`: `2026.2.0-rc1-helm` -> `2026.2.0-helm`
- `docker/compose.metrics-manager.yaml`
- `get-started.md` and `deploy-with-helm.md`

`setup.sh` keeps its `TAG=${TAG:-latest}` default.

Branched off the current `release-2026.2.0` tip. `helm template` renders all 8 LVS images at `2026.2.0`; no `rc` reference remains.