### PR TITLE
[DOCS] Improve cross-linking to official docs - 26.2

### DIFF
--- a/education-ai-suite/smart-classroom/content_search/README.md
+++ b/education-ai-suite/smart-classroom/content_search/README.md
@@ -12,7 +12,7 @@ Content Search is a multimodal service for smart classroom environments. It enab
 
 ## Quick Start
 
-For installation and setup instructions, see [Get Started](../docs/user-guide/get-started.md#step-4-set-up-content-search).
+For installation and setup instructions, see [Get Started](../docs/user-guide/get-started.md).
 
 ## API Endpoints
 
@@ -34,7 +34,7 @@ For installation and setup instructions, see [Get Started](../docs/user-guide/ge
 
 ## Documentation
 
-- **User Guide**: [Get Started](../docs/user-guide/get-started.md#step-4-set-up-content-search-optional)
+- **User Guide**: [Get Started](../docs/user-guide/get-started.md)
 - **Dev Guide**: [Content Search API Reference](../docs/dev-guide/content-search/Content_search_API.md)
 - **Microservice APIs**:
   - [File Ingest & Retrieve](../docs/dev-guide/content-search/file_ingest_and_retrieve/API_GUIDE.md)

--- a/federal-and-aerospace-ai-suite/deterministic-threat-detection/docs/user-guide/get-started-scenescape.md
+++ b/federal-and-aerospace-ai-suite/deterministic-threat-detection/docs/user-guide/get-started-scenescape.md
@@ -92,7 +92,7 @@ cd scenescape
 make demo
 ```
 
-> **Note:** Use the instructions in the [Scenescape prebuilt containers guide](https://github.com/open-edge-platform/scenescape/blob/release-2026.2.0/docs/user-guide/how-to-guides/deploy-scenescape-using-prebuilt-containers.md) to use the prebuilt images.
+> **Note:** Use the instructions in the [Scenescape prebuilt containers guide](https://docs.openedgeplatform.intel.com/2026.2/scenescape/how-to-guides/deploy-scenescape-using-prebuilt-containers.html) to use the prebuilt images.
 
 > **Basler camera users:** If you completed the Basler prerequisite steps above, the Docker Compose file has already been patched and the custom DL Streamer image with Basler support has been built. Start Scenescape with `make demo` as usual — the patched compose file will be picked up automatically.
 

--- a/federal-and-aerospace-ai-suite/deterministic-threat-detection/docs/user-guide/how-to-guides/scenescape-deterministic-inference/scenescape-measuring-hota-metrics-with-tsn.md
+++ b/federal-and-aerospace-ai-suite/deterministic-threat-detection/docs/user-guide/how-to-guides/scenescape-deterministic-inference/scenescape-measuring-hota-metrics-with-tsn.md
@@ -153,7 +153,7 @@ cd scenescape
 make demo
 ```
 
-> **Note:** Use the instructions in the [Scenescape prebuilt containers guide](https://github.com/open-edge-platform/scenescape/blob/release-2026.2.0/docs/user-guide/how-to-guides/deploy-scenescape-using-prebuilt-containers.md) to use the prebuilt images.
+> **Note:** Use the instructions in the [Scenescape prebuilt containers guide](https://docs.openedgeplatform.intel.com/2026.2/scenescape/how-to-guides/deploy-scenescape-using-prebuilt-containers.html) to use the prebuilt images.
 
 Create the `hota-scene` scene and its two cameras, then run the setup script:
 
@@ -164,7 +164,7 @@ bash usecases/scenescape-deterministic-inference/hota/scripts/setup-hota-scene.s
 
 > **Note:** If you downloaded and extracted the zip file, replace `edge-ai-suites/federal-and-aerospace-ai-suite/deterministic-threat-detection/` with the path to your extracted `deterministic-threat-detection/` folder.
 
-This creates the scene `hota-scene` and registers cameras `Cam_x1_0` and `Cam_x2_0` via the Scenescape REST API. See the [Scenescape API Reference](https://github.com/open-edge-platform/scenescape/blob/release-2026.2.0/docs/user-guide/api-reference.md) for details.
+This creates the scene `hota-scene` and registers cameras `Cam_x1_0` and `Cam_x2_0` via the Scenescape REST API. See the [Scenescape API Reference](https://docs.openedgeplatform.intel.com/2026.2/scenescape/api-reference.html) for details.
 
 ### 2b. Install the SEI Frame-Number Parser
 
@@ -338,7 +338,7 @@ Results are stored in timestamped subdirectories under `/tmp/tracker-evaluation/
 - [Tracker Evaluation Pipeline README](https://github.com/open-edge-platform/scenescape/tree/release-2026.2.0/tools/tracker/evaluation/README.md)
 - [TrackEval Toolkit](https://github.com/JonathonLuiten/TrackEval)
 - [TSN Traffic Shaping Guide](../common/enable-tsn-traffic-shaping.md)
-- [Scenescape API Reference](https://github.com/open-edge-platform/scenescape/blob/release-2026.2.0/docs/user-guide/api-reference.md)
+- [Scenescape API Reference](https://docs.openedgeplatform.intel.com/2026.2/scenescape/api-reference.html)
 
 - Dataset files:
   - [cam-x1-mp4](https://github.com/open-edge-platform/scenescape/blob/release-2026.2.0/tests/system/metric/unity_dataset/Cam_x1_0.mp4)

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/infrastructure/advanced-image-customization.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/infrastructure/advanced-image-customization.md
@@ -56,7 +56,7 @@ These packages are required before composing any image:
 sudo apt install systemd-ukify mmdebstrap
 ```
 
-Follow the instructions at [Image Composition Prerequisites](https://github.com/open-edge-platform/image-composer-tool/blob/ICT_Release_2026.2/docs/user-guide/get-started/installation.md#image-composition-prerequisites) if you face issues installing packages using apt.
+Follow the instructions at [Image Composition Prerequisites](https://docs.openedgeplatform.intel.com/2026.2/image-composer-tool/get-started/installation.html#image-composition-prerequisites) if you face issues installing packages using apt.
 
 > **Note:** `mmdebstrap` version 0.8.x (shipped with Ubuntu OS version 22.04) has known
 > issues. Ensure you have version 1.4.3 or later. On Ubuntu OS version 23.04 or later, the

--- a/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/infrastructure/advanced-image-customization.md
+++ b/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/infrastructure/advanced-image-customization.md
@@ -56,7 +56,7 @@ These packages are required before composing any image:
 sudo apt install systemd-ukify mmdebstrap
 ```
 
-Follow the instructions at [Image Composition Prerequisites](https://github.com/open-edge-platform/image-composer-tool/blob/ICT_Release_2026.2/docs/user-guide/get-started/installation.md#image-composition-prerequisites) if you face issues installing packages using apt.
+Follow the instructions at [Image Composition Prerequisites](https://docs.openedgeplatform.intel.com/2026.2/image-composer-tool/get-started/installation.html#image-composition-prerequisites) if you face issues installing packages using apt.
 
 > **Note:** `mmdebstrap` version 0.8.x (shipped with Ubuntu OS version 22.04) has known
 > issues. Ensure you have version 1.4.3 or later. On Ubuntu OS version 23.04 or later, the

--- a/manufacturing-ai-suite/industrial-edge-insights-multimodal/training/vlm-fine-tuning/README.md
+++ b/manufacturing-ai-suite/industrial-edge-insights-multimodal/training/vlm-fine-tuning/README.md
@@ -1,6 +1,8 @@
+# VLM Fine-Tuning with Unsloth
+
 For prerequisites, setup, the expected dataset format, the fine-tuning and
 inference steps and flags, and troubleshooting, see the published how-to
 guides.
 
-- [Fine-Tune a VLM with Unsloth Library](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/how-to-guides/how-to-fine-tune-vlm.md).
-- [Fine-Tune a VLM with Unsloth Library — Weld Usecase](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/manufacturing-ai-suite/industrial-edge-insights-multimodal/docs/user-guide/how-to-guides/how-to-fine-tune-vlm-weld-usecase.md).
+- [Fine-Tune a VLM with Unsloth Library](../../docs/user-guide/how-to-guides/how-to-fine-tune-vlm.md).
+- [Fine-Tune a VLM with Unsloth Library — Weld Usecase](../../docs/user-guide/how-to-guides/how-to-fine-tune-vlm-weld-usecase.md).

--- a/metro-ai-suite/agentic-predictive-maintenance-pipeline/docs/user-guide/build-from-source.md
+++ b/metro-ai-suite/agentic-predictive-maintenance-pipeline/docs/user-guide/build-from-source.md
@@ -53,7 +53,7 @@ The build targets use the Dockerfiles located in `services/<service-name>/Docker
 The reasoning agent (`apm-agent`) is no longer built from this repo — it is
 an external image (Intel EAL's `agent-quality-handler` microservice) pulled
 via `docker/compose.agents.yaml`. See the [agent-service integration
-guide](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/agent-quality-handler/docs/user-guide/agent-service-integration-guide.md) for its contract.
+guide](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/agent-quality-handler/agent-service-integration-guide.html) for its contract.
 
 ### 4. Verify the Build
 

--- a/metro-ai-suite/agentic-predictive-maintenance-pipeline/docs/user-guide/release-notes.md
+++ b/metro-ai-suite/agentic-predictive-maintenance-pipeline/docs/user-guide/release-notes.md
@@ -13,7 +13,7 @@
   run sequentially to analyze detections and generate structured maintenance tickets. The reasoning
   agent (`apm-agent`) is not built from this repo — it is an external image (Intel EAL's
   `agent-quality-handler` microservice) pulled via `docker/compose.agents.yaml`. See the
-  [agent-service integration guide](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/agent-quality-handler/docs/user-guide/agent-service-integration-guide.md) for its contract.
+  [agent-service integration guide](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/agent-quality-handler/agent-service-integration-guide.html) for its contract.
 - Two operating modes: Large Language Model (LLM) mode for AI-generated analysis (using OpenVINO
   Model Server) and fallback mode for rule-based operation without an LLM service.
 - Real-time video inference via Deep Learning Streamer (DL Streamer) with YOLO-based object detection; DL Streamer publishes

--- a/metro-ai-suite/live-video-analysis/live-video-search/README.md
+++ b/metro-ai-suite/live-video-analysis/live-video-search/README.md
@@ -8,8 +8,8 @@
 
 To see the system requirements and other installations, see the following guides:
 
-  - [Get Started](./docs/user-guide/get-started.md): Step‑by‑step setup.
-  - [System Requirements](./docs/user-guide/get-started/system-requirements.md): Hardware and software requirements.
+- [Get Started](./docs/user-guide/get-started.md): Step‑by‑step setup.
+- [System Requirements](./docs/user-guide/get-started/system-requirements.md): Hardware and software requirements.
 
 ## How It Works
 
@@ -34,11 +34,11 @@ graph TD
 
 ## Learn More
 
-  - [Architecture](./docs/user-guide/how-it-works.md): End‑to‑end architecture.
-  - [System Requirements](./docs/user-guide/get-started/system-requirements.md): Hardware and software requirements.
-  - [Build from Source](./docs/user-guide/get-started/build-from-source.md): Build images for the stack.
-  - [API Reference](./docs/user-guide/api-reference.md): Key endpoints and references.
-  - [Release Notes](./docs/user-guide/release-notes.md): Updates and fixes.
+- [Architecture](./docs/user-guide/how-it-works.md): End‑to‑end architecture.
+- [System Requirements](./docs/user-guide/get-started/system-requirements.md): Hardware and software requirements.
+- [Build from Source](./docs/user-guide/get-started/build-from-source.md): Build images for the stack.
+- [API Reference](./docs/user-guide/api-reference.md): Key endpoints and references.
+- [Release Notes](./docs/user-guide/release-notes.md): Updates and fixes.
 
 ## Notes
 

--- a/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-gen-ai-sdk/get-started.md
+++ b/metro-ai-suite/metro-sdk-manager/docs/user-guide/oep-gen-ai-sdk/get-started.md
@@ -78,7 +78,7 @@ http://localhost:8102
   \- Vector database integration and document processing workflows
 - [Multimodal Embedding Serving](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/multimodal-embedding-serving/index.html)
   \- Embedding generation service architecture and API documentation
-- [Multimodal Data Preparation](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/visual-data-preparation-for-retrieval/multimodal-dataprep/docs/user-guide/Overview.md)
+- [Multimodal Data Preparation](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/multimodal-data-preparation/index.html)
   \- Multimodal data ingestion and preparation workflows for retrieval
 - [Edge AI Libraries](https://docs.openedgeplatform.intel.com/2026.2/ai-libraries.html)
   \- Complete development toolkit documentation and microservice API references

--- a/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/README.md
+++ b/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/tests/README.md
@@ -41,8 +41,8 @@ export SUDO_PASSWORD=your_sudo_password
 ## Installation
 
 - Clone the repository and install prerequisites according to the following guides (for Kubernetes, also set up proxy settings if needed):
-  - [Docker Guide](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/get-started.md)
-  - [Kubernetes Guide](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/metro-ai-suite/metro-vision-ai-app-recipe/smart-intersection/docs/user-guide/get-started/deploy-with-helm.md)
+  - [Docker Guide](../docs/user-guide/get-started.md)
+  - [Kubernetes Guide](../docs/user-guide/get-started/deploy-with-helm.md)
 
 1. **Navigate to the smart-intersection directory:**
 

--- a/metro-ai-suite/video-processing-for-nvr/README.md
+++ b/metro-ai-suite/video-processing-for-nvr/README.md
@@ -77,4 +77,4 @@ The sample application has been validated on Intel® platforms Arrow Lake, Meteo
 
 ## License
 
-The sample application is licensed under [APACHE 2.0](https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/LICENSE).
+The sample application is licensed under [APACHE 2.0](../../LICENSE).

--- a/metro-ai-suite/visual-search-question-and-answering/docs/user-guide/get-started.md
+++ b/metro-ai-suite/visual-search-question-and-answering/docs/user-guide/get-started.md
@@ -94,7 +94,7 @@ Note: supported media types: jpg, png, mp4
    ```
 
    **Important**: You must set `EMBEDDING_MODEL_NAME` and `VLM_MODEL_NAME` before running `env.sh`. See
-   [multimodal-embedding-serving's supported models](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/multimodal-embedding-serving/docs/user-guide/supported-models.md) for available embedding models, and [vlm-openvino-serving's supported models](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2025.2.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md#models-supported) for available vlm models.
+   [multimodal-embedding-serving's supported models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/multimodal-embedding-serving/supported-models.html) for available embedding models, and [vlm-openvino-serving's supported models](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md#models-supported) for available vlm models.
 
    For PRC users, set up the huggingface endpoint first:
 

--- a/metro-ai-suite/visual-search-question-and-answering/docs/user-guide/get-started.md
+++ b/metro-ai-suite/visual-search-question-and-answering/docs/user-guide/get-started.md
@@ -93,8 +93,9 @@ Note: supported media types: jpg, png, mp4
    source env.sh
    ```
 
-   **Important**: You must set `EMBEDDING_MODEL_NAME` and `VLM_MODEL_NAME` before running `env.sh`. See
-   [multimodal-embedding-serving's supported models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/multimodal-embedding-serving/supported-models.html) for available embedding models, and [vlm-openvino-serving's supported models](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md#models-supported) for available vlm models.
+   > **Important:** You must set `EMBEDDING_MODEL_NAME` and `VLM_MODEL_NAME` before running `env.sh`. See
+   > [Supported models](https://docs.openedgeplatform.intel.com/2026.2/edge-ai-libraries/multimodal-embedding-serving/supported-models.html) for Multimodal Embedding Serving for available embedding models, and
+   > [Supported models](https://github.com/open-edge-platform/edge-ai-libraries/blob/release-2026.2.0/microservices/vlm-openvino-serving/docs/user-guide/Overview.md#models-supported) for VLM OpenVINO for available VLM models.
 
    For PRC users, set up the huggingface endpoint first:
 


### PR DESCRIPTION
### Description

- improve cross-linking to official published OEP docs by changing links inside `/docs/user-guide/` from GH to the OEP website
- simplify global links to relative where feasible (outside of `/docs/user-guide/`) to reduce maintenance debt
- fix some broken links

### How Has This Been Tested?

Links checked

### Checklist:

- [X] I agree to use the APACHE-2.0 license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with APACHE-2.0. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.