### PR TITLE
Replace fedaero-latest with 2026.2.0

### DIFF
--- a/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
+++ b/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
@@ -45,7 +45,7 @@ cd edge-ai-suites/federal-and-aerospace-ai-suite/deterministic-threat-detection
 Download and extract the standalone application package:
 
 ```bash
-curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2.0/deterministic-threat-detection.zip
+curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2/deterministic-threat-detection.zip
 unzip deterministic-threat-detection.zip
 cd deterministic-threat-detection
 ```

--- a/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
+++ b/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
@@ -45,7 +45,7 @@ cd edge-ai-suites/federal-and-aerospace-ai-suite/deterministic-threat-detection
 Download and extract the standalone application package:
 
 ```bash
-curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-latest/deterministic-threat-detection.zip
+curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/deterministic-threat-detection.zip
 unzip deterministic-threat-detection.zip
 cd deterministic-threat-detection
 ```

--- a/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
+++ b/federal-and-aerospace-ai-suite/deterministic-threat-detection/README.md
@@ -45,7 +45,7 @@ cd edge-ai-suites/federal-and-aerospace-ai-suite/deterministic-threat-detection
 Download and extract the standalone application package:
 
 ```bash
-curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/deterministic-threat-detection.zip
+curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2.0/deterministic-threat-detection.zip
 unzip deterministic-threat-detection.zip
 cd deterministic-threat-detection
 ```

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
@@ -72,7 +72,7 @@ docker info|grep -i PROXY
 Download the compressed file:
 
 ```bash
-curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/handheld-multi-modal.zip
+curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2/handheld-multi-modal.zip
 ```
 
 Decompress the downloaded file and enter the working directory:

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/deploy-applications.md
@@ -72,7 +72,7 @@ docker info|grep -i PROXY
 Download the compressed file:
 
 ```bash
-curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-latest/handheld-multi-modal.zip
+curl -OjL https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/handheld-multi-modal.zip
 ```
 
 Decompress the downloaded file and enter the working directory:

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/index.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/index.md
@@ -8,7 +8,7 @@
   <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/handheld-multi-modal/README.md">
      Readme
   </a>
-  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2.0/handheld-multi-modal.zip">
+  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2/handheld-multi-modal.zip">
      Download Package
   </a>
 </div>

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/index.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/index.md
@@ -8,7 +8,7 @@
   <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/handheld-multi-modal/README.md">
      Readme
   </a>
-  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.1/handheld-multi-modal.zip">
+  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2.0/handheld-multi-modal.zip">
      Download Package
   </a>
 </div>

--- a/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/install-oep-sdks.md
+++ b/federal-and-aerospace-ai-suite/handheld-multi-modal/docs/user-guide/install-oep-sdks.md
@@ -88,7 +88,7 @@ docker run --rm -it --name dlstreamer \
   -v $PWD:/data \
   -e DISPLAY=$DISPLAY \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
-  intel/dlstreamer:2026.2.0-ubuntu24-rc2
+  intel/dlstreamer:2026.2.0-ubuntu24
 ```
 
 Inside the container, run the detection pipeline:

--- a/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/index.md
+++ b/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/index.md
@@ -8,7 +8,7 @@
   <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/uav-vision-analytics/README.md">
      Readme
   </a>
-  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-latest/uav-mission-apps.zip">
+  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/uav-mission-apps.zip">
      Download Package
   </a>
 </div>

--- a/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/index.md
+++ b/federal-and-aerospace-ai-suite/uav-vision-analytics/docs/user-guide/index.md
@@ -8,7 +8,7 @@
   <a class="icon_document" href="https://github.com/open-edge-platform/edge-ai-suites/blob/release-2026.2.0/federal-and-aerospace-ai-suite/uav-vision-analytics/README.md">
      Readme
   </a>
-  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/fedaero-2026.2.0/uav-mission-apps.zip">
+  <a class="icon_download" href="https://github.com/open-edge-platform/edge-ai-suites/releases/download/2026.2/uav-mission-apps.zip">
      Download Package
   </a>
 </div>


### PR DESCRIPTION
### Description

Replace fedaero-latest that is updated on every change to one of the folder with 2026.2.0 pinned version (pipeline must be triggered manually)