### PR TITLE
[STIA] Finalize ovms subchart 2026.2.0 tag

### DIFF
--- a/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/ovms/Chart.yaml
+++ b/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/ovms/Chart.yaml
@@ -5,5 +5,5 @@ apiVersion: v2
 name: ovms
 description: OpenVINO Model Server (OVMS) subchart for Smart Traffic Intersection Agent
 type: application
-version: 2026.2.0-rc2-helm
+version: 2026.2.0-helm
 appVersion: "2026.1"

--- a/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/ovms/Chart.yaml
+++ b/metro-ai-suite/smart-traffic-intersection-agent/chart/subcharts/ovms/Chart.yaml
@@ -6,4 +6,4 @@ name: ovms
 description: OpenVINO Model Server (OVMS) subchart for Smart Traffic Intersection Agent
 type: application
 version: 2026.2.0-helm
-appVersion: "2026.1"
+appVersion: "2026.2"


### PR DESCRIPTION
### Description

Promote the OVMS subchart of the Smart Traffic Intersection Agent from the `2026.2.0-rc2` release candidate to the final `2026.2.0` release tag. This subchart was missed during the STIA release-tag finalization in #4378, which covered the parent chart, the `metrics-manager` subchart, and chart dependencies.

Tag/version bump only; no functional or API changes.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Verified the ovms subchart `version` changed from `2026.2.0-rc2-helm` to `2026.2.0-helm`, consistent with the sibling charts finalized in #4378. Pre-commit hooks (helmlint, yaml checks) passed.

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with APACHE-2.0.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.